### PR TITLE
gazsim-scripts: start gzclient separately to avoid black GUI

### DIFF
--- a/etc/scripts/gazsim-startup.bash
+++ b/etc/scripts/gazsim-startup.bash
@@ -160,7 +160,7 @@ case $COMMAND in
     gazebo )
 	# change Language (in german there is an error that gazebo can not use a number with comma)
 	export LC_ALL="C"
-	gazebo $REPLAY $GAZEBO_WORLD $@
+	( gzserver $REPLAY $GAZEBO_WORLD_PATH & ); sleep 10s; gzclient
 	;;
     gzserver ) 
 	# change Language (in german there is an error that gazebo can not use a number with comma)


### PR DESCRIPTION
This is a really old patch still done by @zwilling back in the days. It still is required for me (at least every now and then). The simulation visualization in the Gazebo client will just stay black on startup. Since I'm tired of carrying it around manually all the time, I propose this for inclusion in master.

The original commit message:
> There seems to be a problem with the gazebo client, which may only show a black world when started together with the gazebo server. Because this problem does not occur when starting both separately with a delay in between, the startup script was changed accordingly.

What this does is disentangle the call to gazebo to use gzserver and gzclient separately, rather than combined in the gazebo binary.