### PR TITLE
tviehmann/cx-production-cleanup

### DIFF
--- a/src/clips-specs/rcll2018/goal-production.clp
+++ b/src/clips-specs/rcll2018/goal-production.clp
@@ -750,7 +750,7 @@
   ;MPS-BS CEs
   (wm-fact (key domain fact mps-type args? m ?bs t BS))
   (domain-object (name ?bs-side) (type mps-side))
-  (domain-fact (name location-free) (param-values ?bs ?bs-siide))
+  (domain-fact (name location-free) (param-values ?bs ?bs-side))
   (not (wm-fact (key domain fact wp-at args? wp ?some-wp m ?bs side ?any-side)))
   (not (wm-fact (key domain fact holding args? r ?robot wp ?any-wp)))
   (wm-fact (key domain fact mps-state args? m ?bs s ~BROKEN&~DOWN))


### PR DESCRIPTION
This PR handles the clean up of `goal-production.clp` as a contribution to https://github.com/carologistics/fawkes-robotino/issues/10.
Most of the commits address code styling and readability improvements, however there are also two commits contained that slightly change the behaviour of the agent and were found during clean up:
1. f1fb216 is very minor to only delete priority increases during evaluation.
2. 2240b84 resulted from structuring the goal priorities and addresses the issue of blocking the base station only to feed a fresh base to a ring station which we already discussed during Montreal. 