### PR TITLE
config: update accel-limits

### DIFF
--- a/cfg/conf.d/robotino.yaml
+++ b/cfg/conf.d/robotino.yaml
@@ -92,12 +92,12 @@ hardware/robotino:
       gear: 32.0
 
     # Maximum acceleration and deceleration for translation, m/s^2
-    trans-acceleration: 0.8
-    trans-deceleration: 1.5
+    trans-acceleration: 0.4
+    trans-deceleration: 1.0
 
     # Maximum acceleration and deceleration for rotation, rad/s^2
     rot-acceleration: 1.6
-    rot-deceleration: 3.14
+    rot-deceleration: 1.6
 
   bumper:
     # Set to true to enable the emergency stop on bumper contact (provided


### PR DESCRIPTION
The acceleration limits have to be lowered because as of 2018,
the gripper got much heavier. This leads to the robot almost falling by
its own acceleration settings.