### PR TITLE
Increase driving speed when exploring a zone

### DIFF
--- a/cfg/conf.d/clips-executive.yaml
+++ b/cfg/conf.d/clips-executive.yaml
@@ -190,8 +190,12 @@ clips-executive:
           exploration:
             # Reduce navigator velocity while traveling the field so we can find
             # laser-lines more reliably
-            max-velocity: 0.4
-            max-rotation: 0.5
+            low-velocity: 0.4
+            low-rotation: 0.5
+
+            # Increased speed and rotation when exploring a zone
+            max-velocity: 1.0
+            max-rotation: 1.0
 
             # Center of a laser-line must be this far from the zone border
             # before we start investigating it further (i.e. call the


### PR DESCRIPTION
Currently the exploration uses a rather slow velocity and rotation speed. This is done to get less noisy tag and laser line findings. However, as soon as a bot starts exploring an interesting zone we want to finish it as fast as possible.
This this PR introduces a second pair of configuration values, only used for exploring a specific zone