### PR TITLE
CX: Fix bug in location unlock handling

### DIFF
--- a/src/clips-specs/rcll2018/lock-actions.clp
+++ b/src/clips-specs/rcll2018/lock-actions.clp
@@ -190,7 +190,12 @@
 (defrule lock-actions-unlock-location-done
   ?l <- (location-unlock-pending ?loc ?side)
   (mutex (name ?lock-name&:(eq ?lock-name (sym-cat ?loc - ?side)))
-         (state OPEN) (request NONE))
+         (state OPEN) (request UNLOCK) (response UNLOCKED))
   =>
+  (do-for-fact ((?wm-fact wm-fact)) (eq ?wm-fact:key (create$ domain fact
+                                        location-locked args? m ?loc s ?side))
+     (retract ?wm-fact)
+  )
   (retract ?l)
+  (modify ?m (request NONE) (response NONE))
 )


### PR DESCRIPTION
This PR resolves two issues regarding the unlocking of location locks by

1. Acknowledging location unlock responses properly.
2.  Deleting location-locked facts after unlocking as they are not handled by the domain-effects due to distance based unlocking.