### PR TITLE
gazsim-scripts: fix gnome-terminal issues, screen support

### DIFF
--- a/etc/scripts/gazsim.bash
+++ b/etc/scripts/gazsim.bash
@@ -90,6 +90,11 @@ case "$TERMINAL" in
         SUBTERM_PREFIX="gnome-terminal --tab -- "
         SUBTERM_SUFFIX=" ; "
         ;;
+    screen)
+        TERM_COMMAND="screen -A -d -m -S gazsim /usr/bin/sleep 1 ; "
+        SUBTERM_PREFIX="screen -S gazsim -X screen "
+        SUBTERM_SUFFIX=" ; "
+        ;;
     tmux)
         if [[ -n $TMUX ]] ; then
             TERM_COMMAND=""


### PR DESCRIPTION
Some tweaks to the gazsim-scripts, in particular:
* Fix the issues with gnome-terminal
* Add support to run the simulation within a screen session
* Improve the way the commands are initialized.
* Allow to override the terminal to use with the `TERMINAL` env variable, e.g., you can run `TERMINAL=screen ./gazsim.bash ...`

This fixes #31.