### PR TITLE
cx: fix mps reset after failed retry of wp-get

### DIFF
--- a/src/clips-specs/rcll2018/execution-monitoring.clp
+++ b/src/clips-specs/rcll2018/execution-monitoring.clp
@@ -330,6 +330,18 @@
 )
 
 
+(defrule execution-monitoring-retry-action-wp-get-final
+  (plan-action
+        (action-name ?an&wp-get)
+        (state FINAL)
+        (param-values $? ?wp $? ?mps $?))
+  (domain-obj-is-of-type ?mps mps)
+  (domain-obj-is-of-type ?wp workpiece)
+  ?wm <- (wm-fact (key monitoring action-retried args? r ?r a ?an m ?mps wp ?wp))
+  =>
+  (retract ?wm)
+)
+
 ;
 ;======================================Misc==============================
 ;

--- a/src/clips-specs/rcll2018/goal-production.clp
+++ b/src/clips-specs/rcll2018/goal-production.clp
@@ -1165,7 +1165,7 @@
   (goal (id ?production-id) (class URGENT) (mode FORMULATED))
   (wm-fact (key domain fact self args? r ?self))
   ?t <- (wm-fact (key monitoring action-retried args? r ?self a wp-get m ?mps wp ?wp)
-                (value ?tried&:(> ?tried ?*MAX-RETRIES-PICK*)))
+                (value ?tried&:(>= ?tried ?*MAX-RETRIES-PICK*)))
   =>
   (printout t "Goal " RESET-MPS " formulated" crlf)
   (assert (goal (id (sym-cat RESET-MPS- (gensym*)))

--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -308,11 +308,8 @@
    fails."
   ?g <- (goal (id ?goal-id) (class PRODUCTION-MAINTAIN) (parent nil)
               (mode FINISHED) (outcome ?outcome))
-  ?t <- (wm-fact (key monitoring action-retried args? r ?self a ?an m ?mps wp ?wp)
-                 (value ?tried&:(>= ?tried ?*MAX-RETRIES-PICK*)))
   =>
   (printout t "Goal '" ?goal-id "' has been " ?outcome ", evaluating" crlf)
-  (retract ?t)
   (do-for-all-facts ((?prio wm-fact)) (wm-key-prefix ?prio:key (create$ evaluated fact rs-fill-priority))
    (retract ?prio))
   (modify ?g (mode EVALUATED))


### PR DESCRIPTION
This PR fixes the formulation of a mps-reset goal after a failed retried wp-get. Before, the wp-get would have been retried, but after failing the last time, the mps would have not been reset, since the corresponding monitoring fact was removed at the wrong position, before goal formulation.