### PR TITLE
Add script for simulated network problems

### DIFF
--- a/etc/scripts/rcll_netemulation.sh
+++ b/etc/scripts/rcll_netemulation.sh
@@ -129,7 +129,7 @@ done
 
 function clear_rules() {
 echo "clear rules on dev $1"
-sudo tc qdisc del dev $1 root
+tc qdisc del dev $1 root
 }
 
 function show_rules() {


### PR DESCRIPTION
This PR adds a network simulation script. The Script allows to apply delay, loss, corruption, duplicates and limit bandwith.
The rules are only applied to ports used by robot memory
 (27017, 27021, 27022, 27023, 27031, 27032, 27033)

See --help option for usage description