### PR TITLE
Dont reset the machine after the last retry automatically

### DIFF
--- a/src/clips-specs/rcll2018/execution-monitoring.clp
+++ b/src/clips-specs/rcll2018/execution-monitoring.clp
@@ -355,7 +355,9 @@
           (value ?tries&:(< ?tries ?*MAX-RETRIES-PICK*)))
   =>
   (bind ?tries (+ 1 ?tries))
-  (modify ?pa (state PENDING))
+  (if (<= ?tries ?*MAX-RETRIES-PICK*) then
+    (modify ?pa (state PENDING))
+  )
   (modify ?wm (value ?tries))
 )
 

--- a/src/clips-specs/rcll2018/goal-production.clp
+++ b/src/clips-specs/rcll2018/goal-production.clp
@@ -1173,7 +1173,7 @@
   (goal (id ?production-id) (class PRODUCTION-MAINTAIN) (mode SELECTED))
   (wm-fact (key domain fact self args? r ?self))
   ?t <- (wm-fact (key monitoring action-retried args? r ?self a wp-get m ?mps wp ?wp)
-                (value ?tried&:(>= ?tried ?*MAX-RETRIES-PICK*)))
+                (value ?tried&:(> ?tried ?*MAX-RETRIES-PICK*)))
   =>
   (printout t "Goal " RESET-MPS " formulated" crlf)
   (assert (goal (id (sym-cat RESET-MPS- (gensym*)))


### PR DESCRIPTION
The execution monitoring retries a failed get action a certain number of times. After the retries, we wanted to reset the mps, to get to a consistent state. 
However, the mps used to get reset after the last retry, regardless whether it was successful or not. 
This is fixes #16 