### PR TITLE
cx/rcll2018: dont stop before exploring

### DIFF
--- a/cfg/conf.d/clips-executive.yaml
+++ b/cfg/conf.d/clips-executive.yaml
@@ -143,7 +143,6 @@ clips-executive:
         wp-put-slide-cc: bring_product_to{place=?(m)S, slide="TRUE"}
         wp-get: get_product_from{place=?(m)S, side=?(side|/INPUT/input/|/OUTPUT/output/)s}
         wp-discard: ax12gripper{command="OPEN"}
-        stop: relgoto{x=0, y=0}
 
       blackboard-preload: ["Position3DInterface", "NavGraphWithMPSGeneratorInterface" , "NavGraphGeneratorInterface" , "NavigatorInterface", "AX12GripperInterface", "MotorInterface", "LaserLineInterface", "TagVisionInterface", "ZoneInterface" , "RobotinoSensorInterface" , "RobotinoLightInterface" ]
 

--- a/src/clips-specs/rcll2018/domain.pddl
+++ b/src/clips-specs/rcll2018/domain.pddl
@@ -491,12 +491,6 @@
 			:effect (self ?r)
 	)
 
-	(:action stop
-			:parameters (?r - robot)
-			:precondition (self ?r)
-			:effect (self ?r)
-	)
-
 	(:action explore-zone
 			:parameters (?r - robot ?z - zone)
 			:precondition (self ?r)

--- a/src/clips-specs/rcll2018/exploration.clp
+++ b/src/clips-specs/rcll2018/exploration.clp
@@ -229,10 +229,9 @@
   (assert
     (plan (id EXPLORE-ZONE) (goal-id ?goal-id))
     (plan-action (id 1) (plan-id EXPLORE-ZONE) (goal-id ?goal-id) (action-name one-time-lock) (param-names name) (param-values ?zn))
-    (plan-action (id 2) (plan-id EXPLORE-ZONE) (goal-id ?goal-id) (action-name stop) (param-names r) (param-values ?r))
-    (plan-action (id 3) (plan-id EXPLORE-ZONE) (goal-id ?goal-id) (action-name explore-zone) (param-names r z) (param-values ?r ?zn))
-    (plan-action (id 4) (plan-id EXPLORE-ZONE) (goal-id ?goal-id) (action-name evaluation))
-    (plan-action (id 5) (plan-id EXPLORE-ZONE) (goal-id ?goal-id) (action-name unlock) (param-names name) (param-values ?zn) (executable TRUE))
+    (plan-action (id 2) (plan-id EXPLORE-ZONE) (goal-id ?goal-id) (action-name explore-zone) (param-names r z) (param-values ?r ?zn))
+    (plan-action (id 3) (plan-id EXPLORE-ZONE) (goal-id ?goal-id) (action-name evaluation))
+    (plan-action (id 4) (plan-id EXPLORE-ZONE) (goal-id ?goal-id) (action-name unlock) (param-names name) (param-values ?zn) (executable TRUE))
   )
 )
 


### PR DESCRIPTION
Since the explore-zone action triggers a new skill, the previous moving action will be interrupted anyways. This removes some obsolete code and maybe speeds up the exploration a little bit