### PR TITLE
fix syntax error due to undbound variable in location lock unlocking

### DIFF
--- a/src/clips-specs/rcll2018/lock-actions.clp
+++ b/src/clips-specs/rcll2018/lock-actions.clp
@@ -189,7 +189,7 @@
 
 (defrule lock-actions-unlock-location-done
   ?l <- (location-unlock-pending ?loc ?side)
-  (mutex (name ?lock-name&:(eq ?lock-name (sym-cat ?loc - ?side)))
+  ?m <- (mutex (name ?lock-name&:(eq ?lock-name (sym-cat ?loc - ?side)))
          (state OPEN) (request UNLOCK) (response UNLOCKED))
   =>
   (do-for-fact ((?wm-fact wm-fact)) (eq ?wm-fact:key (create$ domain fact


### PR DESCRIPTION
This PR fixes a syntax error introduced through #114.