### PR TITLE
Load ros-movebase in gazsim-meta-robotino-ros

### DIFF
--- a/cfg/conf.d/meta_plugins_gazebo.yaml
+++ b/cfg/conf.d/meta_plugins_gazebo.yaml
@@ -31,6 +31,7 @@ fawkes/meta_plugins:
     - gazsim-vis-localization
     - skiller
     - mps-laser-gen
+    - gazsim-meta-robotino-ros-movebase
   gazsim-meta-robotino-ros-movebase:
     - ros-cmdvel
     - ros-navigator
@@ -64,7 +65,6 @@ fawkes/meta_plugins:
 
   gazsim-meta-clips-exec:
     - gazsim-meta-robotino-ros
-    - gazsim-meta-robotino-ros-movebase
     - m-clips-executive
 
   m-skill-sim-clips-exec:


### PR DESCRIPTION
This loads the meta plugin `gazsim-meta-ros-movebase` in `gazsim-meta-robotino-ros`.
Previously the robot wouldn't drive when the `-a` option to `gazsim.bash` is missing, even though `-r` is there.