### PR TITLE
agent: properly destroy the content of protobuf messages

### DIFF
--- a/src/agents/rcll2016/exploration.clp
+++ b/src/agents/rcll2016/exploration.clp
@@ -628,7 +628,6 @@
   (not (have-exp-info))
   (lock-role ?role)
   =>
-  (retract ?pbm)
   (foreach ?m (pb-field-list ?p "zones")
     (bind ?name (sym-cat (pb-field-value ?m "zone")))
     (bind ?team (sym-cat (pb-field-value ?m "team_color")))
@@ -656,6 +655,8 @@
   )
   (assert (exp-machines-initialized) 
           (have-exp-info))
+  (retract ?pbm)
+  (pb-destroy ?p)
 )
 
 (defrule exp-send-recognized-machines
@@ -697,7 +698,6 @@
   (phase EXPLORATION)
   ?pbm <- (protobuf-msg (type "llsf_msgs.MachineReportInfo") (ptr ?p))
   =>
-  (retract ?pbm)
   (unwatch facts zone-exploration)
   (foreach ?machine (pb-field-list ?p "reported_machines")
     (do-for-fact ((?m zone-exploration)) (eq ?m:machine (sym-cat ?machine))
@@ -706,6 +706,8 @@
     )
   )
   (watch facts zone-exploration)
+  (retract ?pbm)
+  (pb-destroy ?p)
 )
 
 (defrule exp-prepare-for-production-get-lock-for-ins
@@ -808,6 +810,8 @@
       (retract ?s)
       (assert (state EXP_PREPARE_FOR_PRODUCTION_FINISHED))
   )
+  (retract ?pf)
+  (pb-destroy ?p)
 )
 
 (defrule exp-add-missing-tag-from-other-team

--- a/src/agents/rcll2016/lock-managing.clp
+++ b/src/agents/rcll2016/lock-managing.clp
@@ -92,6 +92,7 @@
         (assert (lock-role SLAVE))
       )
   )
+  (pb-destroy ?p)
 )
 
 (defrule lock-getting-master
@@ -150,7 +151,6 @@
   (bind ?a (str-cat (pb-field-value ?p "agent")))
   (bind ?r (sym-cat (pb-field-value ?p "resource")))
   ;(printout t "Received lock message with type " ?type " of " ?r " from " ?a crlf)
-  (retract ?msg)
   (if (eq ?role MASTER)
     then
     (if (or (eq ?type GET) (eq ?type RELEASE)) then
@@ -177,6 +177,8 @@
       )
     )
   )
+  (retract ?msg)
+  (pb-destroy ?p)
 )
 
 (defrule lock-send-status-of-all-locks-to-slaves
@@ -217,6 +219,7 @@
     (assert (locked-resource (agent ?a) (resource ?r)))
   )
   (retract ?msg)
+  (pb-destroy ?p)
 )
 
 ;;;;;; accepting, releasing and refusing locks ;;;;;;;
@@ -456,4 +459,5 @@
   (wm-remove-incoming-by-agent (sym-cat ?agent))
 
   (retract ?msg)
+  (pb-destroy ?p)
 )

--- a/src/agents/rcll2016/net.clp
+++ b/src/agents/rcll2016/net.clp
@@ -148,6 +148,7 @@
 	  (points MAGENTA (pb-field-value ?p "points_magenta"))
 	  (points CYAN (pb-field-value ?p "points_cyan"))
   )
+  (pb-destroy ?p)
 )
 
 (defrule net-recv-BeaconSignal
@@ -167,8 +168,7 @@
     (bind ?x (pb-field-value ?beacon-pose "x"))
     (bind ?y (pb-field-value ?beacon-pose "y"))
   )
-  (assert (active-robot (name (sym-cat ?beacon-name)) (last-seen ?now) (x ?x) (y ?y)))     
-  (retract ?pf) 
+  (assert (active-robot (name (sym-cat ?beacon-name)) (last-seen ?now) (x ?x) (y ?y)))
 )
 
 (defrule net-recv-order
@@ -218,5 +218,4 @@
       )
     )
   )
-  (retract ?pf)
 )

--- a/src/agents/rcll2016/worldmodel-synchronization.clp
+++ b/src/agents/rcll2016/worldmodel-synchronization.clp
@@ -404,6 +404,7 @@
     )
   )
   (retract ?msg)
+  (pb-destroy ?p)
   ;reenable watching
   (progn$ (?templ ?templs)
     (watch facts ?templ)
@@ -472,6 +473,7 @@
     (worldmodel-sync-apply-key-value-msg ?pair)
   )
   (retract ?pmsg)
+  (pb-destroy ?p)
   ;send acknowledgment
   (bind ?msg-ack (pb-create "llsf_msgs.WorldmodelChangeAck"))
   (pb-set-field ?msg-ack "id" ?id)  
@@ -488,6 +490,7 @@
     (retract ?wmc)
   )
   (retract ?pmsg)
+  (pb-destroy ?p)
 )
 
 (defrule worldmodel-sync-apply-delayed-worldmodel-change

--- a/src/agents/rcll2016/worldmodel.clp
+++ b/src/agents/rcll2016/worldmodel.clp
@@ -50,6 +50,7 @@
   )
   (assert (received-machine-info))
   (retract ?pb-msg)
+  (pb-destroy ?p)
 )
 
 (defrule wm-drive-to-bs-started


### PR DESCRIPTION
Fixes memleaks in old RCLL2016 agent. No harm in merging it now to satisfy #33.