### PR TITLE
Remove timeout of locking actions

### DIFF
--- a/src/clips-specs/rcll2018/lock-actions.clp
+++ b/src/clips-specs/rcll2018/lock-actions.clp
@@ -107,19 +107,6 @@
   (modify ?li (status REQUESTED) (last-try ?now))
 )
 
-(defrule lock-actions-lock-failed
-	?pa <- (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (id ?id)
-                      (action-name lock|location-lock) (state RUNNING))
-  ?li <- (lock-info (name ?name) (goal-id ?goal-id) (plan-id ?plan-id)
-                    (action-id ?id) (status WAITING) (start-time $?start)
-                    (last-error ?error-msg))
-  (time $?now&:(timeout ?now ?start ?*LOCK-ACTION-TIMEOUT-SEC*))
-  =>
-  (printout warn "Failed to get lock " ?name " in " ?*LOCK-ACTION-TIMEOUT-SEC*
-    "s, giving up" crlf)
-	(modify ?pa (state EXECUTION-FAILED) (error-msg ?error-msg))
-  (retract ?li)
-)
 
 (defrule lock-actions-unlock-start
 	?pa <- (plan-action (plan-id ?plan-id) (id ?id) (state PENDING)
@@ -134,6 +121,7 @@
 	(mutex-unlock-async ?lock-name)
 	(modify ?pa (state RUNNING))
 )
+
 
 (defrule lock-actions-unlock-done
   ?pa <- (plan-action (id ?id) (action-name unlock) (state RUNNING)


### PR DESCRIPTION
This fixes #53. Some time ago we wanted the bots to try to get a lock only a certain amount of times to overcome situations in which a lock was held by a non-functioning bot. Since the introduction of lock-expiring (even if it is not 100% working right now), failing a goal only because a lock took too long is not wanted anymore. We rather should wait for the lock expiring to kick in, and then continue with the goal.