### PR TITLE
cfg ros: use trans_vel instead of x/y for adaption

### DIFF
--- a/cfg/conf.d/ros.yaml
+++ b/cfg/conf.d/ros.yaml
@@ -36,9 +36,8 @@ ros:
 
   navigator:
     dynreconf:
-      path: "/move_base/TebLocalPlannerROS"
-      x_vel_name: "max_vel_x"
-      y_vel_name: "max_vel_y"
+      path: "/safety_controller"
+      trans_vel_name: "max_vel_trans"
       rot_vel_name: "max_vel_theta"
 
     fixed_frame: "map"


### PR DESCRIPTION
The ROS navigator thread uses a generalized translational vel setting
instead of a separation between x and y.

This is required for the change introduced in https://github.com/fawkesrobotics/fawkes/pull/18