### PR TITLE
Update refbox messages for the competition year 2019

### DIFF
--- a/src/libs/llsf_msgs/MachineDescription.proto
+++ b/src/libs/llsf_msgs/MachineDescription.proto
@@ -54,22 +54,6 @@ enum LightState {
   BLINK = 2;
 }
 
-enum MachineSide {
-  INPUT  = 1;
-  OUTPUT = 2;
-}
-
-enum ConveyorDirection {
-  FORWARD  = 1;	// from input to output
-  BACKWARD = 2;	// from output to input
-}
-
-enum SensorOnMPS {
-  SENSOR_INPUT  = 1;
-  SENSOR_OUTPUT = 2;
-  SENSOR_MIDDLE = 3;
-}
-
 enum SSOp {
   STORE   = 1;
   RETRIEVE = 2;
@@ -78,7 +62,7 @@ enum SSOp {
 message SSSlot {
   // Ordering is a right hand coordinate system, starting at the left bottom front corner
   required uint32 x = 1; // [0-5] height; the shelfs
-  required uint32 y = 2; // [0-3] width;  the place on the shelf
+  required uint32 y = 2; // [0-4] width;  the place on the shelf
   required uint32 z = 3; // [0-1] depth;  the front or back row of the shelf
 }
 

--- a/src/libs/llsf_msgs/MachineInstructions.proto
+++ b/src/libs/llsf_msgs/MachineInstructions.proto
@@ -4,7 +4,6 @@
  *
  *  Created: Thu Apr 16 14:19:07 2015
  *  Copyright  2013  Tim Niemueller [www.niemueller.de]
- *             2017  Tobias Neumann
  ****************************************************************************/
 
 /*  Redistribution and use in source and binary forms, with or without
@@ -46,99 +45,14 @@ import "Team.proto";
 option java_package = "org.robocup_logistics.llsf_msgs";
 option java_outer_classname = "MachineInstructionProtos";
 
-message SetSignalLight {
-  required LightState red    = 2;
-  required LightState yellow = 3;
-  required LightState green  = 4;
-}
-
-message MoveConveyorBelt {
-  required ConveyorDirection direction   = 2;
-  required SensorOnMPS       stop_sensor = 3;
-}
-
-message BSPushBase {
-  required uint32 slot = 2; // [0-2] where 0 is on the input side, 1 in the middle and 2 on the output side
+enum MachineSide {
+  INPUT  = 1;
+  OUTPUT = 2;
 }
 
 message SSTask {
   required SSOp   operation = 2;
-  required SSSlot slot      = 3;
-}
-
-message RSMountRing {
-  required uint32 feeder = 2; // [0,1] where 0 is the feeder closer to the input side and 1 is the feeder closer to the output side
-}
-
-message CSTask {
-  required CSOp operation = 2;
-}
-
-message DSActivateGate {
-  required uint32 gate = 2; // [0-2] where 0 is the gate closest to the input, 1 is the gate in the middle and 2 is the last gate from the input
-}
-
-enum InstructMachineSet {
-  INSTRUCT_MACHINE_SET_SIGNAL_LIGHT = 1;
-  INSTRUCT_MACHINE_MOVE_CONVEYOR    = 2;
-  INSTRUCT_MACHINE_STOP_CONVEYOR    = 3;
-  INSTRUCT_MACHINE_WAIT_FOR_PICKUP  = 4;
-  INSTRUCT_MACHINE_BS = 11;
-  INSTRUCT_MACHINE_SS = 12;
-  INSTRUCT_MACHINE_RS = 13;
-  INSTRUCT_MACHINE_CS = 14;
-  INSTRUCT_MACHINE_DS = 15;
-  INSTRUCT_MACHINE_PULL_MSGS_FROM_MPS = 31;
-  INSTRUCT_MACHINE_RESET = 51;
-}
-
-message InstructMachine {
-  enum CompType {
-    COMP_ID  = 2000;
-    MSG_TYPE = 102;
-  }
-
-  required uint32 id = 1;
-//  required Team   team_color = 2;
-  // Machine name which to instruct
-  required string machine = 3;
-  // which MPS comand is set and has to be completed
-  required InstructMachineSet set = 4;
-
-  optional SetSignalLight   light_state   = 5;
-  optional MoveConveyorBelt conveyor_belt = 6;
-
-  optional BSPushBase     bs = 11;
-  optional SSTask         ss = 12;
-  optional RSMountRing    rs = 13;
-  optional CSTask         cs = 14;
-  optional DSActivateGate ds = 15;
-}
-
-enum MachineReplySet {
-  MACHINE_REPLY_FINISHED         = 1;
-  MACHINE_REPLY_FINISHED_WITH_PAYLOAD = 2;
-}
-
-message MachineSensorInfo {
-  optional uint32 added_bases  = 11 [default = 0];
-  optional int32  barcode      = 12 [default = -1];
-}
-
-message MachineReply {
-  enum CompType {
-    COMP_ID  = 2000;
-    MSG_TYPE = 103;
-  }
-
-  required uint32 id = 1;
-//  required Team   team_color = 2;
-  // Machine name which to instruct
-  required string machine = 3;
-  // which MPS comand is set and has to be completed
-  required MachineReplySet set = 4;
-
-  repeated MachineSensorInfo sensors = 11;
+  required SSSlot shelf     = 3;
 }
 
 message PrepareInstructionBS {
@@ -147,7 +61,9 @@ message PrepareInstructionBS {
 }
 
 message PrepareInstructionDS {
-  required uint32 gate = 1;
+  reserved "gate";
+  reserved 1;
+  required uint32 order_id = 2;
 }
 
 message PrepareInstructionSS {
@@ -188,13 +104,5 @@ message ResetMachine {
   required Team   team_color = 1;
   // Machine name which to instruct
   required string machine = 2;
-}
-
-message MachineRequestPull {
-  enum CompType {
-    COMP_ID  = 2000;
-    MSG_TYPE = 105;
-  }
-  required string machine = 3;
 }
 

--- a/src/libs/llsf_msgs/OrderInfo.proto
+++ b/src/libs/llsf_msgs/OrderInfo.proto
@@ -39,10 +39,22 @@ syntax = "proto2";
 package llsf_msgs;
 
 import "Team.proto";
+import "Time.proto";
 import "ProductColor.proto";
 
 option java_package = "org.robocup_logistics.llsf_msgs";
 option java_outer_classname = "OrderInfoProtos";
+
+message UnconfirmedDelivery {
+  enum CompType {
+    COMP_ID  = 2000;
+    MSG_TYPE = 45;
+  }
+
+  required uint32 id            = 1;
+  required Team   team          = 2;
+  required Time   delivery_time = 3;
+}
 
 message Order {
   enum CompType {
@@ -80,6 +92,9 @@ message Order {
   // (non-defunct, i.e. non-red light) gate
   required uint32 delivery_gate = 11;
 
+  repeated UnconfirmedDelivery unconfirmed_deliveries = 12;
+
+  required bool competitive = 13;
 }
 
 message OrderInfo {
@@ -92,29 +107,22 @@ message OrderInfo {
   repeated Order orders = 1;
 }
 
-
 message SetOrderDelivered {
   enum CompType {
     COMP_ID  = 2000;
     MSG_TYPE = 43;
   }
 
-  required Team team_color = 1;
-  required uint32 order_id = 2;
+  required Team   team_color = 1;
+  required uint32 order_id   = 2;
 }
 
-
-message SetOrderDeliveredByColor {
+message ConfirmDelivery {
   enum CompType {
     COMP_ID  = 2000;
-    MSG_TYPE = 44;
+    MSG_TYPE = 46;
   }
 
-  required Team         team_color = 1;
-
-	/** Colors of delivered product. Zero,
-	 * or more rings orderd from bottom to top */
-  required BaseColor    base_color = 3;
-  repeated RingColor    ring_colors = 4;
-  required CapColor     cap_color = 5;
+  required uint32 delivery_id = 1;
+  required bool   correct     = 2;
 }


### PR DESCRIPTION
Update the protobuf messages, taken from the [RefBox 2019 Beta 1](https://github.com/robocup-logistics/rcll-refbox/releases/tag/2019-beta.1).

This doesn't include any changes to the code on our side and requires additional changes, at least #91.