### PR TITLE
fawkes-robotino: reformat correctly

### DIFF
--- a/src/plugins/arduino/arduino_plugin.cpp
+++ b/src/plugins/arduino/arduino_plugin.cpp
@@ -20,36 +20,37 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "com_thread.h"
 #include "tf_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Plugin to provide Arduino platform support for Fawkes.
  * @author Tim Niemueller, Nicolas Limpert
  */
-class ArduinoPlugin : public fawkes::Plugin {
+class ArduinoPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  ArduinoPlugin(Configuration *config) : Plugin(config) {
-    std::string prefix = "/arduino";
+	ArduinoPlugin(Configuration *config) : Plugin(config)
+	{
+		std::string prefix = "/arduino";
 
-    std::string cfg_name = prefix.substr(1, prefix.length());
-    std::string cfg_prefix = prefix + "/";
+		std::string cfg_name   = prefix.substr(1, prefix.length());
+		std::string cfg_prefix = prefix + "/";
 
-    cfg_name = cfg_name.substr(0, cfg_name.find("/"));
+		cfg_name = cfg_name.substr(0, cfg_name.find("/"));
 
-    ArduinoTFThread *tf_thread = new ArduinoTFThread(cfg_name, cfg_prefix);
-    ArduinoComThread *com_thread =
-        new ArduinoComThread(cfg_name, cfg_prefix, tf_thread);
+		ArduinoTFThread * tf_thread  = new ArduinoTFThread(cfg_name, cfg_prefix);
+		ArduinoComThread *com_thread = new ArduinoComThread(cfg_name, cfg_prefix, tf_thread);
 
-    thread_list.push_back(tf_thread);
-    thread_list.push_back(com_thread);
-  }
+		thread_list.push_back(tf_thread);
+		thread_list.push_back(com_thread);
+	}
 };
 
 PLUGIN_DESCRIPTION("Arduino platform support")

--- a/src/plugins/arduino/com_message.cpp
+++ b/src/plugins/arduino/com_message.cpp
@@ -21,6 +21,7 @@
 #include "com_message.h"
 
 #include <core/exception.h>
+
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
@@ -65,40 +66,53 @@ const char ArduinoComMessage::MSG_HEAD[] = {'A', 'T', ' '};
 /** Constructor.
  * Create empty message for writing.
  */
-ArduinoComMessage::ArduinoComMessage() { ctor(); }
+ArduinoComMessage::ArduinoComMessage()
+{
+	ctor();
+}
 
 /** Constructor for initial command.
  * Create message for writing and add command for given message ID.
  * @param cmdid message ID of command to add
  * @param value message value to be passed
  */
-ArduinoComMessage::ArduinoComMessage(command_id_t cmdid, unsigned int value) {
-  ctor();
-  add_command(cmdid, value);
+ArduinoComMessage::ArduinoComMessage(command_id_t cmdid, unsigned int value)
+{
+	ctor();
+	add_command(cmdid, value);
 }
 
 /** Destructor.
  */
-ArduinoComMessage::~ArduinoComMessage() { dtor(); }
+ArduinoComMessage::~ArduinoComMessage()
+{
+	dtor();
+}
 
-void ArduinoComMessage::dtor() { free(data_); }
+void
+ArduinoComMessage::dtor()
+{
+	free(data_);
+}
 
-void ArduinoComMessage::ctor() {
-  // always allocate 128 bytes, increase if necessary
-  data_size_ = 128;
-  data_ = (char *)malloc(data_size_);
+void
+ArduinoComMessage::ctor()
+{
+	// always allocate 128 bytes, increase if necessary
+	data_size_ = 128;
+	data_      = (char *)malloc(data_size_);
 
-  // init buffer with zeros
-  memset(data_, 0, data_size_);
+	// init buffer with zeros
+	memset(data_, 0, data_size_);
 
-  // append header
-  memcpy(data_, MSG_HEAD, 3);
+	// append header
+	memcpy(data_, MSG_HEAD, 3);
 
-  // start first command after header
-  cur_buffer_index_ = 3;
+	// start first command after header
+	cur_buffer_index_ = 3;
 
-  // setup a minimum of 1 second to wait
-  msecs_to_wait_ = 1000;
+	// setup a minimum of 1 second to wait
+	msecs_to_wait_ = 1000;
 }
 
 /** Add a command.
@@ -110,51 +124,50 @@ void ArduinoComMessage::ctor() {
  * @param value the value to the added command.
  * @return true if command was successfully added
  */
-bool ArduinoComMessage::add_command(command_id_t cmd, unsigned int value) {
-  // TODO: Test if "home" command also works if a "value" was accidentially
-  // appended!
-  bool valid_command = false;
-  char char_cmd = static_cast<char>(cmd);
+bool
+ArduinoComMessage::add_command(command_id_t cmd, unsigned int value)
+{
+	// TODO: Test if "home" command also works if a "value" was accidentially
+	// appended!
+	bool valid_command = false;
+	char char_cmd      = static_cast<char>(cmd);
 
-  if (cmd == command_id_t::CMD_CALIBRATE ||
-      cmd == command_id_t::CMD_X_NEW_POS ||
-      cmd == command_id_t::CMD_Y_NEW_POS ||
-      cmd == command_id_t::CMD_Z_NEW_POS ||
-      cmd == command_id_t::CMD_OPEN ||
-      cmd == command_id_t::CMD_CLOSE ||
-      cmd == command_id_t::CMD_STATUS_REQ) {
-    valid_command = true;
-  }
+	if (cmd == command_id_t::CMD_CALIBRATE || cmd == command_id_t::CMD_X_NEW_POS
+	    || cmd == command_id_t::CMD_Y_NEW_POS || cmd == command_id_t::CMD_Z_NEW_POS
+	    || cmd == command_id_t::CMD_OPEN || cmd == command_id_t::CMD_CLOSE
+	    || cmd == command_id_t::CMD_STATUS_REQ) {
+		valid_command = true;
+	}
 
-  if (valid_command == true) {
-    //    std::cout << "Buffer valid?: ";
-    // skip the AT header, therefore start at index 3
-    for (int i = 3; i < data_size_; i++) {
-      //      std::cout << (int) data_[i] << ' ';
-      // cancel when the command was already set
-      if (data_[i] == char_cmd) {
-        valid_command = false;
-        break;
-      }
-    }
-  }
-  //  std::cout << std::endl;
+	if (valid_command == true) {
+		//    std::cout << "Buffer valid?: ";
+		// skip the AT header, therefore start at index 3
+		for (int i = 3; i < data_size_; i++) {
+			//      std::cout << (int) data_[i] << ' ';
+			// cancel when the command was already set
+			if (data_[i] == char_cmd) {
+				valid_command = false;
+				break;
+			}
+		}
+	}
+	//  std::cout << std::endl;
 
-  // check whether we're exceeding the data_size_
-  valid_command &= cur_buffer_index_ + 1 + num_digits(value) < data_size_ - 1;
+	// check whether we're exceeding the data_size_
+	valid_command &= cur_buffer_index_ + 1 + num_digits(value) < data_size_ - 1;
 
-  if (valid_command == false) {
-    return false;
-  }
+	if (valid_command == false) {
+		return false;
+	}
 
-  data_[cur_buffer_index_] = char_cmd;
-  cur_buffer_index_++;
+	data_[cur_buffer_index_] = char_cmd;
+	cur_buffer_index_++;
 
-  cur_buffer_index_ += sprintf(data_ + cur_buffer_index_, "%u", value);
-  data_[cur_buffer_index_] = ' ';
-  cur_buffer_index_++;
+	cur_buffer_index_ += sprintf(data_ + cur_buffer_index_, "%u", value);
+	data_[cur_buffer_index_] = ' ';
+	cur_buffer_index_++;
 
-  return true;
+	return true;
 }
 
 /** Get access to buffer for sending.
@@ -163,22 +176,24 @@ bool ArduinoComMessage::add_command(command_id_t cmd, unsigned int value) {
  * on the destruction of the message.
  * @return buffer of escaped data.
  */
-boost::asio::const_buffer ArduinoComMessage::buffer() {
-  // Add terminator character to the end
-  data_[data_size_ - 1] = '+';
+boost::asio::const_buffer
+ArduinoComMessage::buffer()
+{
+	// Add terminator character to the end
+	data_[data_size_ - 1] = '+';
 
 #ifdef DEBUG
-  std::cout << "Buffer: ";
-  //  printf("Buffer: ");
-  for (size_t i = 0; i < data_size_; ++i) {
-    //      printf("%c", data_[i]);
-    std::cout << data_[i];
-  }
-  std::cout << std::endl;
+	std::cout << "Buffer: ";
+	//  printf("Buffer: ");
+	for (size_t i = 0; i < data_size_; ++i) {
+		//      printf("%c", data_[i]);
+		std::cout << data_[i];
+	}
+	std::cout << std::endl;
 //  printf("\n");
 #endif
 
-  return boost::asio::buffer(data_, data_size_);
+	return boost::asio::buffer(data_, data_size_);
 }
 
 /** Set the number of msecs the associated action of this
@@ -186,30 +201,42 @@ boost::asio::const_buffer ArduinoComMessage::buffer() {
  * long as the last value is smaller than the new value).
  * @param msecs milliseconds
  */
-void ArduinoComMessage::set_msecs_if_lower(unsigned int msecs) {
-  // TODO: Do we have to wait for each axis alone or just the longest running
-  // one?
-  if (msecs_to_wait_ < msecs) {
-    msecs_to_wait_ = msecs;
-  }
+void
+ArduinoComMessage::set_msecs_if_lower(unsigned int msecs)
+{
+	// TODO: Do we have to wait for each axis alone or just the longest running
+	// one?
+	if (msecs_to_wait_ < msecs) {
+		msecs_to_wait_ = msecs;
+	}
 }
 
 /** Get the number of msecs the associated action of this
  * message is probably going to need to be executed
  * @return msecs milliseconds
  */
-unsigned int ArduinoComMessage::get_msecs() { return msecs_to_wait_; }
+unsigned int
+ArduinoComMessage::get_msecs()
+{
+	return msecs_to_wait_;
+}
 
 /** Get the data size of the message
  * this is only used for error reporting
  * @return data size of the message
  */
-unsigned short ArduinoComMessage::get_data_size() { return data_size_; }
+unsigned short
+ArduinoComMessage::get_data_size()
+{
+	return data_size_;
+}
 
 /** Get the current buffer index
  * this is only used for error reporting
  * @return current buffer index
  */
-unsigned short ArduinoComMessage::get_cur_buffer_index() {
-  return cur_buffer_index_;
+unsigned short
+ArduinoComMessage::get_cur_buffer_index()
+{
+	return cur_buffer_index_;
 }

--- a/src/plugins/arduino/com_message.h
+++ b/src/plugins/arduino/com_message.h
@@ -25,60 +25,63 @@
 #include <boost/asio.hpp>
 #include <cstdint>
 
-class ArduinoComMessage {
+class ArduinoComMessage
+{
 public:
-  /**
+	/**
    * @brief Mapping for all possible commands, that can be send to the arduino
    */
-  enum class command_id_t : char {
-    CMD_CALIBRATE = 'C',
-    CMD_X_NEW_POS = 'X',
-    CMD_Y_NEW_POS = 'Y',
-    CMD_Z_NEW_POS = 'Z',
-    CMD_CLOSE = 'G',
-    CMD_OPEN = 'O',
-    CMD_STATUS_REQ = 'S'
-  };
+	enum class command_id_t : char {
+		CMD_CALIBRATE  = 'C',
+		CMD_X_NEW_POS  = 'X',
+		CMD_Y_NEW_POS  = 'Y',
+		CMD_Z_NEW_POS  = 'Z',
+		CMD_CLOSE      = 'G',
+		CMD_OPEN       = 'O',
+		CMD_STATUS_REQ = 'S'
+	};
 
-  /**
+	/**
    * @brief The prefix of each message to the arduino
    */
-  static const char MSG_HEAD[3];
+	static const char MSG_HEAD[3];
 
-  ArduinoComMessage();
-  ~ArduinoComMessage();
-  ArduinoComMessage(command_id_t cmdid, unsigned int value);
+	ArduinoComMessage();
+	~ArduinoComMessage();
+	ArduinoComMessage(command_id_t cmdid, unsigned int value);
 
-  bool add_command(command_id_t cmd, unsigned int number);
-  unsigned short get_data_size();
-  unsigned short get_cur_buffer_index();
+	bool           add_command(command_id_t cmd, unsigned int number);
+	unsigned short get_data_size();
+	unsigned short get_cur_buffer_index();
 
-  boost::asio::const_buffer buffer();
+	boost::asio::const_buffer buffer();
 
-  void set_msecs_if_lower(unsigned int msecs);
-  unsigned int get_msecs();
+	void         set_msecs_if_lower(unsigned int msecs);
+	unsigned int get_msecs();
 
-  /**
+	/**
    * @brief Calculates the number of digits an integer consists of
    *
    * @param i The number of which the number of digits should be calculated
    *
    * @return The amount of digits i consists of
    */
-  static inline unsigned short num_digits(unsigned int i) {
-    return i > 0 ? (int)log10((double)i) + 1 : 1;
-  }
+	static inline unsigned short
+	num_digits(unsigned int i)
+	{
+		return i > 0 ? (int)log10((double)i) + 1 : 1;
+	}
 
 private:
-  void ctor();
-  void dtor();
+	void ctor();
+	void dtor();
 
 private:
-  char *data_;
-  unsigned short data_size_;
-  unsigned short cur_buffer_index_; // index of next data field
+	char *         data_;
+	unsigned short data_size_;
+	unsigned short cur_buffer_index_; // index of next data field
 
-  unsigned int msecs_to_wait_;
+	unsigned int msecs_to_wait_;
 };
 
 #endif

--- a/src/plugins/arduino/com_thread.cpp
+++ b/src/plugins/arduino/com_thread.cpp
@@ -21,20 +21,19 @@
  */
 
 #include "com_thread.h"
+
 #include <baseapp/run.h>
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
+#include <interfaces/ArduinoInterface.h>
 #include <utils/math/angle.h>
 #include <utils/time/wait.h>
-
-#include <interfaces/ArduinoInterface.h>
-
-#include <unistd.h>
 
 #include <boost/lambda/bind.hpp>
 #include <boost/lambda/lambda.hpp>
 #include <boost/thread/thread.hpp>
 #include <libudev.h>
+#include <unistd.h>
 
 using namespace fawkes;
 
@@ -44,669 +43,688 @@ using namespace fawkes;
  */
 
 /** Constructor. */
-ArduinoComThread::ArduinoComThread(std::string &cfg_name,
-                                   std::string &cfg_prefix,
+ArduinoComThread::ArduinoComThread(std::string &    cfg_name,
+                                   std::string &    cfg_prefix,
                                    ArduinoTFThread *tf_thread)
-    : Thread("ArduinoComThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlackBoardInterfaceListener("ArduinoThread(%s)", cfg_name.c_str()),
-      fawkes::TransformAspect(), serial_(io_service_), deadline_(io_service_),
-      tf_thread_(tf_thread) {
-  data_mutex_ = new Mutex();
-  cfg_prefix_ = cfg_prefix;
-  cfg_name_ = cfg_name;
-  set_coalesce_wakeups(false);
+: Thread("ArduinoComThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlackBoardInterfaceListener("ArduinoThread(%s)", cfg_name.c_str()),
+  fawkes::TransformAspect(),
+  serial_(io_service_),
+  deadline_(io_service_),
+  tf_thread_(tf_thread)
+{
+	data_mutex_ = new Mutex();
+	cfg_prefix_ = cfg_prefix;
+	cfg_name_   = cfg_name;
+	set_coalesce_wakeups(false);
 }
 
 /** Destructor. */
-ArduinoComThread::~ArduinoComThread() {}
-
-void ArduinoComThread::init() {
-  // --------------------------------------------------------------------------
-  // //
-  load_config();
-
-  arduino_if_ = blackboard->open_for_writing<ArduinoInterface>(
-      "Arduino", cfg_name_.c_str());
-
-  joystick_if_ = blackboard->open_for_reading<JoystickInterface>(
-      "Joystick", cfg_ifid_joystick_.c_str());
-
-  deadline_.expires_at(boost::posix_time::pos_infin);
-  opened_ = false;
-
-  open_device();
-
-  open_tries_ = 0;
-  movement_pending_ = false;
-
-  // initially calibrate the gripper on startup
-  calibrated_ = false;
-
-  // move to home position on startup
-
-  home_pending_ = true;
-
-  set_acceleration_pending_ = false;
-  msecs_to_wait_ = 0;
-
-  bbil_add_message_interface(arduino_if_);
-
-  blackboard->register_listener(this);
-  arduino_if_->set_final(true);
-
-  arduino_if_->set_status(ArduinoInterface::IDLE);
-  arduino_if_->write();
-  wakeup();
+ArduinoComThread::~ArduinoComThread()
+{
 }
 
-void ArduinoComThread::finalize() {
-  // TODO: 18:05:21.526199 PluginNetworkHandler: [EXCEPTION]
-  // Thread[ArduinoComThread]::finalize() threw unsupported exception
+void
+ArduinoComThread::init()
+{
+	// --------------------------------------------------------------------------
+	// //
+	load_config();
 
-  blackboard->unregister_listener(this);
-  blackboard->close(arduino_if_);
-  close_device();
+	arduino_if_ = blackboard->open_for_writing<ArduinoInterface>("Arduino", cfg_name_.c_str());
+
+	joystick_if_ =
+	  blackboard->open_for_reading<JoystickInterface>("Joystick", cfg_ifid_joystick_.c_str());
+
+	deadline_.expires_at(boost::posix_time::pos_infin);
+	opened_ = false;
+
+	open_device();
+
+	open_tries_       = 0;
+	movement_pending_ = false;
+
+	// initially calibrate the gripper on startup
+	calibrated_ = false;
+
+	// move to home position on startup
+
+	home_pending_ = true;
+
+	set_acceleration_pending_ = false;
+	msecs_to_wait_            = 0;
+
+	bbil_add_message_interface(arduino_if_);
+
+	blackboard->register_listener(this);
+	arduino_if_->set_final(true);
+
+	arduino_if_->set_status(ArduinoInterface::IDLE);
+	arduino_if_->write();
+	wakeup();
 }
 
-void ArduinoComThread::append_message_to_queue(
-    ArduinoComMessage::command_id_t cmd, unsigned int value,
-    unsigned int timeout) {
-  ArduinoComMessage *msg = new ArduinoComMessage(cmd, value);
-  msg->set_msecs_if_lower(timeout);
-  append_message_to_queue(msg);
+void
+ArduinoComThread::finalize()
+{
+	// TODO: 18:05:21.526199 PluginNetworkHandler: [EXCEPTION]
+	// Thread[ArduinoComThread]::finalize() threw unsupported exception
+
+	blackboard->unregister_listener(this);
+	blackboard->close(arduino_if_);
+	close_device();
 }
 
-void ArduinoComThread::append_message_to_queue(ArduinoComMessage *msg) {
-  messages_.push(msg);
+void
+ArduinoComThread::append_message_to_queue(ArduinoComMessage::command_id_t cmd,
+                                          unsigned int                    value,
+                                          unsigned int                    timeout)
+{
+	ArduinoComMessage *msg = new ArduinoComMessage(cmd, value);
+	msg->set_msecs_if_lower(timeout);
+	append_message_to_queue(msg);
 }
 
-bool ArduinoComThread::add_command_to_message(
-    ArduinoComMessage *msg, ArduinoComMessage::command_id_t command,
-    unsigned int value) {
-  // TODO: Check if consistency for sending values is kept - is it always
-  // unsigned int?
-  if (!msg->add_command(command, value)) {
-    logger->log_error(
-        name(),
-        "Faulty command! id: %c value: %u size: %u msg_len: %u, index: %u",
-        static_cast<char>(command), value, msg->get_data_size(),
-        ArduinoComMessage::num_digits(value) + 1, msg->get_cur_buffer_index());
-    return false;
-  }
-  return true;
+void
+ArduinoComThread::append_message_to_queue(ArduinoComMessage *msg)
+{
+	messages_.push(msg);
 }
 
-void ArduinoComThread::loop() {
-  if (opened_) {
-    arduino_if_->read();
-
-    while (!arduino_if_->msgq_empty() && arduino_if_->is_final() &&
-           calibrated_) {
-      if (arduino_if_->msgq_first_is<ArduinoInterface::MoveXYZAbsMessage>()) {
-        ArduinoInterface::MoveXYZAbsMessage *msg = arduino_if_->msgq_first(msg);
-
-        ArduinoComMessage *arduino_msg = new ArduinoComMessage();
-
-        fawkes::tf::StampedTransform tf_pose_target;
-
-        try {
-          tf_listener->lookup_transform(cfg_gripper_frame_id_, msg->target_frame(),
-                                        tf_pose_target);
-        } catch (fawkes::tf::ExtrapolationException &e) {
-          logger->log_error(name(), "Extrapolation error");
-          break;
-        } catch (fawkes::tf::ConnectivityException &e) {
-          logger->log_error(name(), "Connectivity exception: %s", e.what());
-          break;
-        } catch (fawkes::IllegalArgumentException &e) {
-          logger->log_error(name(),
-                            "IllegalArgumentException exception - did you set "
-                            "the frame_id?: %s",
-                            e.what());
-          break;
-        } catch (fawkes::Exception &e) {
-          logger->log_error(name(), "Other exception: %s", e.what());
-          break;
-        }
-        logger->log_info(name(), "Target: %f,%f,%f in frame %s", msg->x(),
-                         msg->y(), msg->z(), msg->target_frame());
-
-        float goal_x = tf_pose_target.getOrigin().getX() + msg->x();
-        float goal_y =
-            tf_pose_target.getOrigin().getY() + msg->y() + cfg_y_max_ / 2.;
-        float goal_z = tf_pose_target.getOrigin().getZ() + msg->z();
-        logger->log_info(name(), "Transformed: %f,%f,%f in frame %s", goal_x,
-                         goal_y, goal_z, cfg_gripper_frame_id_.c_str());
-
-        bool msg_has_data = false;
-        int d = 0;
-        if (goal_x >= 0. && goal_x <= arduino_if_->x_max()) {
-          int new_abs_x =
-              round_to_2nd_dec(goal_x * X_AXIS_STEPS_PER_MM * 1000.0);
-          logger->log_debug(name(), "Set new X: %u", new_abs_x);
-          add_command_to_message(arduino_msg,
-                                 ArduinoComMessage::command_id_t::CMD_X_NEW_POS,
-                                 new_abs_x);
-
-          // calculate millseconds needed for this movement
-          d = new_abs_x - gripper_pose_[X];
-          arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
-          msg_has_data = true;
-        } else {
-          logger->log_error(name(), "Motion exceeds X dimension: %f", goal_x);
-          arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_X);
-          arduino_if_->write();
-        }
-
-        if (goal_y >= 0. && goal_y <= arduino_if_->y_max()) {
-          int new_abs_y =
-              round_to_2nd_dec(goal_y * Y_AXIS_STEPS_PER_MM * 1000.0);
-          logger->log_debug(name(), "Set new Y: %u", new_abs_y);
-          add_command_to_message(arduino_msg,
-                                 ArduinoComMessage::command_id_t::CMD_Y_NEW_POS,
-                                 new_abs_y);
-
-          // calculate millseconds needed for this movement
-          d = new_abs_y - gripper_pose_[Y];
-          arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
-          msg_has_data = true;
-        } else {
-          logger->log_error(name(), "Motion exceeds Y dimension: %f", goal_y);
-          arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_Y);
-          arduino_if_->write();
-        }
-        if (goal_z >= 0. && goal_z <= arduino_if_->z_max()) {
-          int new_abs_z =
-              round_to_2nd_dec(goal_z * Z_AXIS_STEPS_PER_MM * 1000.0);
-          logger->log_debug(name(), "Set new Z: %u", new_abs_z);
-          add_command_to_message(arduino_msg,
-                                 ArduinoComMessage::command_id_t::CMD_Z_NEW_POS,
-                                 new_abs_z);
-
-          // calculate millseconds needed for this movement
-          d = new_abs_z - gripper_pose_[Z];
-          arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
-          msg_has_data = true;
-        } else {
-          logger->log_error(name(), "Motion exceeds Z dimension: %f", goal_z);
-          arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_Z);
-          arduino_if_->write();
-        }
-
-        if (msg_has_data == true) {
-          append_message_to_queue(arduino_msg);
-        } else {
-          delete arduino_msg;
-        }
-
-      } else if (arduino_if_
-                     ->msgq_first_is<ArduinoInterface::MoveXYZRelMessage>()) {
-        ArduinoInterface::MoveXYZRelMessage *msg = arduino_if_->msgq_first(msg);
-        ArduinoComMessage *arduino_msg = new ArduinoComMessage();
-
-        bool msg_has_data = false;
-
-        float cur_x = gripper_pose_[X] / X_AXIS_STEPS_PER_MM / 1000.;
-        float cur_y = gripper_pose_[Y] / Y_AXIS_STEPS_PER_MM / 1000.;
-        float cur_z = gripper_pose_[Z] / Z_AXIS_STEPS_PER_MM / 1000.;
-        logger->log_debug(name(), "Move rel: %f %f %f cur pose: %f %f %f",
-                          msg->x(), msg->y(), msg->z(), cur_x, cur_y, cur_z);
-        if (msg->x() + cur_x >= 0. && msg->x() + cur_x <= arduino_if_->x_max()) {
-          int new_abs_x = round_to_2nd_dec((msg->x() + cur_x) *
-                                           X_AXIS_STEPS_PER_MM * 1000.0);
-          logger->log_debug(name(), "Set new X: %u", new_abs_x);
-          add_command_to_message(arduino_msg,
-                                 ArduinoComMessage::command_id_t::CMD_X_NEW_POS,
-                                 new_abs_x);
-
-          // calculate millseconds needed for this movement
-          int d = new_abs_x - gripper_pose_[X];
-          arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
-          msg_has_data = true;
-        } else {
-          logger->log_error(name(), "Motion exceeds X dimension: %f",
-                            msg->x() + cur_x);
-          arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_X);
-          arduino_if_->write();
-        }
-
-        if (msg->y() + cur_y >= 0. && msg->y() + cur_y <= arduino_if_->y_max()) {
-          int new_abs_y = round_to_2nd_dec((msg->y() + cur_y) *
-                                           Y_AXIS_STEPS_PER_MM * 1000.0);
-          logger->log_debug(name(), "Set new Y: %u", new_abs_y);
-          add_command_to_message(arduino_msg,
-                                 ArduinoComMessage::command_id_t::CMD_Y_NEW_POS,
-                                 new_abs_y);
-
-          // calculate millseconds needed for this movement
-          int d = new_abs_y - gripper_pose_[Y];
-          arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
-          msg_has_data = true;
-        } else {
-          logger->log_error(name(), "Motion exceeds Y dimension: %f",
-                            msg->y() + cur_y);
-          arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_Y);
-          arduino_if_->write();
-        }
-        if (msg->z() + cur_z >= 0. && msg->z() + cur_z <= arduino_if_->z_max()) {
-          int new_abs_z = round_to_2nd_dec((msg->z() + cur_z) *
-                                           Z_AXIS_STEPS_PER_MM * 1000.0);
-          logger->log_debug(name(), "Set new Z: %u", new_abs_z);
-          add_command_to_message(arduino_msg,
-                                 ArduinoComMessage::command_id_t::CMD_Z_NEW_POS,
-                                 new_abs_z);
-
-          // calculate millseconds needed for this movement
-          int d = new_abs_z - gripper_pose_[Z];
-          arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
-          msg_has_data = true;
-        } else {
-          logger->log_error(name(), "Motion exceeds Z dimension: %f",
-                            msg->z() + cur_z);
-          arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_Z);
-          arduino_if_->write();
-        }
-
-        if (msg_has_data == true) {
-          append_message_to_queue(arduino_msg);
-        } else {
-          delete arduino_msg;
-        }
-      } else if (arduino_if_->msgq_first_is<
-                     ArduinoInterface::MoveGripperRelMessage>()) {
-        // TODO
-      } else if (arduino_if_
-                     ->msgq_first_is<ArduinoInterface::ToHomeMessage>()) {
-        home_pending_ = true;
-      } else if (arduino_if_
-                     ->msgq_first_is<ArduinoInterface::CalibrateMessage>()) {
-        calibrated_ = false;
-        // TODO
-      } else if (arduino_if_
-                     ->msgq_first_is<ArduinoInterface::CloseGripperMessage>()) {
-        ArduinoInterface::CloseGripperMessage *msg =
-            arduino_if_->msgq_first(msg);
-        logger->log_debug(name(), "Close Gripper");
-        append_message_to_queue(ArduinoComMessage::command_id_t::CMD_CLOSE, 0,
-                                10000);
-      } else if (arduino_if_
-                     ->msgq_first_is<ArduinoInterface::OpenGripperMessage>()) {
-        ArduinoInterface::OpenGripperMessage *msg =
-            arduino_if_->msgq_first(msg);
-        logger->log_debug(name(), "Open Gripper");
-        append_message_to_queue(ArduinoComMessage::command_id_t::CMD_OPEN, 0,
-                                10000);
-      } else if (arduino_if_->msgq_first_is<
-                     ArduinoInterface::StatusUpdateMessage>()) {
-        ArduinoInterface::StatusUpdateMessage *msg =
-            arduino_if_->msgq_first(msg);
-        logger->log_debug(name(), "Request Status");
-        append_message_to_queue(ArduinoComMessage::command_id_t::CMD_STATUS_REQ,
-                                0, 10000);
-      }
-
-      arduino_if_->msgq_pop();
-    }
-
-    //        joystick_if_->read();
-
-    if (calibrated_ == true) {
-
-      if (home_pending_ == true) {
-        logger->log_info(name(), "home pending");
-        ArduinoComMessage *arduino_msg = new ArduinoComMessage();
-
-        int new_abs_x = 0;
-        int new_abs_y = round_to_2nd_dec(arduino_if_->y_max() *
-                                         Y_AXIS_STEPS_PER_MM * 1000. / 2.);
-        int new_abs_z = 0;
-        add_command_to_message(arduino_msg,
-                               ArduinoComMessage::command_id_t::CMD_X_NEW_POS,
-                               new_abs_x);
-        add_command_to_message(arduino_msg,
-                               ArduinoComMessage::command_id_t::CMD_Y_NEW_POS,
-                               new_abs_y);
-        add_command_to_message(arduino_msg,
-                               ArduinoComMessage::command_id_t::CMD_Z_NEW_POS,
-                               new_abs_z);
-
-        // simply wait for 10 seconds for a timeout.
-        arduino_msg->set_msecs_if_lower(50000);
-        append_message_to_queue(arduino_msg);
-        home_pending_ = false;
-      }
-
-      tf_thread_->set_position(gripper_pose_[X] / X_AXIS_STEPS_PER_MM / 1000.,
-                               gripper_pose_[Y] / Y_AXIS_STEPS_PER_MM / 1000.,
-                               gripper_pose_[Z] / Z_AXIS_STEPS_PER_MM / 1000.);
-
-    } else {
-      logger->log_warn(name(), "Calibrate pending");
-      append_message_to_queue(ArduinoComMessage::command_id_t::CMD_CALIBRATE, 0,
-                              50000);
-    }
-
-  } else {
-    try {
-      open_device();
-      opened_ = true;
-      logger->log_info(name(), "Connection re-established after %u tries",
-                       open_tries_ + 1);
-    } catch (Exception &e) {
-      open_tries_ += 1;
-      if (open_tries_ >= 1000) {
-        logger->log_error(name(), "Connection problem to arduino. Tried 1000 "
-                                  "reconnects - retrying...");
-        open_tries_ = 0;
-      }
-    }
-  }
-
-  while (messages_.size() > 0) {
-    arduino_if_->set_final(false);
-    arduino_if_->set_status(ArduinoInterface::MOVING);
-    arduino_if_->write();
-
-    send_one_message();
-
-    movement_pending_ = current_arduino_status_ != 'I';
-
-    if (movement_pending_ == false) {
-      // Update gripper pose in iface
-
-      arduino_if_->set_status(ArduinoInterface::IDLE);
-      arduino_if_->write();
-
-      if (calibrated_ == false) {
-        arduino_if_->set_x_max(cfg_x_max_);
-        arduino_if_->set_y_max(cfg_y_max_);
-        arduino_if_->set_z_max(cfg_z_max_);
-        calibrated_ = true;
-        if (home_pending_ == true) {
-          wakeup();
-        }
-      }
-    }
-    arduino_if_->set_x_position(gripper_pose_[X] / X_AXIS_STEPS_PER_MM / 1000.);
-    arduino_if_->set_y_position(gripper_pose_[Y] / Y_AXIS_STEPS_PER_MM / 1000.);
-    arduino_if_->set_z_position(gripper_pose_[Z] / Z_AXIS_STEPS_PER_MM / 1000.);
-    arduino_if_->set_final(!movement_pending_);
-    arduino_if_->write();
-
-    tf_thread_->set_position(arduino_if_->x_position(),
-                             arduino_if_->y_position(),
-                             arduino_if_->z_position());
-  }
+bool
+ArduinoComThread::add_command_to_message(ArduinoComMessage *             msg,
+                                         ArduinoComMessage::command_id_t command,
+                                         unsigned int                    value)
+{
+	// TODO: Check if consistency for sending values is kept - is it always
+	// unsigned int?
+	if (!msg->add_command(command, value)) {
+		logger->log_error(name(),
+		                  "Faulty command! id: %c value: %u size: %u msg_len: %u, index: %u",
+		                  static_cast<char>(command),
+		                  value,
+		                  msg->get_data_size(),
+		                  ArduinoComMessage::num_digits(value) + 1,
+		                  msg->get_cur_buffer_index());
+		return false;
+	}
+	return true;
 }
 
-bool ArduinoComThread::is_connected() { return serial_.is_open(); }
+void
+ArduinoComThread::loop()
+{
+	if (opened_) {
+		arduino_if_->read();
 
-void ArduinoComThread::open_device() {
-  if (!opened_) {
-    logger->log_debug(name(), "Open device");
-    try {
-      input_buffer_.consume(input_buffer_.size());
+		while (!arduino_if_->msgq_empty() && arduino_if_->is_final() && calibrated_) {
+			if (arduino_if_->msgq_first_is<ArduinoInterface::MoveXYZAbsMessage>()) {
+				ArduinoInterface::MoveXYZAbsMessage *msg = arduino_if_->msgq_first(msg);
 
-      boost::mutex::scoped_lock lock(io_mutex_);
+				ArduinoComMessage *arduino_msg = new ArduinoComMessage();
 
-      serial_.open(cfg_device_);
+				fawkes::tf::StampedTransform tf_pose_target;
 
-      boost::asio::serial_port::parity PARITY(
-          boost::asio::serial_port::parity::none);
-      boost::asio::serial_port::baud_rate BAUD(115200);
-      boost::asio::serial_port::character_size thecsize(
-          boost::asio::serial_port::character_size(8U));
-      boost::asio::serial_port::stop_bits STOP(
-          boost::asio::serial_port::stop_bits::one);
+				try {
+					tf_listener->lookup_transform(cfg_gripper_frame_id_, msg->target_frame(), tf_pose_target);
+				} catch (fawkes::tf::ExtrapolationException &e) {
+					logger->log_error(name(), "Extrapolation error");
+					break;
+				} catch (fawkes::tf::ConnectivityException &e) {
+					logger->log_error(name(), "Connectivity exception: %s", e.what());
+					break;
+				} catch (fawkes::IllegalArgumentException &e) {
+					logger->log_error(name(),
+					                  "IllegalArgumentException exception - did you set "
+					                  "the frame_id?: %s",
+					                  e.what());
+					break;
+				} catch (fawkes::Exception &e) {
+					logger->log_error(name(), "Other exception: %s", e.what());
+					break;
+				}
+				logger->log_info(name(),
+				                 "Target: %f,%f,%f in frame %s",
+				                 msg->x(),
+				                 msg->y(),
+				                 msg->z(),
+				                 msg->target_frame());
 
-      serial_.set_option(PARITY);
-      serial_.set_option(BAUD);
-      serial_.set_option(thecsize);
-      serial_.set_option(STOP);
+				float goal_x = tf_pose_target.getOrigin().getX() + msg->x();
+				float goal_y = tf_pose_target.getOrigin().getY() + msg->y() + cfg_y_max_ / 2.;
+				float goal_z = tf_pose_target.getOrigin().getZ() + msg->z();
+				logger->log_info(name(),
+				                 "Transformed: %f,%f,%f in frame %s",
+				                 goal_x,
+				                 goal_y,
+				                 goal_z,
+				                 cfg_gripper_frame_id_.c_str());
 
-      {
-        struct termios param;
-        if (tcgetattr(serial_.native_handle(), &param) == 0) {
-          // set blocking mode, seemingly needed to make Asio work properly
-          param.c_cc[VMIN] = 1;
-          param.c_cc[VTIME] = 0;
-          if (tcsetattr(serial_.native_handle(), TCSANOW, &param) != 0) {
-            // another reason to fail...
-          }
-        } // else: BANG, cannot set VMIN/VTIME, fail
-      }
+				bool msg_has_data = false;
+				int  d            = 0;
+				if (goal_x >= 0. && goal_x <= arduino_if_->x_max()) {
+					int new_abs_x = round_to_2nd_dec(goal_x * X_AXIS_STEPS_PER_MM * 1000.0);
+					logger->log_debug(name(), "Set new X: %u", new_abs_x);
+					add_command_to_message(arduino_msg,
+					                       ArduinoComMessage::command_id_t::CMD_X_NEW_POS,
+					                       new_abs_x);
 
-      opened_ = sync_with_arduino();
+					// calculate millseconds needed for this movement
+					d = new_abs_x - gripper_pose_[X];
+					arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
+					msg_has_data = true;
+				} else {
+					logger->log_error(name(), "Motion exceeds X dimension: %f", goal_x);
+					arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_X);
+					arduino_if_->write();
+				}
 
-    } catch (boost::system::system_error &e) {
-      throw Exception("Arduino failed I/O: %s", e.what());
-    }
-  }
+				if (goal_y >= 0. && goal_y <= arduino_if_->y_max()) {
+					int new_abs_y = round_to_2nd_dec(goal_y * Y_AXIS_STEPS_PER_MM * 1000.0);
+					logger->log_debug(name(), "Set new Y: %u", new_abs_y);
+					add_command_to_message(arduino_msg,
+					                       ArduinoComMessage::command_id_t::CMD_Y_NEW_POS,
+					                       new_abs_y);
+
+					// calculate millseconds needed for this movement
+					d = new_abs_y - gripper_pose_[Y];
+					arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
+					msg_has_data = true;
+				} else {
+					logger->log_error(name(), "Motion exceeds Y dimension: %f", goal_y);
+					arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_Y);
+					arduino_if_->write();
+				}
+				if (goal_z >= 0. && goal_z <= arduino_if_->z_max()) {
+					int new_abs_z = round_to_2nd_dec(goal_z * Z_AXIS_STEPS_PER_MM * 1000.0);
+					logger->log_debug(name(), "Set new Z: %u", new_abs_z);
+					add_command_to_message(arduino_msg,
+					                       ArduinoComMessage::command_id_t::CMD_Z_NEW_POS,
+					                       new_abs_z);
+
+					// calculate millseconds needed for this movement
+					d = new_abs_z - gripper_pose_[Z];
+					arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
+					msg_has_data = true;
+				} else {
+					logger->log_error(name(), "Motion exceeds Z dimension: %f", goal_z);
+					arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_Z);
+					arduino_if_->write();
+				}
+
+				if (msg_has_data == true) {
+					append_message_to_queue(arduino_msg);
+				} else {
+					delete arduino_msg;
+				}
+
+			} else if (arduino_if_->msgq_first_is<ArduinoInterface::MoveXYZRelMessage>()) {
+				ArduinoInterface::MoveXYZRelMessage *msg         = arduino_if_->msgq_first(msg);
+				ArduinoComMessage *                  arduino_msg = new ArduinoComMessage();
+
+				bool msg_has_data = false;
+
+				float cur_x = gripper_pose_[X] / X_AXIS_STEPS_PER_MM / 1000.;
+				float cur_y = gripper_pose_[Y] / Y_AXIS_STEPS_PER_MM / 1000.;
+				float cur_z = gripper_pose_[Z] / Z_AXIS_STEPS_PER_MM / 1000.;
+				logger->log_debug(name(),
+				                  "Move rel: %f %f %f cur pose: %f %f %f",
+				                  msg->x(),
+				                  msg->y(),
+				                  msg->z(),
+				                  cur_x,
+				                  cur_y,
+				                  cur_z);
+				if (msg->x() + cur_x >= 0. && msg->x() + cur_x <= arduino_if_->x_max()) {
+					int new_abs_x = round_to_2nd_dec((msg->x() + cur_x) * X_AXIS_STEPS_PER_MM * 1000.0);
+					logger->log_debug(name(), "Set new X: %u", new_abs_x);
+					add_command_to_message(arduino_msg,
+					                       ArduinoComMessage::command_id_t::CMD_X_NEW_POS,
+					                       new_abs_x);
+
+					// calculate millseconds needed for this movement
+					int d = new_abs_x - gripper_pose_[X];
+					arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
+					msg_has_data = true;
+				} else {
+					logger->log_error(name(), "Motion exceeds X dimension: %f", msg->x() + cur_x);
+					arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_X);
+					arduino_if_->write();
+				}
+
+				if (msg->y() + cur_y >= 0. && msg->y() + cur_y <= arduino_if_->y_max()) {
+					int new_abs_y = round_to_2nd_dec((msg->y() + cur_y) * Y_AXIS_STEPS_PER_MM * 1000.0);
+					logger->log_debug(name(), "Set new Y: %u", new_abs_y);
+					add_command_to_message(arduino_msg,
+					                       ArduinoComMessage::command_id_t::CMD_Y_NEW_POS,
+					                       new_abs_y);
+
+					// calculate millseconds needed for this movement
+					int d = new_abs_y - gripper_pose_[Y];
+					arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
+					msg_has_data = true;
+				} else {
+					logger->log_error(name(), "Motion exceeds Y dimension: %f", msg->y() + cur_y);
+					arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_Y);
+					arduino_if_->write();
+				}
+				if (msg->z() + cur_z >= 0. && msg->z() + cur_z <= arduino_if_->z_max()) {
+					int new_abs_z = round_to_2nd_dec((msg->z() + cur_z) * Z_AXIS_STEPS_PER_MM * 1000.0);
+					logger->log_debug(name(), "Set new Z: %u", new_abs_z);
+					add_command_to_message(arduino_msg,
+					                       ArduinoComMessage::command_id_t::CMD_Z_NEW_POS,
+					                       new_abs_z);
+
+					// calculate millseconds needed for this movement
+					int d = new_abs_z - gripper_pose_[Z];
+					arduino_msg->set_msecs_if_lower(abs(d) * cfg_speed_);
+					msg_has_data = true;
+				} else {
+					logger->log_error(name(), "Motion exceeds Z dimension: %f", msg->z() + cur_z);
+					arduino_if_->set_status(ArduinoInterface::ERROR_OUT_OF_RANGE_Z);
+					arduino_if_->write();
+				}
+
+				if (msg_has_data == true) {
+					append_message_to_queue(arduino_msg);
+				} else {
+					delete arduino_msg;
+				}
+			} else if (arduino_if_->msgq_first_is<ArduinoInterface::MoveGripperRelMessage>()) {
+				// TODO
+			} else if (arduino_if_->msgq_first_is<ArduinoInterface::ToHomeMessage>()) {
+				home_pending_ = true;
+			} else if (arduino_if_->msgq_first_is<ArduinoInterface::CalibrateMessage>()) {
+				calibrated_ = false;
+				// TODO
+			} else if (arduino_if_->msgq_first_is<ArduinoInterface::CloseGripperMessage>()) {
+				ArduinoInterface::CloseGripperMessage *msg = arduino_if_->msgq_first(msg);
+				logger->log_debug(name(), "Close Gripper");
+				append_message_to_queue(ArduinoComMessage::command_id_t::CMD_CLOSE, 0, 10000);
+			} else if (arduino_if_->msgq_first_is<ArduinoInterface::OpenGripperMessage>()) {
+				ArduinoInterface::OpenGripperMessage *msg = arduino_if_->msgq_first(msg);
+				logger->log_debug(name(), "Open Gripper");
+				append_message_to_queue(ArduinoComMessage::command_id_t::CMD_OPEN, 0, 10000);
+			} else if (arduino_if_->msgq_first_is<ArduinoInterface::StatusUpdateMessage>()) {
+				ArduinoInterface::StatusUpdateMessage *msg = arduino_if_->msgq_first(msg);
+				logger->log_debug(name(), "Request Status");
+				append_message_to_queue(ArduinoComMessage::command_id_t::CMD_STATUS_REQ, 0, 10000);
+			}
+
+			arduino_if_->msgq_pop();
+		}
+
+		//        joystick_if_->read();
+
+		if (calibrated_ == true) {
+			if (home_pending_ == true) {
+				logger->log_info(name(), "home pending");
+				ArduinoComMessage *arduino_msg = new ArduinoComMessage();
+
+				int new_abs_x = 0;
+				int new_abs_y = round_to_2nd_dec(arduino_if_->y_max() * Y_AXIS_STEPS_PER_MM * 1000. / 2.);
+				int new_abs_z = 0;
+				add_command_to_message(arduino_msg,
+				                       ArduinoComMessage::command_id_t::CMD_X_NEW_POS,
+				                       new_abs_x);
+				add_command_to_message(arduino_msg,
+				                       ArduinoComMessage::command_id_t::CMD_Y_NEW_POS,
+				                       new_abs_y);
+				add_command_to_message(arduino_msg,
+				                       ArduinoComMessage::command_id_t::CMD_Z_NEW_POS,
+				                       new_abs_z);
+
+				// simply wait for 10 seconds for a timeout.
+				arduino_msg->set_msecs_if_lower(50000);
+				append_message_to_queue(arduino_msg);
+				home_pending_ = false;
+			}
+
+			tf_thread_->set_position(gripper_pose_[X] / X_AXIS_STEPS_PER_MM / 1000.,
+			                         gripper_pose_[Y] / Y_AXIS_STEPS_PER_MM / 1000.,
+			                         gripper_pose_[Z] / Z_AXIS_STEPS_PER_MM / 1000.);
+
+		} else {
+			logger->log_warn(name(), "Calibrate pending");
+			append_message_to_queue(ArduinoComMessage::command_id_t::CMD_CALIBRATE, 0, 50000);
+		}
+
+	} else {
+		try {
+			open_device();
+			opened_ = true;
+			logger->log_info(name(), "Connection re-established after %u tries", open_tries_ + 1);
+		} catch (Exception &e) {
+			open_tries_ += 1;
+			if (open_tries_ >= 1000) {
+				logger->log_error(name(),
+				                  "Connection problem to arduino. Tried 1000 "
+				                  "reconnects - retrying...");
+				open_tries_ = 0;
+			}
+		}
+	}
+
+	while (messages_.size() > 0) {
+		arduino_if_->set_final(false);
+		arduino_if_->set_status(ArduinoInterface::MOVING);
+		arduino_if_->write();
+
+		send_one_message();
+
+		movement_pending_ = current_arduino_status_ != 'I';
+
+		if (movement_pending_ == false) {
+			// Update gripper pose in iface
+
+			arduino_if_->set_status(ArduinoInterface::IDLE);
+			arduino_if_->write();
+
+			if (calibrated_ == false) {
+				arduino_if_->set_x_max(cfg_x_max_);
+				arduino_if_->set_y_max(cfg_y_max_);
+				arduino_if_->set_z_max(cfg_z_max_);
+				calibrated_ = true;
+				if (home_pending_ == true) {
+					wakeup();
+				}
+			}
+		}
+		arduino_if_->set_x_position(gripper_pose_[X] / X_AXIS_STEPS_PER_MM / 1000.);
+		arduino_if_->set_y_position(gripper_pose_[Y] / Y_AXIS_STEPS_PER_MM / 1000.);
+		arduino_if_->set_z_position(gripper_pose_[Z] / Z_AXIS_STEPS_PER_MM / 1000.);
+		arduino_if_->set_final(!movement_pending_);
+		arduino_if_->write();
+
+		tf_thread_->set_position(arduino_if_->x_position(),
+		                         arduino_if_->y_position(),
+		                         arduino_if_->z_position());
+	}
 }
 
-void ArduinoComThread::close_device() {
-  boost::mutex::scoped_lock lock(io_mutex_);
-  serial_.cancel();
-  serial_.close();
-  opened_ = false;
+bool
+ArduinoComThread::is_connected()
+{
+	return serial_.is_open();
 }
 
-void ArduinoComThread::flush_device() {
-  if (serial_.is_open()) {
-    try {
-      boost::system::error_code ec = boost::asio::error::would_block;
-      bytes_read_ = 0;
-      do {
-        ec = boost::asio::error::would_block;
-        bytes_read_ = 0;
+void
+ArduinoComThread::open_device()
+{
+	if (!opened_) {
+		logger->log_debug(name(), "Open device");
+		try {
+			input_buffer_.consume(input_buffer_.size());
 
-        deadline_.expires_from_now(boost::posix_time::milliseconds(200));
-        boost::asio::async_read(
-            serial_, input_buffer_, boost::asio::transfer_at_least(1),
-            (boost::lambda::var(ec) = boost::lambda::_1,
-             boost::lambda::var(bytes_read_) = boost::lambda::_2));
+			boost::mutex::scoped_lock lock(io_mutex_);
 
-        do
-          io_service_.run_one();
-        while (ec == boost::asio::error::would_block);
+			serial_.open(cfg_device_);
 
-        if (bytes_read_ > 0) {
-          logger->log_warn(name(), "Flushing %zu bytes\n", bytes_read_);
-        }
+			boost::asio::serial_port::parity         PARITY(boost::asio::serial_port::parity::none);
+			boost::asio::serial_port::baud_rate      BAUD(115200);
+			boost::asio::serial_port::character_size thecsize(
+			  boost::asio::serial_port::character_size(8U));
+			boost::asio::serial_port::stop_bits STOP(boost::asio::serial_port::stop_bits::one);
 
-      } while (bytes_read_ > 0);
-      deadline_.expires_from_now(boost::posix_time::pos_infin);
-    } catch (boost::system::system_error &e) {
-      // ignore, just assume done, if there really is an error we'll
-      // catch it later on
-    }
-  }
+			serial_.set_option(PARITY);
+			serial_.set_option(BAUD);
+			serial_.set_option(thecsize);
+			serial_.set_option(STOP);
+
+			{
+				struct termios param;
+				if (tcgetattr(serial_.native_handle(), &param) == 0) {
+					// set blocking mode, seemingly needed to make Asio work properly
+					param.c_cc[VMIN]  = 1;
+					param.c_cc[VTIME] = 0;
+					if (tcsetattr(serial_.native_handle(), TCSANOW, &param) != 0) {
+						// another reason to fail...
+					}
+				} // else: BANG, cannot set VMIN/VTIME, fail
+			}
+
+			opened_ = sync_with_arduino();
+
+		} catch (boost::system::system_error &e) {
+			throw Exception("Arduino failed I/O: %s", e.what());
+		}
+	}
 }
 
-void ArduinoComThread::send_message(ArduinoComMessage &msg) {
-  try {
-    boost::asio::write(serial_, boost::asio::const_buffers_1(msg.buffer()));
-  } catch (boost::system::system_error &e) {
-    logger->log_error(name(), "ERROR on send message! %s", e.what());
-  }
+void
+ArduinoComThread::close_device()
+{
+	boost::mutex::scoped_lock lock(io_mutex_);
+	serial_.cancel();
+	serial_.close();
+	opened_ = false;
 }
 
-bool ArduinoComThread::sync_with_arduino() {
-  std::string s;
-  std::size_t found;
-  fawkes::Time start_time;
-  fawkes::Time now;
+void
+ArduinoComThread::flush_device()
+{
+	if (serial_.is_open()) {
+		try {
+			boost::system::error_code ec = boost::asio::error::would_block;
+			bytes_read_                  = 0;
+			do {
+				ec          = boost::asio::error::would_block;
+				bytes_read_ = 0;
 
-  logger->log_debug(name(), "sync with arduino");
-  do {
-    s = read_packet(6000);
-    logger->log_debug(name(), "Read '%s'", s.c_str());
-    found = s.find("AT HELLO");
-    now = fawkes::Time();
-  } while (found == std::string::npos && (now - start_time < 3.));
+				deadline_.expires_from_now(boost::posix_time::milliseconds(200));
+				boost::asio::async_read(serial_,
+				                        input_buffer_,
+				                        boost::asio::transfer_at_least(1),
+				                        (boost::lambda::var(ec)          = boost::lambda::_1,
+				                         boost::lambda::var(bytes_read_) = boost::lambda::_2));
 
-  if (now - start_time >= 3.) {
-    logger->log_error(name(), "Timeout reached trying to sync with arduino");
-    return false;
-  }
-  if (found == std::string::npos) {
-    logger->log_error(
-        name(),
-        "Synchronization with Arduino failed, HELLO-Package not located");
-    return false;
-  } else {
-    logger->log_info(name(), "Synchronization with Arduino successful");
-    return true;
-  }
+				do
+					io_service_.run_one();
+				while (ec == boost::asio::error::would_block);
+
+				if (bytes_read_ > 0) {
+					logger->log_warn(name(), "Flushing %zu bytes\n", bytes_read_);
+				}
+
+			} while (bytes_read_ > 0);
+			deadline_.expires_from_now(boost::posix_time::pos_infin);
+		} catch (boost::system::system_error &e) {
+			// ignore, just assume done, if there really is an error we'll
+			// catch it later on
+		}
+	}
 }
 
-bool ArduinoComThread::send_one_message() {
-  boost::mutex::scoped_lock lock(io_mutex_);
-  if (messages_.size() > 0) {
-    ArduinoComMessage *cur_msg = messages_.front();
-    messages_.pop();
-    msecs_to_wait_ = cur_msg->get_msecs();
-    send_message(*cur_msg);
-
-    delete cur_msg;
-
-    std::string s = read_packet(1000); // read receipt
-    logger->log_debug(name(), "Read receipt: %s", s.c_str());
-    s = read_packet(msecs_to_wait_); // read
-    logger->log_debug(name(), "Read status: %s", s.c_str());
-
-    return true;
-  } else {
-    return false;
-  }
+void
+ArduinoComThread::send_message(ArduinoComMessage &msg)
+{
+	try {
+		boost::asio::write(serial_, boost::asio::const_buffers_1(msg.buffer()));
+	} catch (boost::system::system_error &e) {
+		logger->log_error(name(), "ERROR on send message! %s", e.what());
+	}
 }
 
-void ArduinoComThread::handle_nodata(const boost::system::error_code &ec) {
-  // ec may be set if the timer is cancelled, i.e., updated
-  if (!ec) {
-    serial_.cancel();
-    logger->log_error(
-        name(), "No data received for too long, re-establishing connection");
-    //        printf("No data received for too long, re-establishing
-    //        connection\n");
-    logger->log_debug(name(), "BufSize: %zu\n", input_buffer_.size());
-    std::string s(boost::asio::buffer_cast<const char *>(input_buffer_.data()),
-                  input_buffer_.size());
-    logger->log_debug(name(), "Received: %zu  %s\n", s.size(), s.c_str());
+bool
+ArduinoComThread::sync_with_arduino()
+{
+	std::string  s;
+	std::size_t  found;
+	fawkes::Time start_time;
+	fawkes::Time now;
 
-    io_mutex_.unlock();
+	logger->log_debug(name(), "sync with arduino");
+	do {
+		s = read_packet(6000);
+		logger->log_debug(name(), "Read '%s'", s.c_str());
+		found = s.find("AT HELLO");
+		now   = fawkes::Time();
+	} while (found == std::string::npos && (now - start_time < 3.));
 
-    close_device();
-    sleep(1);
-    open_device();
-  }
+	if (now - start_time >= 3.) {
+		logger->log_error(name(), "Timeout reached trying to sync with arduino");
+		return false;
+	}
+	if (found == std::string::npos) {
+		logger->log_error(name(), "Synchronization with Arduino failed, HELLO-Package not located");
+		return false;
+	} else {
+		logger->log_info(name(), "Synchronization with Arduino successful");
+		return true;
+	}
 }
 
-std::string ArduinoComThread::read_packet(unsigned int timeout) {
+bool
+ArduinoComThread::send_one_message()
+{
+	boost::mutex::scoped_lock lock(io_mutex_);
+	if (messages_.size() > 0) {
+		ArduinoComMessage *cur_msg = messages_.front();
+		messages_.pop();
+		msecs_to_wait_ = cur_msg->get_msecs();
+		send_message(*cur_msg);
 
-  boost::system::error_code ec = boost::asio::error::would_block;
-  bytes_read_ = 0;
+		delete cur_msg;
 
-  logger->log_debug(name(), "read_packet with timeout: %u", timeout);
+		std::string s = read_packet(1000); // read receipt
+		logger->log_debug(name(), "Read receipt: %s", s.c_str());
+		s = read_packet(msecs_to_wait_); // read
+		logger->log_debug(name(), "Read status: %s", s.c_str());
 
-  deadline_.expires_from_now(boost::posix_time::milliseconds(timeout));
-  deadline_.async_wait(boost::bind(&ArduinoComThread::handle_nodata, this,
-                                   boost::asio::placeholders::error));
-
-  boost::asio::async_read_until(
-      serial_, input_buffer_, "\r\n",
-      (boost::lambda::var(ec) = boost::lambda::_1,
-       boost::lambda::var(bytes_read_) = boost::lambda::_2));
-
-  //    do io_service_.run_one(); while (ec == boost::asio::error::would_block);
-
-  do {
-    io_service_.run_one();
-    if (ec == boost::asio::error::would_block) {
-      usleep(10000);
-    }
-  } while (ec == boost::asio::error::would_block);
-
-  if (ec) {
-    if (ec.value() == boost::system::errc::operation_canceled) {
-      logger->log_error(name(), "Arduino read operation cancelled: %s",
-                        ec.message().c_str());
-    }
-  }
-
-  // Package received - analyze package
-  std::string s(boost::asio::buffer_cast<const char *>(input_buffer_.data()),
-                bytes_read_);
-  input_buffer_.consume(bytes_read_);
-  deadline_.cancel();
-
-  if (s.find("AT ") == std::string::npos) {
-    logger->log_error(name(), "Package error - bytes read: %zu, %s",
-                      bytes_read_, s.c_str());
-    // TODO: after re-opening the device it fails to be used again - fix this!
-    return "";
-  }
-  if (bytes_read_ > 4) {
-    logger->log_debug(name(), "Package received: %s:", s.c_str());
-    //        if (s.find("AT OK") == std::string::npos) {
-    // Package is no receipt for the previous sent package
-    current_arduino_status_ = s.at(3);
-    //        }
-  }
-  if (current_arduino_status_ == 'E') {
-    logger->log_error(name(), "Arduino error: %s", s.substr(4).c_str());
-  } else if (current_arduino_status_ == 'I') {
-    // TODO: setup absolute pose reporting!
-
-    std::stringstream ss(s.substr(4));
-    std::string gripper_status;
-    ss >> gripper_pose_[X] >> gripper_pose_[Y] >> gripper_pose_[Z] >>
-        gripper_pose_[A] >> gripper_status;
-    if (gripper_status == "CLOSED") {
-      arduino_if_->set_gripper_closed(true);
-      arduino_if_->write();
-    } else if (gripper_status == "OPEN") {
-      arduino_if_->set_gripper_closed(false);
-      arduino_if_->write();
-    }
-  } else {
-    // Probably something went wrong with communication
-    current_arduino_status_ = 'E';
-  }
-  //    read_pending_ = false;
-  return s;
+		return true;
+	} else {
+		return false;
+	}
 }
 
-void ArduinoComThread::load_config() {
-  // TODO: allow setting of stepper velocity from config!
-  try {
-    logger->log_info(name(), "load_config");
-    cfg_device_ = config->get_string(cfg_prefix_ + "/device");
-    cfg_speed_ = config->get_int(cfg_prefix_ + "/speed");
-    cfg_accel_ = config->get_int(cfg_prefix_ + "/accel");
-    cfg_ifid_joystick_ =
-        config->get_string(cfg_prefix_ + "/joystick_interface_id");
-    cfg_gripper_frame_id_ =
-        config->get_string(cfg_prefix_ + "/gripper_frame_id");
+void
+ArduinoComThread::handle_nodata(const boost::system::error_code &ec)
+{
+	// ec may be set if the timer is cancelled, i.e., updated
+	if (!ec) {
+		serial_.cancel();
+		logger->log_error(name(), "No data received for too long, re-establishing connection");
+		//        printf("No data received for too long, re-establishing
+		//        connection\n");
+		logger->log_debug(name(), "BufSize: %zu\n", input_buffer_.size());
+		std::string s(boost::asio::buffer_cast<const char *>(input_buffer_.data()),
+		              input_buffer_.size());
+		logger->log_debug(name(), "Received: %zu  %s\n", s.size(), s.c_str());
 
-    cfg_x_max_ = config->get_float(cfg_prefix_ + "/x_max");
-    cfg_y_max_ = config->get_float(cfg_prefix_ + "/y_max");
-    cfg_z_max_ = config->get_float(cfg_prefix_ + "/z_max");
+		io_mutex_.unlock();
 
-    set_speed_pending_ = false;
-    set_acceleration_pending_ = false;
-
-    // 2mm / rotation
-  } catch (Exception &e) {
-  }
+		close_device();
+		sleep(1);
+		open_device();
+	}
 }
 
-bool ArduinoComThread::bb_interface_message_received(Interface *interface,
-                                                     Message *message) throw() {
-  wakeup();
-  return true;
+std::string
+ArduinoComThread::read_packet(unsigned int timeout)
+{
+	boost::system::error_code ec = boost::asio::error::would_block;
+	bytes_read_                  = 0;
+
+	logger->log_debug(name(), "read_packet with timeout: %u", timeout);
+
+	deadline_.expires_from_now(boost::posix_time::milliseconds(timeout));
+	deadline_.async_wait(
+	  boost::bind(&ArduinoComThread::handle_nodata, this, boost::asio::placeholders::error));
+
+	boost::asio::async_read_until(serial_,
+	                              input_buffer_,
+	                              "\r\n",
+	                              (boost::lambda::var(ec)          = boost::lambda::_1,
+	                               boost::lambda::var(bytes_read_) = boost::lambda::_2));
+
+	//    do io_service_.run_one(); while (ec == boost::asio::error::would_block);
+
+	do {
+		io_service_.run_one();
+		if (ec == boost::asio::error::would_block) {
+			usleep(10000);
+		}
+	} while (ec == boost::asio::error::would_block);
+
+	if (ec) {
+		if (ec.value() == boost::system::errc::operation_canceled) {
+			logger->log_error(name(), "Arduino read operation cancelled: %s", ec.message().c_str());
+		}
+	}
+
+	// Package received - analyze package
+	std::string s(boost::asio::buffer_cast<const char *>(input_buffer_.data()), bytes_read_);
+	input_buffer_.consume(bytes_read_);
+	deadline_.cancel();
+
+	if (s.find("AT ") == std::string::npos) {
+		logger->log_error(name(), "Package error - bytes read: %zu, %s", bytes_read_, s.c_str());
+		// TODO: after re-opening the device it fails to be used again - fix this!
+		return "";
+	}
+	if (bytes_read_ > 4) {
+		logger->log_debug(name(), "Package received: %s:", s.c_str());
+		//        if (s.find("AT OK") == std::string::npos) {
+		// Package is no receipt for the previous sent package
+		current_arduino_status_ = s.at(3);
+		//        }
+	}
+	if (current_arduino_status_ == 'E') {
+		logger->log_error(name(), "Arduino error: %s", s.substr(4).c_str());
+	} else if (current_arduino_status_ == 'I') {
+		// TODO: setup absolute pose reporting!
+
+		std::stringstream ss(s.substr(4));
+		std::string       gripper_status;
+		ss >> gripper_pose_[X] >> gripper_pose_[Y] >> gripper_pose_[Z] >> gripper_pose_[A]
+		  >> gripper_status;
+		if (gripper_status == "CLOSED") {
+			arduino_if_->set_gripper_closed(true);
+			arduino_if_->write();
+		} else if (gripper_status == "OPEN") {
+			arduino_if_->set_gripper_closed(false);
+			arduino_if_->write();
+		}
+	} else {
+		// Probably something went wrong with communication
+		current_arduino_status_ = 'E';
+	}
+	//    read_pending_ = false;
+	return s;
 }
 
-float inline ArduinoComThread::round_to_2nd_dec(float f) {
-  return round(f * 100.) / 100.;
+void
+ArduinoComThread::load_config()
+{
+	// TODO: allow setting of stepper velocity from config!
+	try {
+		logger->log_info(name(), "load_config");
+		cfg_device_           = config->get_string(cfg_prefix_ + "/device");
+		cfg_speed_            = config->get_int(cfg_prefix_ + "/speed");
+		cfg_accel_            = config->get_int(cfg_prefix_ + "/accel");
+		cfg_ifid_joystick_    = config->get_string(cfg_prefix_ + "/joystick_interface_id");
+		cfg_gripper_frame_id_ = config->get_string(cfg_prefix_ + "/gripper_frame_id");
+
+		cfg_x_max_ = config->get_float(cfg_prefix_ + "/x_max");
+		cfg_y_max_ = config->get_float(cfg_prefix_ + "/y_max");
+		cfg_z_max_ = config->get_float(cfg_prefix_ + "/z_max");
+
+		set_speed_pending_        = false;
+		set_acceleration_pending_ = false;
+
+		// 2mm / rotation
+	} catch (Exception &e) {
+	}
+}
+
+bool
+ArduinoComThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+{
+	wakeup();
+	return true;
+}
+
+float inline ArduinoComThread::round_to_2nd_dec(float f)
+{
+	return round(f * 100.) / 100.;
 }

--- a/src/plugins/arduino/com_thread.h
+++ b/src/plugins/arduino/com_thread.h
@@ -24,6 +24,7 @@
 
 #include "com_message.h"
 #include "tf_thread.h"
+
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/clock.h>
@@ -33,7 +34,6 @@
 #include <blackboard/interface_listener.h>
 #include <core/threading/thread.h>
 #include <interfaces/JoystickInterface.h>
-
 #include <tf/types.h>
 #include <utils/time/time.h>
 
@@ -67,115 +67,115 @@ class ArduinoComThread : public fawkes::Thread,
                          public fawkes::ClockAspect,
                          public fawkes::BlackBoardAspect,
                          public fawkes::BlackBoardInterfaceListener,
-                         public fawkes::TransformAspect {
+                         public fawkes::TransformAspect
+{
 public:
-  ArduinoComThread();
-  /**
+	ArduinoComThread();
+	/**
    * @brief Constructor for the arduino communication thread
    *
    * @param cfg_name Name of the config file
    * @param cfg_prefix Prefix tags to arduino config
    * @param tf_thread Pointer to transform thread
    */
-  ArduinoComThread(std::string &cfg_name, std::string &cfg_prefix,
-                   ArduinoTFThread *tf_thread);
-  virtual ~ArduinoComThread();
+	ArduinoComThread(std::string &cfg_name, std::string &cfg_prefix, ArduinoTFThread *tf_thread);
+	virtual ~ArduinoComThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  /**
+	/**
    * @brief Checks if the serial connection is open
    *
    * @return True if the serial connection is open
    */
-  virtual bool is_connected();
+	virtual bool is_connected();
 
-  // For BlackBoardInterfaceListener
-  virtual bool bb_interface_message_received(fawkes::Interface *interface,
-                                             fawkes::Message *message) throw();
+	// For BlackBoardInterfaceListener
+	virtual bool bb_interface_message_received(fawkes::Interface *interface,
+	                                           fawkes::Message *  message) throw();
 
-  /**
+	/**
    * @brief All variables that define the position of the gripper
    * X,Y,Z position of the axis
    * A position of the motor, that controls the gripper
    */
-  typedef enum { X, Y, Z, A } gripper_pose_t;
+	typedef enum { X, Y, Z, A } gripper_pose_t;
 
 private:
-  void open_device();
-  void close_device();
-  void flush_device();
+	void open_device();
+	void close_device();
+	void flush_device();
 
-  bool sync_with_arduino();
-  std::string read_packet(unsigned int timeout);
-  void send_message(ArduinoComMessage &msg);
+	bool        sync_with_arduino();
+	std::string read_packet(unsigned int timeout);
+	void        send_message(ArduinoComMessage &msg);
 
-  void handle_nodata(const boost::system::error_code &ec);
-  bool send_one_message();
+	void handle_nodata(const boost::system::error_code &ec);
+	bool send_one_message();
 
-  std::string cfg_device_;
-  unsigned int cfg_speed_;
-  unsigned int cfg_accel_;
-  std::string cfg_prefix_;
-  std::string cfg_name_;
-  std::string cfg_ifid_joystick_;
-  std::string cfg_gripper_frame_id_;
-  std::string cfg_gripper_dyn_x_frame_id_;
-  std::string cfg_gripper_dyn_y_frame_id_;
-  std::string cfg_gripper_dyn_z_frame_id_;
-  float cfg_x_max_;
-  float cfg_y_max_;
-  float cfg_z_max_;
-  bool movement_pending_;
-  bool calibrated_;
-  char current_arduino_status_;
+	std::string  cfg_device_;
+	unsigned int cfg_speed_;
+	unsigned int cfg_accel_;
+	std::string  cfg_prefix_;
+	std::string  cfg_name_;
+	std::string  cfg_ifid_joystick_;
+	std::string  cfg_gripper_frame_id_;
+	std::string  cfg_gripper_dyn_x_frame_id_;
+	std::string  cfg_gripper_dyn_y_frame_id_;
+	std::string  cfg_gripper_dyn_z_frame_id_;
+	float        cfg_x_max_;
+	float        cfg_y_max_;
+	float        cfg_z_max_;
+	bool         movement_pending_;
+	bool         calibrated_;
+	char         current_arduino_status_;
 
-  unsigned int msecs_to_wait_;
+	unsigned int msecs_to_wait_;
 
-  // gripper pose to be stored in X, Y, Z
-  // TODO: setup proper values!
-  int gripper_pose_[3] = {100000, 100000, 100000};
+	// gripper pose to be stored in X, Y, Z
+	// TODO: setup proper values!
+	int gripper_pose_[3] = {100000, 100000, 100000};
 
-  size_t bytes_read_;
-  bool read_pending_;
-  bool set_speed_pending_;
-  bool set_acceleration_pending_;
-  bool home_pending_;
+	size_t bytes_read_;
+	bool   read_pending_;
+	bool   set_speed_pending_;
+	bool   set_acceleration_pending_;
+	bool   home_pending_;
 
-  bool opened_;
-  unsigned int open_tries_;
+	bool         opened_;
+	unsigned int open_tries_;
 
-  std::queue<ArduinoComMessage *> messages_;
+	std::queue<ArduinoComMessage *> messages_;
 
-  boost::asio::io_service io_service_;
-  boost::asio::serial_port serial_;
-  boost::asio::deadline_timer deadline_;
-  boost::asio::streambuf input_buffer_;
+	boost::asio::io_service     io_service_;
+	boost::asio::serial_port    serial_;
+	boost::asio::deadline_timer deadline_;
+	boost::asio::streambuf      input_buffer_;
 
-  boost::mutex io_mutex_;
-  fawkes::ArduinoInterface *arduino_if_;
-  fawkes::JoystickInterface *joystick_if_;
+	boost::mutex               io_mutex_;
+	fawkes::ArduinoInterface * arduino_if_;
+	fawkes::JoystickInterface *joystick_if_;
 
-  ArduinoTFThread *tf_thread_;
+	ArduinoTFThread *tf_thread_;
 
-  void load_config();
+	void load_config();
 
-  void append_message_to_queue(ArduinoComMessage::command_id_t cmd,
-                               unsigned int value = 0,
-                               unsigned int timeout = 1000);
-  void append_message_to_queue(ArduinoComMessage *msg);
-  bool add_command_to_message(ArduinoComMessage *msg,
-                              ArduinoComMessage::command_id_t command,
-                              unsigned int value);
+	void append_message_to_queue(ArduinoComMessage::command_id_t cmd,
+	                             unsigned int                    value   = 0,
+	                             unsigned int                    timeout = 1000);
+	void append_message_to_queue(ArduinoComMessage *msg);
+	bool add_command_to_message(ArduinoComMessage *             msg,
+	                            ArduinoComMessage::command_id_t command,
+	                            unsigned int                    value);
 
-  float inline round_to_2nd_dec(float f);
-  void pose_publish_tf();
+	float inline round_to_2nd_dec(float f);
+	void pose_publish_tf();
 
 protected:
-  /** Mutex to protect data_. Lock whenever accessing it. */
-  fawkes::Mutex *data_mutex_;
+	/** Mutex to protect data_. Lock whenever accessing it. */
+	fawkes::Mutex *data_mutex_;
 };
 
 #endif

--- a/src/plugins/arduino/tf_thread.cpp
+++ b/src/plugins/arduino/tf_thread.cpp
@@ -21,21 +21,20 @@
  */
 
 #include "tf_thread.h"
+
 #include <baseapp/run.h>
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
-#include <utils/math/angle.h>
-#include <utils/time/wait.h>
-
 #include <interfaces/ArduinoInterface.h>
 #include <interfaces/BatteryInterface.h>
-
-#include <unistd.h>
+#include <utils/math/angle.h>
+#include <utils/time/wait.h>
 
 #include <boost/lambda/bind.hpp>
 #include <boost/lambda/lambda.hpp>
 #include <boost/thread/thread.hpp>
 #include <libudev.h>
+#include <unistd.h>
 
 using namespace fawkes;
 
@@ -46,58 +45,71 @@ using namespace fawkes;
 
 /** Constructor. */
 ArduinoTFThread::ArduinoTFThread(std::string &cfg_name, std::string &cfg_prefix)
-    : Thread("ArduinoTFThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PREPARE),
-      TransformAspect(TransformAspect::ONLY_PUBLISHER, "gripper_") {
-  cfg_prefix_ = cfg_prefix;
-  cfg_name_ = cfg_name;
+: Thread("ArduinoTFThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PREPARE),
+  TransformAspect(TransformAspect::ONLY_PUBLISHER, "gripper_")
+{
+	cfg_prefix_ = cfg_prefix;
+	cfg_name_   = cfg_name;
 }
 
 /** Destructor. */
-ArduinoTFThread::~ArduinoTFThread() {}
-
-void ArduinoTFThread::init() {
-  load_config();
-  //    last_official_z_position_ = 0.;
-  //    desired_end_z_pose_ = 0.;
-  cur_x_ = 0.0;
-  cur_y_ = 0.0;
-  cur_z_ = 0.0;
+ArduinoTFThread::~ArduinoTFThread()
+{
 }
 
-void ArduinoTFThread::finalize() {}
+void
+ArduinoTFThread::init()
+{
+	load_config();
+	//    last_official_z_position_ = 0.;
+	//    desired_end_z_pose_ = 0.;
+	cur_x_ = 0.0;
+	cur_y_ = 0.0;
+	cur_z_ = 0.0;
+}
 
-void ArduinoTFThread::loop() {
-  boost::mutex::scoped_lock lock(data_mutex_);
-  fawkes::Time now(clock);
+void
+ArduinoTFThread::finalize()
+{
+}
 
-  //    float d_mm = current_end_z_pose_ - desired_end_z_pose_;
-  //    double d_s = now - end_time_point_;
+void
+ArduinoTFThread::loop()
+{
+	boost::mutex::scoped_lock lock(data_mutex_);
+	fawkes::Time              now(clock);
 
-  tf::Quaternion q(0.0, 0.0, 0.0);
+	//    float d_mm = current_end_z_pose_ - desired_end_z_pose_;
+	//    double d_s = now - end_time_point_;
 
-  tf::Vector3 v_x(cur_x_, 0.0, 0.0);
+	tf::Quaternion q(0.0, 0.0, 0.0);
 
-  tf::Vector3 v_y(0.0, (cur_y_ - cfg_y_max_ / 2.), 0.0);
+	tf::Vector3 v_x(cur_x_, 0.0, 0.0);
 
-  tf::Vector3 v_z(0.0, 0.0, cur_z_);
+	tf::Vector3 v_y(0.0, (cur_y_ - cfg_y_max_ / 2.), 0.0);
 
-  tf::Transform tf_pose_gripper_x(q, v_x);
-  tf::Transform tf_pose_gripper_y(q, v_y);
-  tf::Transform tf_pose_gripper_z(q, v_z);
+	tf::Vector3 v_z(0.0, 0.0, cur_z_);
 
-  tf::StampedTransform stamped_transform_x(tf_pose_gripper_x, now.stamp(),
-                                           cfg_gripper_origin_x_frame_id_,
-                                           cfg_gripper_dyn_x_frame_id_);
-  tf::StampedTransform stamped_transform_y(tf_pose_gripper_y, now.stamp(),
-                                           cfg_gripper_origin_y_frame_id_,
-                                           cfg_gripper_dyn_y_frame_id_);
-  tf::StampedTransform stamped_transform_z(tf_pose_gripper_z, now.stamp(),
-                                           cfg_gripper_origin_z_frame_id_,
-                                           cfg_gripper_dyn_z_frame_id_);
-  tf_publisher->send_transform(stamped_transform_x);
-  tf_publisher->send_transform(stamped_transform_y);
-  tf_publisher->send_transform(stamped_transform_z);
+	tf::Transform tf_pose_gripper_x(q, v_x);
+	tf::Transform tf_pose_gripper_y(q, v_y);
+	tf::Transform tf_pose_gripper_z(q, v_z);
+
+	tf::StampedTransform stamped_transform_x(tf_pose_gripper_x,
+	                                         now.stamp(),
+	                                         cfg_gripper_origin_x_frame_id_,
+	                                         cfg_gripper_dyn_x_frame_id_);
+	tf::StampedTransform stamped_transform_y(tf_pose_gripper_y,
+	                                         now.stamp(),
+	                                         cfg_gripper_origin_y_frame_id_,
+	                                         cfg_gripper_dyn_y_frame_id_);
+	tf::StampedTransform stamped_transform_z(tf_pose_gripper_z,
+	                                         now.stamp(),
+	                                         cfg_gripper_origin_z_frame_id_,
+	                                         cfg_gripper_dyn_z_frame_id_);
+	tf_publisher->send_transform(stamped_transform_x);
+	tf_publisher->send_transform(stamped_transform_y);
+	tf_publisher->send_transform(stamped_transform_z);
 }
 
 //// interpolate the current z position based on an assumption of where the
@@ -117,32 +129,29 @@ void ArduinoTFThread::loop() {
 //
 //}
 
-void ArduinoTFThread::set_position(float new_x_pos, float new_y_pos,
-                                   float new_z_pos) {
-  boost::mutex::scoped_lock lock(data_mutex_);
-  cur_x_ = new_x_pos;
-  cur_y_ = new_y_pos;
-  cur_z_ = new_z_pos;
-  wakeup();
+void
+ArduinoTFThread::set_position(float new_x_pos, float new_y_pos, float new_z_pos)
+{
+	boost::mutex::scoped_lock lock(data_mutex_);
+	cur_x_ = new_x_pos;
+	cur_y_ = new_y_pos;
+	cur_z_ = new_z_pos;
+	wakeup();
 }
 
-void ArduinoTFThread::load_config() {
-  cfg_gripper_frame_id_ = config->get_string(cfg_prefix_ + "/gripper_frame_id");
-  cfg_gripper_origin_x_frame_id_ =
-      config->get_string(cfg_prefix_ + "/gripper_origin_x_frame_id");
-  cfg_gripper_origin_y_frame_id_ =
-      config->get_string(cfg_prefix_ + "/gripper_origin_y_frame_id");
-  cfg_gripper_origin_z_frame_id_ =
-      config->get_string(cfg_prefix_ + "/gripper_origin_z_frame_id");
+void
+ArduinoTFThread::load_config()
+{
+	cfg_gripper_frame_id_          = config->get_string(cfg_prefix_ + "/gripper_frame_id");
+	cfg_gripper_origin_x_frame_id_ = config->get_string(cfg_prefix_ + "/gripper_origin_x_frame_id");
+	cfg_gripper_origin_y_frame_id_ = config->get_string(cfg_prefix_ + "/gripper_origin_y_frame_id");
+	cfg_gripper_origin_z_frame_id_ = config->get_string(cfg_prefix_ + "/gripper_origin_z_frame_id");
 
-  cfg_gripper_dyn_x_frame_id_ =
-      config->get_string(cfg_prefix_ + "/gripper_dyn_x_frame_id");
-  cfg_gripper_dyn_y_frame_id_ =
-      config->get_string(cfg_prefix_ + "/gripper_dyn_y_frame_id");
-  cfg_gripper_dyn_z_frame_id_ =
-      config->get_string(cfg_prefix_ + "/gripper_dyn_z_frame_id");
+	cfg_gripper_dyn_x_frame_id_ = config->get_string(cfg_prefix_ + "/gripper_dyn_x_frame_id");
+	cfg_gripper_dyn_y_frame_id_ = config->get_string(cfg_prefix_ + "/gripper_dyn_y_frame_id");
+	cfg_gripper_dyn_z_frame_id_ = config->get_string(cfg_prefix_ + "/gripper_dyn_z_frame_id");
 
-  cfg_x_max_ = config->get_float(cfg_prefix_ + "/x_max");
-  cfg_y_max_ = config->get_float(cfg_prefix_ + "/y_max");
-  cfg_z_max_ = config->get_float(cfg_prefix_ + "/z_max");
+	cfg_x_max_ = config->get_float(cfg_prefix_ + "/x_max");
+	cfg_y_max_ = config->get_float(cfg_prefix_ + "/y_max");
+	cfg_z_max_ = config->get_float(cfg_prefix_ + "/z_max");
 }

--- a/src/plugins/arduino/tf_thread.h
+++ b/src/plugins/arduino/tf_thread.h
@@ -34,7 +34,6 @@
 #include <core/threading/thread.h>
 #include <interfaces/JoystickInterface.h>
 #include <tf/types.h>
-
 #include <utils/time/time.h>
 
 #include <boost/asio.hpp>
@@ -59,64 +58,64 @@ class ArduinoTFThread : public fawkes::Thread,
 
 {
 public:
-  ArduinoTFThread();
-  /**
+	ArduinoTFThread();
+	/**
    * @brief Constructor
    *
    * @param cfg_name Name of the config file
    * @param cfg_prefix Tag prefixes of the arduino tf config values
    */
-  ArduinoTFThread(std::string &cfg_name, std::string &cfg_prefix);
-  virtual ~ArduinoTFThread();
+	ArduinoTFThread(std::string &cfg_name, std::string &cfg_prefix);
+	virtual ~ArduinoTFThread();
 
-  virtual void init();
-  //	virtual void once();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	//	virtual void once();
+	virtual void loop();
+	virtual void finalize();
 
-  /**
+	/**
    * @brief Resets the current position to a given position
    *
    * @param new_x New X-coordinate
    * @param new_y New Y-coordinate
    * @param new_z New Z-coordinate
    */
-  void set_position(float new_x, float new_y, float new_z);
+	void set_position(float new_x, float new_y, float new_z);
 
 private:
-  std::string cfg_gripper_frame_id_;
-  std::string cfg_gripper_dyn_x_frame_id_;
-  std::string cfg_gripper_dyn_y_frame_id_;
-  std::string cfg_gripper_dyn_z_frame_id_;
+	std::string cfg_gripper_frame_id_;
+	std::string cfg_gripper_dyn_x_frame_id_;
+	std::string cfg_gripper_dyn_y_frame_id_;
+	std::string cfg_gripper_dyn_z_frame_id_;
 
-  std::string cfg_gripper_origin_x_frame_id_;
-  std::string cfg_gripper_origin_y_frame_id_;
-  std::string cfg_gripper_origin_z_frame_id_;
+	std::string cfg_gripper_origin_x_frame_id_;
+	std::string cfg_gripper_origin_y_frame_id_;
+	std::string cfg_gripper_origin_z_frame_id_;
 
-  std::string cfg_prefix_;
-  std::string cfg_name_;
+	std::string cfg_prefix_;
+	std::string cfg_name_;
 
-  float cfg_static_tf_x_home_;
-  float cfg_static_tf_y_home_;
-  float cfg_static_tf_z_home_;
-  float cfg_x_max_;
-  float cfg_y_max_;
-  float cfg_z_max_;
+	float cfg_static_tf_x_home_;
+	float cfg_static_tf_y_home_;
+	float cfg_static_tf_z_home_;
+	float cfg_x_max_;
+	float cfg_y_max_;
+	float cfg_z_max_;
 
-  void load_config();
+	void load_config();
 
-  fawkes::Time end_time_point_;
-  float desired_end_z_pose_;
-  float current_end_z_pose_;
+	fawkes::Time end_time_point_;
+	float        desired_end_z_pose_;
+	float        current_end_z_pose_;
 
-  float cur_step_d_;
-  float cur_x_;
-  float cur_y_;
-  float cur_z_;
+	float cur_step_d_;
+	float cur_x_;
+	float cur_y_;
+	float cur_z_;
 
 protected:
-  /** Mutex to protect data_. Lock whenever accessing it. */
-  boost::mutex data_mutex_;
+	/** Mutex to protect data_. Lock whenever accessing it. */
+	boost::mutex data_mutex_;
 };
 
 #endif

--- a/src/plugins/asp-planner/asp_planner_clingo.cpp
+++ b/src/plugins/asp-planner/asp_planner_clingo.cpp
@@ -22,6 +22,10 @@
 #include "asp_planner_externals.h"
 #include "asp_planner_thread.h"
 
+#include <core/exception.h>
+#include <core/threading/mutex_locker.h>
+#include <plugins/asp/aspect/clingo_access.h>
+
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -29,385 +33,381 @@
 #include <sstream>
 #include <thread>
 
-#include <core/exception.h>
-#include <core/threading/mutex_locker.h>
-#include <plugins/asp/aspect/clingo_access.h>
-
 using fawkes::MutexLocker;
 
 /**
  * @brief Takes care of everything regarding clingo interface in init().
  */
-void AspPlannerThread::initClingo(void) {
-  MutexLocker navgraphLocker(navgraph.objmutex_ptr());
-  navgraph->add_change_listener(this);
-  navgraphLocker.unlock();
+void
+AspPlannerThread::initClingo(void)
+{
+	MutexLocker navgraphLocker(navgraph.objmutex_ptr());
+	navgraph->add_change_listener(this);
+	navgraphLocker.unlock();
 
-  MutexLocker locker(clingo.objmutex_ptr());
-  clingo->register_model_callback(std::make_shared<std::function<bool(void)>>(
-      [this](void) { return newModel(); }));
-  clingo->register_finish_callback(
-      std::make_shared<std::function<void(Clingo::SolveResult)>>(
-          [this](const Clingo::SolveResult result) {
-            solvingFinished(result);
-            return;
-          }));
-  clingo->set_ground_callback([this](auto... args) {
-    this->groundFunctions(args...);
-    return;
-  });
+	MutexLocker locker(clingo.objmutex_ptr());
+	clingo->register_model_callback(
+	  std::make_shared<std::function<bool(void)>>([this](void) { return newModel(); }));
+	clingo->register_finish_callback(std::make_shared<std::function<void(Clingo::SolveResult)>>(
+	  [this](const Clingo::SolveResult result) {
+		  solvingFinished(result);
+		  return;
+	  }));
+	clingo->set_ground_callback([this](auto... args) {
+		this->groundFunctions(args...);
+		return;
+	});
 
-  constexpr auto infix = "planner/";
-  const auto prefixLen = std::strlen(ConfigPrefix);
-  constexpr auto infixLen = std::strlen(infix);
-  char buffer[prefixLen + infixLen + 20];
-  const auto suffix = buffer + prefixLen + infixLen;
-  std::strcpy(buffer, ConfigPrefix);
-  std::strcpy(buffer + prefixLen, infix);
+	constexpr auto infix     = "planner/";
+	const auto     prefixLen = std::strlen(ConfigPrefix);
+	constexpr auto infixLen  = std::strlen(infix);
+	char           buffer[prefixLen + infixLen + 20];
+	const auto     suffix = buffer + prefixLen + infixLen;
+	std::strcpy(buffer, ConfigPrefix);
+	std::strcpy(buffer + prefixLen, infix);
 
-  std::strcpy(suffix, "program-path");
-  const auto path = config->get_string(buffer);
-  std::strcpy(suffix, "program-files");
-  const auto files = config->get_strings(buffer);
+	std::strcpy(suffix, "program-path");
+	const auto path = config->get_string(buffer);
+	std::strcpy(suffix, "program-files");
+	const auto files = config->get_strings(buffer);
 
-  std::strcpy(suffix, "threads");
-  const auto threads = config->get_int(buffer);
-  std::strcpy(suffix, "use-splitting");
-  const auto splitting = config->get_bool(buffer);
-  clingo->set_num_threads(threads, splitting);
+	std::strcpy(suffix, "threads");
+	const auto threads = config->get_int(buffer);
+	std::strcpy(suffix, "use-splitting");
+	const auto splitting = config->get_bool(buffer);
+	clingo->set_num_threads(threads, splitting);
 
-  logger->log_info(LoggingComponent,
-                   "Loading program files from %s. Debug state: %d",
-                   path.c_str(), clingo->debug_level());
-  for (const auto &file : files) {
-    clingo->load_file(path + file);
-  } // for ( const auto& file : files )
+	logger->log_info(LoggingComponent,
+	                 "Loading program files from %s. Debug state: %d",
+	                 path.c_str(),
+	                 clingo->debug_level());
+	for (const auto &file : files) {
+		clingo->load_file(path + file);
+	} // for ( const auto& file : files )
 
-  clingo->ground({{"base", {}}});
+	clingo->ground({{"base", {}}});
 
-  return;
+	return;
 }
 
 /**
  * @brief Takes care of everything regarding clingo interface in finalize().
  */
-void AspPlannerThread::finalizeClingo(void) {
-  MutexLocker locker(clingo.objmutex_ptr());
-  if (clingo->solving()) {
-    clingo->cancel_solving();
-    do // while ( clingo->solving() )
-    {
-      using namespace std::chrono_literals;
-      std::this_thread::sleep_for(20ms);
-    } while (clingo->solving());
-  } // if ( clingo->solving() )
-  return;
+void
+AspPlannerThread::finalizeClingo(void)
+{
+	MutexLocker locker(clingo.objmutex_ptr());
+	if (clingo->solving()) {
+		clingo->cancel_solving();
+		do // while ( clingo->solving() )
+		{
+			using namespace std::chrono_literals;
+			std::this_thread::sleep_for(20ms);
+		} while (clingo->solving());
+	} // if ( clingo->solving() )
+	return;
 }
 
 /**
  * @brief Handles the loop concerning the solving process.
  */
-void AspPlannerThread::loopClingo(void) {
-  MutexLocker aspLocker(clingo.objmutex_ptr());
-  // Locked: clingo
+void
+AspPlannerThread::loopClingo(void)
+{
+	MutexLocker aspLocker(clingo.objmutex_ptr());
+	// Locked: clingo
 
-  if (!ProgramGrounded) {
-    return;
-  } // if ( !ProgramGrounded )
+	if (!ProgramGrounded) {
+		return;
+	} // if ( !ProgramGrounded )
 
-  MutexLocker reqLocker(&RequestMutex);
-  const auto requests =
-      GroundRequests.size() + ReleaseRequests.size() + AssignRequests.size();
-  reqLocker.unlock();
+	MutexLocker reqLocker(&RequestMutex);
+	const auto  requests = GroundRequests.size() + ReleaseRequests.size() + AssignRequests.size();
+	reqLocker.unlock();
 
-  if (clingo->solving()) {
-    if (shouldInterrupt() && !SentCancel) {
-      logger->log_warn(
-          LoggingComponent,
-          "Cancel solving, new requests: %zu, interrupt level: %s, reason: %s",
-          requests, interruptString(Interrupt.load()), InterruptReason.load());
-      clingo->cancel_solving();
-      SentCancel = true;
-    } // if ( shouldInterrupt() && !SentCancel )
-    return;
-  } // if ( clingo->solving() )
+	if (clingo->solving()) {
+		if (shouldInterrupt() && !SentCancel) {
+			logger->log_warn(LoggingComponent,
+			                 "Cancel solving, new requests: %zu, interrupt level: %s, reason: %s",
+			                 requests,
+			                 interruptString(Interrupt.load()),
+			                 InterruptReason.load());
+			clingo->cancel_solving();
+			SentCancel = true;
+		} // if ( shouldInterrupt() && !SentCancel )
+		return;
+	} // if ( clingo->solving() )
 
-  MutexLocker navgraphLocker(&NavgraphDistanceMutex);
-  // Locked: clingo, NavgraphDistanceMutex
-  if (UpdateNavgraphDistances) {
-    const bool lastUpdate = NodesToFind.empty();
-    if (lastUpdate) {
-      MutexLocker worldLocker(&WorldMutex);
-      // Locked: clingo, NavgraphDistanceMutex, WorldMutex
-      if (ReceivedZonesToExplore) {
-        for (const auto &zone : ZonesToExplore) {
-          releaseZone(zone, false);
-        } // for ( const auto& zone : ZonesToExplore )
-        ZonesToExplore.clear();
-      } // if ( ReceivedZonesToExplore )
-      else {
-        for (auto zone = 1; zone <= 24; ++zone) {
-          releaseZone(zone, false);
-        } // for ( auto zone = 1; zone <= 24; ++zone )
-      }   // else -> if ( ReceivedZonesToExplore )
-      navgraphLocker.unlock();
-      // Locked: clingo, WorldMutex
-      fillNavgraphNodesForASP(false);
-      navgraphLocker.relock();
-      // Locked: clingo, WorldMutex, NavgraphDistanceMutex
-    } // if ( lastUpdate )
-    // Locked: clingo, NavgraphDistanceMutex
+	MutexLocker navgraphLocker(&NavgraphDistanceMutex);
+	// Locked: clingo, NavgraphDistanceMutex
+	if (UpdateNavgraphDistances) {
+		const bool lastUpdate = NodesToFind.empty();
+		if (lastUpdate) {
+			MutexLocker worldLocker(&WorldMutex);
+			// Locked: clingo, NavgraphDistanceMutex, WorldMutex
+			if (ReceivedZonesToExplore) {
+				for (const auto &zone : ZonesToExplore) {
+					releaseZone(zone, false);
+				} // for ( const auto& zone : ZonesToExplore )
+				ZonesToExplore.clear();
+			} // if ( ReceivedZonesToExplore )
+			else {
+				for (auto zone = 1; zone <= 24; ++zone) {
+					releaseZone(zone, false);
+				} // for ( auto zone = 1; zone <= 24; ++zone )
+			}   // else -> if ( ReceivedZonesToExplore )
+			navgraphLocker.unlock();
+			// Locked: clingo, WorldMutex
+			fillNavgraphNodesForASP(false);
+			navgraphLocker.relock();
+			// Locked: clingo, WorldMutex, NavgraphDistanceMutex
+		} // if ( lastUpdate )
+		// Locked: clingo, NavgraphDistanceMutex
 
-    for (const auto &external : NavgraphDistances) {
-      clingo->assign_external(external, false);
-    } // for ( const auto& external : NavgraphDistances )
+		for (const auto &external : NavgraphDistances) {
+			clingo->assign_external(external, false);
+		} // for ( const auto& external : NavgraphDistances )
 
-    updateNavgraphDistances();
+		updateNavgraphDistances();
 
-    if (lastUpdate) {
-      logger->log_info(
-          LoggingComponent,
-          "All machines found, fix distances and release externals.");
-      for (const auto &external : NavgraphDistances) {
-        queueGround({"setDriveDuration",
-                     Clingo::SymbolVector(external.arguments().begin(),
-                                          external.arguments().end())},
-                    "");
-        Clingo::Symbol args[3];
-        std::copy(external.arguments().begin(), external.arguments().end(),
-                  std::begin(args));
+		if (lastUpdate) {
+			logger->log_info(LoggingComponent,
+			                 "All machines found, fix distances and release externals.");
+			for (const auto &external : NavgraphDistances) {
+				queueGround({"setDriveDuration",
+				             Clingo::SymbolVector(external.arguments().begin(),
+				                                  external.arguments().end())},
+				            "");
+				Clingo::Symbol args[3];
+				std::copy(external.arguments().begin(), external.arguments().end(), std::begin(args));
 
-        // In difference to assigning and grounding we need the full symmetry in
-        // releasing.
-        for (bool swap = true; true;) {
-          for (auto d = 1; d <= realGameTimeToAspGameTime(MaxDriveDuration);
-               ++d) {
-            args[2] = Clingo::Number(d);
-            queueRelease(Clingo::Function(external.name(), {args, 3}), "");
-          } // for ( auto d = 1; d <=
-            // realGameTimeToAspGameTime(MaxDriveDuration); ++d )
+				// In difference to assigning and grounding we need the full symmetry in
+				// releasing.
+				for (bool swap = true; true;) {
+					for (auto d = 1; d <= realGameTimeToAspGameTime(MaxDriveDuration); ++d) {
+						args[2] = Clingo::Number(d);
+						queueRelease(Clingo::Function(external.name(), {args, 3}), "");
+					} // for ( auto d = 1; d <=
+					// realGameTimeToAspGameTime(MaxDriveDuration); ++d )
 
-          if (swap) {
-            std::swap(args[0], args[1]);
-            swap = false;
-          } // if ( swap )
-          else {
-            break;
-          } // else -> if ( swap )
-        }   // for ( bool swap = true; true; )
-      }     // for ( const auto& external : NavgraphDistances )
-    }       // if ( lastUpdate )
-    else {
-      for (const auto &external : NavgraphDistances) {
-        clingo->assign_external(external, true);
-      } // for ( const auto& external : NavgraphDistances )
-    }   // else -> if ( lastUpdate )
-  }     // if ( UpdateNavgraphDistances )
-  else if (requests == 0 && Interrupt == InterruptSolving::Not) {
-    MutexLocker solvingLocker(&SolvingMutex);
-    // Locked: clingo, NavgraphDistanceMutex, SolvingMutex
-    if (Clock::now() - SolvingStarted < std::chrono::seconds(15)) {
-      // Nothing to do and last solving happened within the last fifteen
-      // seconds.
-      return;
-    } // if ( Clock::now() - SolvingStarted < std::chrono::seconds(15) )
-    MutexLocker worldLocker(&WorldMutex);
-    // Locked: clingo, NavgraphDistanceMutex, SolvingMutex, WorldMutex
-    if (StartSolvingGameTime == GameTime) {
-      // Nothing to do and the time hasn't advanced. (Game is paused or still in
-      // setup.)
-      return;
-    } // if ( StartSolvingGameTime == GameTime )
-  }   // else if ( requests == 0 && Interrupt == InterruptSolving::Not )
-  navgraphLocker.unlock();
-  // Locked: clingo
+					if (swap) {
+						std::swap(args[0], args[1]);
+						swap = false;
+					} // if ( swap )
+					else {
+						break;
+					} // else -> if ( swap )
+				}   // for ( bool swap = true; true; )
+			}     // for ( const auto& external : NavgraphDistances )
+		}       // if ( lastUpdate )
+		else {
+			for (const auto &external : NavgraphDistances) {
+				clingo->assign_external(external, true);
+			} // for ( const auto& external : NavgraphDistances )
+		}   // else -> if ( lastUpdate )
+	}     // if ( UpdateNavgraphDistances )
+	else if (requests == 0 && Interrupt == InterruptSolving::Not) {
+		MutexLocker solvingLocker(&SolvingMutex);
+		// Locked: clingo, NavgraphDistanceMutex, SolvingMutex
+		if (Clock::now() - SolvingStarted < std::chrono::seconds(15)) {
+			// Nothing to do and last solving happened within the last fifteen
+			// seconds.
+			return;
+		} // if ( Clock::now() - SolvingStarted < std::chrono::seconds(15) )
+		MutexLocker worldLocker(&WorldMutex);
+		// Locked: clingo, NavgraphDistanceMutex, SolvingMutex, WorldMutex
+		if (StartSolvingGameTime == GameTime) {
+			// Nothing to do and the time hasn't advanced. (Game is paused or still in
+			// setup.)
+			return;
+		} // if ( StartSolvingGameTime == GameTime )
+	}   // else if ( requests == 0 && Interrupt == InterruptSolving::Not )
+	navgraphLocker.unlock();
+	// Locked: clingo
 
-  SentCancel = false;
-  Interrupt = InterruptSolving::Not;
-  InterruptReason = "";
+	SentCancel      = false;
+	Interrupt       = InterruptSolving::Not;
+	InterruptReason = "";
 
-  static std::vector<Clingo::Symbol> externals;
+	static std::vector<Clingo::Symbol> externals;
 
-  for (const auto &external : externals) {
-    clingo->assign_external(external, false);
-  } // for ( const auto& external : externals )
+	for (const auto &external : externals) {
+		clingo->assign_external(external, false);
+	} // for ( const auto& external : externals )
 
-  externals.clear();
+	externals.clear();
 
-  // Set "initial" state.
-  MutexLocker worldLocker(&WorldMutex);
+	// Set "initial" state.
+	MutexLocker worldLocker(&WorldMutex);
 
-  if (GameTime == -1) {
-    // The game has ended, we do not need any more planning.
-    return;
-  } // if ( GameTime == -1 )
+	if (GameTime == -1) {
+		// The game has ended, we do not need any more planning.
+		return;
+	} // if ( GameTime == -1 )
 
-  // Locked: clingo, WorldMutex
-  auto addExternal = [this](Clingo::Symbol &&external) {
-    clingo->assign_external(external, true);
-    externals.push_back(std::move(external));
-    return;
-  };
+	// Locked: clingo, WorldMutex
+	auto addExternal = [this](Clingo::Symbol &&external) {
+		clingo->assign_external(external, true);
+		externals.push_back(std::move(external));
+		return;
+	};
 
-  auto locations(LocationInUse);
-  locations.reserve(Robots.size());
+	auto locations(LocationInUse);
+	locations.reserve(Robots.size());
 
-  for (const auto &pair : Robots) {
-    const auto &name(pair.first);
-    const auto &robot(pair.second);
-    clingo->assign_external(robot.AliveExternal, robot.Alive);
+	for (const auto &pair : Robots) {
+		const auto &name(pair.first);
+		const auto &robot(pair.second);
+		clingo->assign_external(robot.AliveExternal, robot.Alive);
 
-    if (!robot.Alive) {
-      continue;
-    } // if ( !robot.Alive )
+		if (!robot.Alive) {
+			continue;
+		} // if ( !robot.Alive )
 
-    if (robot.Holding.isValid()) {
-      addExternal(generateHoldingExternal(name, robot.Holding));
-    } // if ( robot.Holding.isValid() )
+		if (robot.Holding.isValid()) {
+			addExternal(generateHoldingExternal(name, robot.Holding));
+		} // if ( robot.Holding.isValid() )
 
-    if (robot.Doing.isValid()) {
-      addExternal(
-          generateDoingExternal(name, robot.Doing,
-                                realGameTimeToAspGameTime(std::max(
-                                    1, robot.Doing.EstimatedEnd - GameTime))));
-    } // if ( robot.Doing.isValid() )
-    else {
-      auto location = nearestLocation(robot.X, robot.Y);
-      const auto locationRobot = locations.find(location);
-      if (locationRobot != locations.end() && locationRobot->second != name) {
-        /* Two (or more) robots "on" one locations, should only happen at game
+		if (robot.Doing.isValid()) {
+			addExternal(generateDoingExternal(name,
+			                                  robot.Doing,
+			                                  realGameTimeToAspGameTime(
+			                                    std::max(1, robot.Doing.EstimatedEnd - GameTime))));
+		} // if ( robot.Doing.isValid() )
+		else {
+			auto       location      = nearestLocation(robot.X, robot.Y);
+			const auto locationRobot = locations.find(location);
+			if (locationRobot != locations.end() && locationRobot->second != name) {
+				/* Two (or more) robots "on" one locations, should only happen at game
          * start. The robots are mapped to a side of the near base station
          * instead of ins-out. Change their location to ins-out, this is the
          * only location where multiple robots are allowed. */
-        location = Clingo::String("ins-out");
-      } // if ( locationRobot != locations.end() && locationRobot->second !=
-        // name )
-      else {
-        locations.insert({location, name});
-      } // else -> if ( locationRobot != locations.end() &&
-        // locationRobot->second != name )
-      addExternal(generateRobotLocationExternal(name, location));
-    } // else -> if ( robot.Doing.isValid() )
-  }   // for ( const auto& pair : Robots )
+				location = Clingo::String("ins-out");
+			} // if ( locationRobot != locations.end() && locationRobot->second !=
+			// name )
+			else {
+				locations.insert({location, name});
+			} // else -> if ( locationRobot != locations.end() &&
+			// locationRobot->second != name )
+			addExternal(generateRobotLocationExternal(name, location));
+		} // else -> if ( robot.Doing.isValid() )
+	}   // for ( const auto& pair : Robots )
 
-  for (const auto &pair : Machines) {
-    const auto &name(pair.first);
-    const auto &machine(pair.second);
+	for (const auto &pair : Machines) {
+		const auto &name(pair.first);
+		const auto &machine(pair.second);
 
-    auto working = machine.WorkingUntil;
-    if (machine.BrokenUntil) {
-      addExternal(generateMachineBrokenExternal(
-          name, std::max(1, realGameTimeToAspGameTime(machine.BrokenUntil -
-                                                      GameTime))));
-      if (working) {
-        working = machine.BrokenUntil + working - GameTime;
-      } // if ( working )
-    }   // if ( machine.BrokenUntil )
+		auto working = machine.WorkingUntil;
+		if (machine.BrokenUntil) {
+			addExternal(generateMachineBrokenExternal(
+			  name, std::max(1, realGameTimeToAspGameTime(machine.BrokenUntil - GameTime))));
+			if (working) {
+				working = machine.BrokenUntil + working - GameTime;
+			} // if ( working )
+		}   // if ( machine.BrokenUntil )
 
-    if (working) {
-      assert(machine.Storing.isValid());
-      addExternal(generateMachineWorkingExternal(
-          name, std::max(1, realGameTimeToAspGameTime(working - GameTime)),
-          machine.Storing));
-    } // if ( working )
-    else if (machine.Storing.isValid()) {
-      addExternal(generateMachineStoringExternal(name, machine.Storing));
-    } // else if ( machine.Storing.isValid() )
-  }   // for ( const auto& pair : Machines )
+		if (working) {
+			assert(machine.Storing.isValid());
+			addExternal(generateMachineWorkingExternal(
+			  name, std::max(1, realGameTimeToAspGameTime(working - GameTime)), machine.Storing));
+		} // if ( working )
+		else if (machine.Storing.isValid()) {
+			addExternal(generateMachineStoringExternal(name, machine.Storing));
+		} // else if ( machine.Storing.isValid() )
+	}   // for ( const auto& pair : Machines )
 
-  for (const auto &machine : {"CS1", "CS2"}) {
-    const auto &info(Machines[machine]);
-    if (info.Prepared) {
-      addExternal(generatePreparedExternal(machine));
-    }
-  } // for ( const auto& machine : {"CS1", "CS2"} )
+	for (const auto &machine : {"CS1", "CS2"}) {
+		const auto &info(Machines[machine]);
+		if (info.Prepared) {
+			addExternal(generatePreparedExternal(machine));
+		}
+	} // for ( const auto& machine : {"CS1", "CS2"} )
 
-  for (const auto &machine : {"RS1", "RS2"}) {
-    const auto &info(Machines[machine]);
-    addExternal(generateFillStateExternal(machine, info.FillState));
-  } // for ( const auto& machine : {"RS1", "RS2"} )
+	for (const auto &machine : {"RS1", "RS2"}) {
+		const auto &info(Machines[machine]);
+		addExternal(generateFillStateExternal(machine, info.FillState));
+	} // for ( const auto& machine : {"RS1", "RS2"} )
 
-  for (auto index = 0; index < static_cast<int>(Products.size()); ++index) {
-    const auto &product(Products[index]);
-    const ProductIdentifier id{index};
-    addExternal(generateProductExternal(id));
-    addExternal(generateProductBaseExternal(id, product.Base));
+	for (auto index = 0; index < static_cast<int>(Products.size()); ++index) {
+		const auto &            product(Products[index]);
+		const ProductIdentifier id{index};
+		addExternal(generateProductExternal(id));
+		addExternal(generateProductBaseExternal(id, product.Base));
 
-    for (auto ring = 1; ring <= 3; ++ring) {
-      if (product.Rings[ring].empty()) {
-        break;
-      } // if ( product.Rings[ring].empty() )
-      addExternal(generateProductRingExternal(id, ring, product.Rings[ring]));
-    } // for ( auto ring = 1; ring <= 3; ++ring )
+		for (auto ring = 1; ring <= 3; ++ring) {
+			if (product.Rings[ring].empty()) {
+				break;
+			} // if ( product.Rings[ring].empty() )
+			addExternal(generateProductRingExternal(id, ring, product.Rings[ring]));
+		} // for ( auto ring = 1; ring <= 3; ++ring )
 
-    if (!product.Cap.empty()) {
-      addExternal(generateProductCapExternal(id, product.Cap));
-    } // if ( !product.Cap.empty() )
-  } // for ( auto index = 0; index < static_cast<int>(Products.size()); ++index
-    // )
-  worldLocker.unlock();
-  // Locked: clingo
+		if (!product.Cap.empty()) {
+			addExternal(generateProductCapExternal(id, product.Cap));
+		} // if ( !product.Cap.empty() )
+	}   // for ( auto index = 0; index < static_cast<int>(Products.size()); ++index
+	// )
+	worldLocker.unlock();
+	// Locked: clingo
 
-  reqLocker.relock();
-  // Locked: clingo, RequestMutex
-  // Copy the requests to release the lock especially before grounding!
-  auto groundRequests(std::move(GroundRequests));
-  auto releaseRequests(std::move(ReleaseRequests));
-  auto assignRequests(std::move(AssignRequests));
-  reqLocker.unlock();
-  // Locked: clingo
+	reqLocker.relock();
+	// Locked: clingo, RequestMutex
+	// Copy the requests to release the lock especially before grounding!
+	auto groundRequests(std::move(GroundRequests));
+	auto releaseRequests(std::move(ReleaseRequests));
+	auto assignRequests(std::move(AssignRequests));
+	reqLocker.unlock();
+	// Locked: clingo
 
-  if (!groundRequests.empty()) {
-    std::vector<Clingo::Part> parts;
-    parts.reserve(groundRequests.size());
-    for (const auto &request : groundRequests) {
-      parts.emplace_back(request.first, request.second);
-    } // for ( const auto& request : groundRequests )
-    clingo->ground(parts);
-  } // if ( !groundRequests.empty() )
+	if (!groundRequests.empty()) {
+		std::vector<Clingo::Part> parts;
+		parts.reserve(groundRequests.size());
+		for (const auto &request : groundRequests) {
+			parts.emplace_back(request.first, request.second);
+		} // for ( const auto& request : groundRequests )
+		clingo->ground(parts);
+	} // if ( !groundRequests.empty() )
 
-  for (const auto &atom : releaseRequests) {
-    clingo->release_external(atom);
-  } // for ( const auto& atom : releaseRequests )
+	for (const auto &atom : releaseRequests) {
+		clingo->release_external(atom);
+	} // for ( const auto& atom : releaseRequests )
 
-  for (const auto &atom : assignRequests) {
-    clingo->assign_external(atom, true);
-  } // for ( const auto& atom : assignRequests )
+	for (const auto &atom : assignRequests) {
+		clingo->assign_external(atom, true);
+	} // for ( const auto& atom : assignRequests )
 
-  MutexLocker solvingLokcer(&SolvingMutex);
-  worldLocker.relock();
-  // Locked: clingo, SolvingMutex, WorldMutex
+	MutexLocker solvingLokcer(&SolvingMutex);
+	worldLocker.relock();
+	// Locked: clingo, SolvingMutex, WorldMutex
 
-  auto currentTimeExternal = [](const int time) {
-    return Clingo::Function("currentTime", {Clingo::Number(time)});
-  };
+	auto currentTimeExternal = [](const int time) {
+		return Clingo::Function("currentTime", {Clingo::Number(time)});
+	};
 
-  if (GameTime >= ExplorationTime && !ProductionStarted) {
-    ProductionStarted = true;
-    clingo->ground({{"startProduction", {}}});
-    clingo->release_external(Clingo::Id("productionStarted"));
-  } // if ( GameTime >= ExplorationTime && !ProductionStarted )
+	if (GameTime >= ExplorationTime && !ProductionStarted) {
+		ProductionStarted = true;
+		clingo->ground({{"startProduction", {}}});
+		clingo->release_external(Clingo::Id("productionStarted"));
+	} // if ( GameTime >= ExplorationTime && !ProductionStarted )
 
-  const auto aspGameTime = realGameTimeToAspGameTime(GameTime);
-  for (auto gt = realGameTimeToAspGameTime(StartSolvingGameTime);
-       gt < aspGameTime; ++gt) {
-    clingo->release_external(currentTimeExternal(gt));
-  } // for ( auto gt = realGameTimeToAspGameTime(StartSolvingGameTime); gt <
-    // aspGameTime; ++gt )
-  StartSolvingGameTime = GameTime;
-  worldLocker.unlock();
-  // Locked: clingo, SolvingMutex
-  clingo->assign_external(currentTimeExternal(aspGameTime), true);
-  MutexLocker planLocker(&PlanMutex);
-  // Locked: clingo, SolvingMutex, PlanMutex
-  for (auto &robotPlan : Plan) {
-    robotPlan.second.FirstNotDoneOnSolveStart = robotPlan.second.FirstNotDone;
-  } // for ( auto& robotPlan : Plan )
-  planLocker.unlock();
-  // Locked: clingo, SolvingMutex
-  SolvingStarted = Clock::now();
-  clingo->start_solving();
-  return;
+	const auto aspGameTime = realGameTimeToAspGameTime(GameTime);
+	for (auto gt = realGameTimeToAspGameTime(StartSolvingGameTime); gt < aspGameTime; ++gt) {
+		clingo->release_external(currentTimeExternal(gt));
+	} // for ( auto gt = realGameTimeToAspGameTime(StartSolvingGameTime); gt <
+	// aspGameTime; ++gt )
+	StartSolvingGameTime = GameTime;
+	worldLocker.unlock();
+	// Locked: clingo, SolvingMutex
+	clingo->assign_external(currentTimeExternal(aspGameTime), true);
+	MutexLocker planLocker(&PlanMutex);
+	// Locked: clingo, SolvingMutex, PlanMutex
+	for (auto &robotPlan : Plan) {
+		robotPlan.second.FirstNotDoneOnSolveStart = robotPlan.second.FirstNotDone;
+	} // for ( auto& robotPlan : Plan )
+	planLocker.unlock();
+	// Locked: clingo, SolvingMutex
+	SolvingStarted = Clock::now();
+	clingo->start_solving();
+	return;
 }
 
 /**
@@ -416,12 +416,15 @@ void AspPlannerThread::loopClingo(void) {
  * @param[in] reason The reason for the request.
  * @param[in] interrupt Which level of interrupt is requested.
  */
-void AspPlannerThread::queueGround(GroundRequest &&request, const char *reason,
-                                   const InterruptSolving interrupt) {
-  MutexLocker locker(&RequestMutex);
-  GroundRequests.push_back(std::move(request));
-  setInterrupt(interrupt, reason);
-  return;
+void
+AspPlannerThread::queueGround(GroundRequest &&       request,
+                              const char *           reason,
+                              const InterruptSolving interrupt)
+{
+	MutexLocker locker(&RequestMutex);
+	GroundRequests.push_back(std::move(request));
+	setInterrupt(interrupt, reason);
+	return;
 }
 
 /**
@@ -430,12 +433,15 @@ void AspPlannerThread::queueGround(GroundRequest &&request, const char *reason,
  * @param[in] reason The reason for the request.
  * @param[in] interrupt Which level of interrupt is requested.
  */
-void AspPlannerThread::queueRelease(Clingo::Symbol &&atom, const char *reason,
-                                    const InterruptSolving interrupt) {
-  MutexLocker locker(&RequestMutex);
-  ReleaseRequests.push_back(std::move(atom));
-  setInterrupt(interrupt, reason);
-  return;
+void
+AspPlannerThread::queueRelease(Clingo::Symbol &&      atom,
+                               const char *           reason,
+                               const InterruptSolving interrupt)
+{
+	MutexLocker locker(&RequestMutex);
+	ReleaseRequests.push_back(std::move(atom));
+	setInterrupt(interrupt, reason);
+	return;
 }
 
 /**
@@ -444,12 +450,15 @@ void AspPlannerThread::queueRelease(Clingo::Symbol &&atom, const char *reason,
  * @param[in] reason The reason for the request.
  * @param[in] interrupt Which level of interrupt is requested.
  */
-void AspPlannerThread::queueAssign(Clingo::Symbol &&atom, const char *reason,
-                                   const InterruptSolving interrupt) {
-  MutexLocker locker(&RequestMutex);
-  AssignRequests.push_back(std::move(atom));
-  setInterrupt(interrupt, reason);
-  return;
+void
+AspPlannerThread::queueAssign(Clingo::Symbol &&      atom,
+                              const char *           reason,
+                              const InterruptSolving interrupt)
+{
+	MutexLocker locker(&RequestMutex);
+	AssignRequests.push_back(std::move(atom));
+	setInterrupt(interrupt, reason);
+	return;
 }
 
 /**
@@ -457,96 +466,99 @@ void AspPlannerThread::queueAssign(Clingo::Symbol &&atom, const char *reason,
  * @param[in] interrupt Which level of interrupt is requested.
  * @param[in] reason The reason of the interrupt.
  */
-void AspPlannerThread::setInterrupt(const InterruptSolving interrupt,
-                                    const char *reason) {
-  if (static_cast<short>(interrupt) > static_cast<short>(Interrupt.load())) {
-    Interrupt = interrupt;
-    InterruptReason = reason;
-  } // if ( static_cast<short>(interrupt) > static_cast<short>(Interrupt.load())
-    // )
-  return;
+void
+AspPlannerThread::setInterrupt(const InterruptSolving interrupt, const char *reason)
+{
+	if (static_cast<short>(interrupt) > static_cast<short>(Interrupt.load())) {
+		Interrupt       = interrupt;
+		InterruptReason = reason;
+	} // if ( static_cast<short>(interrupt) > static_cast<short>(Interrupt.load())
+	// )
+	return;
 }
 
 /**
  * @brief Says if the solving process should be interrupted.
  * @return If the solving should be interrupted.
  */
-bool AspPlannerThread::shouldInterrupt(void) {
-  const auto now(Clock::now());
-  switch (Interrupt) {
-  case InterruptSolving::Not: {
-    static auto lastCheck(now);
-    static const std::chrono::seconds threshold(config->get_int(
-        std::string(ConfigPrefix) + "interrupt-thresholds/robot-task-check"));
+bool
+AspPlannerThread::shouldInterrupt(void)
+{
+	const auto now(Clock::now());
+	switch (Interrupt) {
+	case InterruptSolving::Not: {
+		static auto                       lastCheck(now);
+		static const std::chrono::seconds threshold(
+		  config->get_int(std::string(ConfigPrefix) + "interrupt-thresholds/robot-task-check"));
 
-    if (now - lastCheck >= threshold) {
-      lastCheck = now;
-      MutexLocker worldLocker(&WorldMutex);
+		if (now - lastCheck >= threshold) {
+			lastCheck = now;
+			MutexLocker worldLocker(&WorldMutex);
 
-      for (const auto &pair : Robots) {
-        if (pair.second.Alive) {
-          const auto &doing(pair.second.Doing);
-          if (doing.isValid()) {
-            static const std::chrono::seconds threshold(
-                config->get_int(std::string(ConfigPrefix) +
-                                "interrupt-thresholds/robot-task-behind"));
-            if (GameTime > doing.EstimatedEnd + threshold.count()) {
-              logger->log_warn(
-                  LoggingComponent,
-                  "Robot %s is more than %ld seconds behind schedule "
-                  "(and has not send an update), increase interrupt level.",
-                  pair.first.c_str(), threshold.count());
-              setInterrupt(InterruptSolving::High, "Delayed Task");
-            } // if ( GameTime > doing.EstimatedEnd + threshold.count() )
-          }   // if ( doing.isValid() )
-        }     // if ( pair.second.Alive )
-      }       // for ( const auto& pair : Robots )
-    }         // if ( now - lastCheck >= threshold )
+			for (const auto &pair : Robots) {
+				if (pair.second.Alive) {
+					const auto &doing(pair.second.Doing);
+					if (doing.isValid()) {
+						static const std::chrono::seconds threshold(config->get_int(
+						  std::string(ConfigPrefix) + "interrupt-thresholds/robot-task-behind"));
+						if (GameTime > doing.EstimatedEnd + threshold.count()) {
+							logger->log_warn(LoggingComponent,
+							                 "Robot %s is more than %ld seconds behind schedule "
+							                 "(and has not send an update), increase interrupt level.",
+							                 pair.first.c_str(),
+							                 threshold.count());
+							setInterrupt(InterruptSolving::High, "Delayed Task");
+						} // if ( GameTime > doing.EstimatedEnd + threshold.count() )
+					}   // if ( doing.isValid() )
+				}     // if ( pair.second.Alive )
+			}       // for ( const auto& pair : Robots )
+		}         // if ( now - lastCheck >= threshold )
 
-    // Check down here, so we have released the locks!
-    if (Interrupt != InterruptSolving::Not) {
-      return shouldInterrupt();
-    } // if ( Interrupt != InterruptSolving::Not )
-    break;
-  } // case InterruptSolving::Not
-  case InterruptSolving::JustStarted: {
-    static const std::chrono::seconds threshold(config->get_int(
-        std::string(ConfigPrefix) + "interrupt-thresholds/just-started"));
-    MutexLocker locker(&SolvingMutex);
-    const auto diff(now - SolvingStarted);
-    return diff <= threshold;
-  } // case InterruptSolving::JustStarted
-  case InterruptSolving::Normal: {
-    static const std::chrono::seconds threshold(config->get_int(
-        std::string(ConfigPrefix) + "interrupt-thresholds/normal"));
-    MutexLocker locker(&PlanMutex);
-    const auto diff(now - LastPlan);
-    return diff <= threshold;
-  } // case InterruptSolving::Normal
-  case InterruptSolving::High: {
-    static const std::chrono::seconds threshold(config->get_int(
-        std::string(ConfigPrefix) + "interrupt-thresholds/high"));
-    MutexLocker locker(&PlanMutex);
-    const auto diff(now - LastPlan);
-    return diff <= threshold;
-  } // case InterruptSolving::High
-  case InterruptSolving::Critical:
-    return true;
-  } // switch ( Interrupt )
-  return false;
+		// Check down here, so we have released the locks!
+		if (Interrupt != InterruptSolving::Not) {
+			return shouldInterrupt();
+		} // if ( Interrupt != InterruptSolving::Not )
+		break;
+	} // case InterruptSolving::Not
+	case InterruptSolving::JustStarted: {
+		static const std::chrono::seconds threshold(
+		  config->get_int(std::string(ConfigPrefix) + "interrupt-thresholds/just-started"));
+		MutexLocker locker(&SolvingMutex);
+		const auto  diff(now - SolvingStarted);
+		return diff <= threshold;
+	} // case InterruptSolving::JustStarted
+	case InterruptSolving::Normal: {
+		static const std::chrono::seconds threshold(
+		  config->get_int(std::string(ConfigPrefix) + "interrupt-thresholds/normal"));
+		MutexLocker locker(&PlanMutex);
+		const auto  diff(now - LastPlan);
+		return diff <= threshold;
+	} // case InterruptSolving::Normal
+	case InterruptSolving::High: {
+		static const std::chrono::seconds threshold(
+		  config->get_int(std::string(ConfigPrefix) + "interrupt-thresholds/high"));
+		MutexLocker locker(&PlanMutex);
+		const auto  diff(now - LastPlan);
+		return diff <= threshold;
+	} // case InterruptSolving::High
+	case InterruptSolving::Critical: return true;
+	} // switch ( Interrupt )
+	return false;
 }
 
 /**
  * @brief Is called, when the solver has found a new model.
  * @return If the solver should search for additional models.
  */
-bool AspPlannerThread::newModel(void) {
-  MutexLocker aspLocker(clingo.objmutex_ptr());
-  MutexLocker locker(&SolvingMutex);
-  Symbols = clingo->model_symbols();
-  NewSymbols = true;
-  LastModel = Clock::now();
-  return true;
+bool
+AspPlannerThread::newModel(void)
+{
+	MutexLocker aspLocker(clingo.objmutex_ptr());
+	MutexLocker locker(&SolvingMutex);
+	Symbols    = clingo->model_symbols();
+	NewSymbols = true;
+	LastModel  = Clock::now();
+	return true;
 }
 
 /**
@@ -554,15 +566,17 @@ bool AspPlannerThread::newModel(void) {
  * exhausted, the program is infeasible or we told him to be finished.
  * @param[in] result Contains the information what condition has been met.
  */
-void AspPlannerThread::solvingFinished(const Clingo::SolveResult &result) {
-  if (result.is_unsatisfiable()) {
-    ++Unsat;
-    logger->log_error(LoggingComponent, "The input is infeasiable! #%d", Unsat);
-  } // if ( result.is_unsatisfiable() )
-  else {
-    Unsat = 0;
-  } // else -> if ( result.is_unsatisfiable() )
-  return;
+void
+AspPlannerThread::solvingFinished(const Clingo::SolveResult &result)
+{
+	if (result.is_unsatisfiable()) {
+		++Unsat;
+		logger->log_error(LoggingComponent, "The input is infeasiable! #%d", Unsat);
+	} // if ( result.is_unsatisfiable() )
+	else {
+		Unsat = 0;
+	} // else -> if ( result.is_unsatisfiable() )
+	return;
 }
 
 /**
@@ -573,201 +587,199 @@ void AspPlannerThread::solvingFinished(const Clingo::SolveResult &result) {
  * @param[in] arguments The ASP arguments for the function.
  * @param[in] retFunction The function used to return the calculated value.
  */
-void AspPlannerThread::groundFunctions(
-    const Clingo::Location &loc, const char *name,
-    const Clingo::SymbolSpan &arguments,
-    Clingo::SymbolSpanCallback &retFunction) {
-  if (clingo->debug_level() >= fawkes::ClingoAccess::ASP_DBG_ALL) {
-    std::stringstream functionCall;
-    functionCall << name << '(';
-    auto sep = "";
-    for (const auto &argument : arguments) {
-      functionCall << sep << argument;
-      sep = ", ";
-    } // for ( const auto& argument : arguments )
-    functionCall << ')';
+void
+AspPlannerThread::groundFunctions(const Clingo::Location &    loc,
+                                  const char *                name,
+                                  const Clingo::SymbolSpan &  arguments,
+                                  Clingo::SymbolSpanCallback &retFunction)
+{
+	if (clingo->debug_level() >= fawkes::ClingoAccess::ASP_DBG_ALL) {
+		std::stringstream functionCall;
+		functionCall << name << '(';
+		auto sep = "";
+		for (const auto &argument : arguments) {
+			functionCall << sep << argument;
+			sep = ", ";
+		} // for ( const auto& argument : arguments )
+		functionCall << ')';
 
-    const auto functionCallStr(functionCall.str());
-    logger->log_warn(LoggingComponent, "Called %s.", functionCallStr.c_str());
-  }
+		const auto functionCallStr(functionCall.str());
+		logger->log_warn(LoggingComponent, "Called %s.", functionCallStr.c_str());
+	}
 
-  string_view view(name);
+	string_view view(name);
 
-  switch (arguments.size()) {
-  case 0: {
-    if (view == "explorationTaskDuration") {
-      static const int dur = [this](void) {
-        char buffer[std::strlen(ConfigPrefix) + 40];
-        std::strcpy(buffer, ConfigPrefix);
-        std::strcpy(buffer + std::strlen(ConfigPrefix),
-                    "time-estimations/explore-zone");
-        return config->get_int(buffer);
-      }();
-      retFunction({Clingo::Number(realGameTimeToAspGameTime(dur))});
-      return;
-    } // if ( view == "explorationTaskDuration" )
-    else if (view == "getTaskDuration") {
-      retFunction({Clingo::Number(
-          realGameTimeToAspGameTime(FetchProductTaskDuration))});
-      return;
-    } // if ( view == "getTaskDuration" )
-    else if (view == "prepareCSTaskDuration") {
-      retFunction(
-          {Clingo::Number(realGameTimeToAspGameTime(PrepareCSTaskDuration))});
-      return;
-    } // if ( view == "prepareCSTaskDuration" )
-    else if (view == "mountCapTaskDuration") {
-      retFunction({Clingo::Number(
-          realGameTimeToAspGameTime(DeliverProductTaskDuration))});
-      return;
-    } // if ( view == "mountCapTaskDuration" )
-    else if (view == "mountRingTaskDuration") {
-      retFunction({Clingo::Number(
-          realGameTimeToAspGameTime(DeliverProductTaskDuration))});
-      return;
-    } // if ( view == "mountRingTaskDuration" )
-    else if (view == "feedRSTaskDuration") {
-      retFunction({Clingo::Number(
-          realGameTimeToAspGameTime(DeliverProductTaskDuration))});
-      return;
-    } // if ( view == "feedRSTaskDuration" )
-    else if (view == "deliverTaskDuration") {
-      retFunction({Clingo::Number(
-          realGameTimeToAspGameTime(DeliverProductTaskDuration))});
-      return;
-    } // if ( view == "deliverTaskDuration" )
-    else if (view == "getProductTaskDuration") {
-      retFunction({Clingo::Number(
-          realGameTimeToAspGameTime(FetchProductTaskDuration))});
-      return;
-    } // if ( view == "getProductTaskDuration" )
-    else if (view == "maxDriveDuration") {
-      retFunction(
-          {Clingo::Number(realGameTimeToAspGameTime(MaxDriveDuration))});
-      return;
-    } // else if ( view == "maxDriveDuration" )
-    else if (view == "maxProducts") {
-      retFunction({Clingo::Number(MaxProducts)});
-      return;
-    } // else if ( view == "maxProducts" )
-    else if (view == "robots") {
-      static const auto robots = [this](void) {
-        Clingo::SymbolVector ret;
-        ret.reserve(Robots.size());
+	switch (arguments.size()) {
+	case 0: {
+		if (view == "explorationTaskDuration") {
+			static const int dur = [this](void) {
+				char buffer[std::strlen(ConfigPrefix) + 40];
+				std::strcpy(buffer, ConfigPrefix);
+				std::strcpy(buffer + std::strlen(ConfigPrefix), "time-estimations/explore-zone");
+				return config->get_int(buffer);
+			}();
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(dur))});
+			return;
+		} // if ( view == "explorationTaskDuration" )
+		else if (view == "getTaskDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(FetchProductTaskDuration))});
+			return;
+		} // if ( view == "getTaskDuration" )
+		else if (view == "prepareCSTaskDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(PrepareCSTaskDuration))});
+			return;
+		} // if ( view == "prepareCSTaskDuration" )
+		else if (view == "mountCapTaskDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(DeliverProductTaskDuration))});
+			return;
+		} // if ( view == "mountCapTaskDuration" )
+		else if (view == "mountRingTaskDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(DeliverProductTaskDuration))});
+			return;
+		} // if ( view == "mountRingTaskDuration" )
+		else if (view == "feedRSTaskDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(DeliverProductTaskDuration))});
+			return;
+		} // if ( view == "feedRSTaskDuration" )
+		else if (view == "deliverTaskDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(DeliverProductTaskDuration))});
+			return;
+		} // if ( view == "deliverTaskDuration" )
+		else if (view == "getProductTaskDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(FetchProductTaskDuration))});
+			return;
+		} // if ( view == "getProductTaskDuration" )
+		else if (view == "maxDriveDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(MaxDriveDuration))});
+			return;
+		} // else if ( view == "maxDriveDuration" )
+		else if (view == "maxProducts") {
+			retFunction({Clingo::Number(MaxProducts)});
+			return;
+		} // else if ( view == "maxProducts" )
+		else if (view == "robots") {
+			static const auto robots = [this](void) {
+				Clingo::SymbolVector ret;
+				ret.reserve(Robots.size());
 
-        for (const auto &robot : PossibleRobots) {
-          ret.emplace_back(Clingo::String(robot.c_str()));
-        } // for ( const auto& robot : PossibleRobots )
-        return ret;
-      }();
-      retFunction({robots.data(), robots.size()});
-      return;
-    } // else if ( view == "robots" )
-    else if (view == "horizon") {
-      retFunction({Clingo::Number(realGameTimeToAspGameTime(LookAhaed))});
-      return;
-    } // else if ( view == "maxTicks" )
-    else if (view == "maxTaskDuration") {
-      retFunction({Clingo::Number(realGameTimeToAspGameTime(MaxTaskDuration))});
-      return;
-    } // else if ( view == "maxTaskDuration" )
-    else if (view == "maxOrders") {
-      retFunction({Clingo::Number(MaxOrders)});
-      return;
-    } // else if ( view == "maxOrders" )
-    else if (view == "maxQuantity") {
-      retFunction({Clingo::Number(MaxQuantity)});
-      return;
-    } // else if ( view == "maxQuantity" )
-    else if (view == "minDeliveryTime") {
-      retFunction({Clingo::Number(realGameTimeToAspGameTime(ExplorationTime))});
-      return;
-    } // else if ( view == "minDeliveryTime" )
-    else if (view == "maxDeliveryTime") {
-      retFunction({Clingo::Number(realGameTimeToAspGameTime(ProductionEnd))});
-      return;
-    } // else if ( view == "maxDeliveryTime" )
-    else if (view == "maxWorkingDuration") {
-      retFunction(
-          {Clingo::Number(realGameTimeToAspGameTime(MaxWorkingDuration))});
-      return;
-    } // else if ( view == "maxWorkingDuration" )
-    break;
-  } // case 0
-  case 1: {
-    if (view == "capColor") {
-      const auto index = arguments[0].number();
-      assert(index >= 1 && index <= 2);
-      retFunction({Clingo::String(CapColors[index - 1].Color)});
-      return;
-    } // if ( view == "capColor" )
-    else if (view == "clingoToASP") {
-      retFunction(
-          {Clingo::Number(realGameTimeToAspGameTime(arguments[0].number()))});
-      return;
-    } // else if ( view == "clingoToASP" )
-    else if (view == "machineWorkingDuration") {
-      retFunction({Clingo::Number(
-          realGameTimeToAspGameTime(WorkingDurations[arguments[0].string()]))});
-      return;
-    } // else if ( view == "machineWorkingDuration" )
-    break;
-  } // case 1
-  } // switch ( arguments.size() )
+				for (const auto &robot : PossibleRobots) {
+					ret.emplace_back(Clingo::String(robot.c_str()));
+				} // for ( const auto& robot : PossibleRobots )
+				return ret;
+			}();
+			retFunction({robots.data(), robots.size()});
+			return;
+		} // else if ( view == "robots" )
+		else if (view == "horizon") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(LookAhaed))});
+			return;
+		} // else if ( view == "maxTicks" )
+		else if (view == "maxTaskDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(MaxTaskDuration))});
+			return;
+		} // else if ( view == "maxTaskDuration" )
+		else if (view == "maxOrders") {
+			retFunction({Clingo::Number(MaxOrders)});
+			return;
+		} // else if ( view == "maxOrders" )
+		else if (view == "maxQuantity") {
+			retFunction({Clingo::Number(MaxQuantity)});
+			return;
+		} // else if ( view == "maxQuantity" )
+		else if (view == "minDeliveryTime") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(ExplorationTime))});
+			return;
+		} // else if ( view == "minDeliveryTime" )
+		else if (view == "maxDeliveryTime") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(ProductionEnd))});
+			return;
+		} // else if ( view == "maxDeliveryTime" )
+		else if (view == "maxWorkingDuration") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(MaxWorkingDuration))});
+			return;
+		} // else if ( view == "maxWorkingDuration" )
+		break;
+	} // case 0
+	case 1: {
+		if (view == "capColor") {
+			const auto index = arguments[0].number();
+			assert(index >= 1 && index <= 2);
+			retFunction({Clingo::String(CapColors[index - 1].Color)});
+			return;
+		} // if ( view == "capColor" )
+		else if (view == "clingoToASP") {
+			retFunction({Clingo::Number(realGameTimeToAspGameTime(arguments[0].number()))});
+			return;
+		} // else if ( view == "clingoToASP" )
+		else if (view == "machineWorkingDuration") {
+			retFunction(
+			  {Clingo::Number(realGameTimeToAspGameTime(WorkingDurations[arguments[0].string()]))});
+			return;
+		} // else if ( view == "machineWorkingDuration" )
+		break;
+	} // case 1
+	} // switch ( arguments.size() )
 
-  std::stringstream functionCall;
-  functionCall << name << '(';
-  auto sep = "";
-  for (const auto &argument : arguments) {
-    functionCall << sep << argument;
-    sep = ", ";
-  } // for ( const auto& argument : arguments )
-  functionCall << ')';
+	std::stringstream functionCall;
+	functionCall << name << '(';
+	auto sep = "";
+	for (const auto &argument : arguments) {
+		functionCall << sep << argument;
+		sep = ", ";
+	} // for ( const auto& argument : arguments )
+	functionCall << ')';
 
-  const auto functionCallStr(functionCall.str());
-  throw fawkes::Exception("Called function %s from %s:%d-%d, but there exists "
-                          "no definition of %s/%d!",
-                          functionCallStr.c_str(), loc.begin_file(),
-                          loc.begin_line(), loc.begin_column(), name,
-                          arguments.size());
-  return;
+	const auto functionCallStr(functionCall.str());
+	throw fawkes::Exception("Called function %s from %s:%d-%d, but there exists "
+	                        "no definition of %s/%d!",
+	                        functionCallStr.c_str(),
+	                        loc.begin_file(),
+	                        loc.begin_line(),
+	                        loc.begin_column(),
+	                        name,
+	                        arguments.size());
+	return;
 }
 
 /**
  * @brief Sets the team for the solver.
  */
-void AspPlannerThread::setTeam(void) {
-  MutexLocker aspLocker(clingo.objmutex_ptr());
-  clingo->ground({{"ourTeam", {Clingo::String(TeamColor)}}});
-  ProgramGrounded = true;
+void
+AspPlannerThread::setTeam(void)
+{
+	MutexLocker aspLocker(clingo.objmutex_ptr());
+	clingo->ground({{"ourTeam", {Clingo::String(TeamColor)}}});
+	ProgramGrounded = true;
 
-  fillNavgraphNodesForASP(true);
-  NodesToFind.clear();
-  NodesToFind.reserve(6);
-  for (const auto &machine : {"BS", "CS1", "CS2", "DS", "RS1", "RS2"}) {
-    NodesToFind.insert(std::string(TeamColor) + "-" + machine + "-I");
-  } // for ( const auto& machine : {"BS", "CS1", "CS2", "DS", "RS1", "RS2"} )
-  DeliveryLocation = generateLocationExternal(TeamColor, "DS", "I");
-  CapLocations[0] = generateLocationExternal(TeamColor, "CS1", "I");
-  CapLocations[1] = generateLocationExternal(TeamColor, "CS2", "I");
-  RingLocations[0] = generateLocationExternal(TeamColor, "RS1", "I");
-  RingLocations[1] = generateLocationExternal(TeamColor, "RS2", "I");
-  graph_changed();
-  logger->log_warn(LoggingComponent,
-                   "Setting UpdateNavgraphDistance from %s to true. %s",
-                   UpdateNavgraphDistances ? "true" : "false", __func__);
-  UpdateNavgraphDistances = true;
-  return;
+	fillNavgraphNodesForASP(true);
+	NodesToFind.clear();
+	NodesToFind.reserve(6);
+	for (const auto &machine : {"BS", "CS1", "CS2", "DS", "RS1", "RS2"}) {
+		NodesToFind.insert(std::string(TeamColor) + "-" + machine + "-I");
+	} // for ( const auto& machine : {"BS", "CS1", "CS2", "DS", "RS1", "RS2"} )
+	DeliveryLocation = generateLocationExternal(TeamColor, "DS", "I");
+	CapLocations[0]  = generateLocationExternal(TeamColor, "CS1", "I");
+	CapLocations[1]  = generateLocationExternal(TeamColor, "CS2", "I");
+	RingLocations[0] = generateLocationExternal(TeamColor, "RS1", "I");
+	RingLocations[1] = generateLocationExternal(TeamColor, "RS2", "I");
+	graph_changed();
+	logger->log_warn(LoggingComponent,
+	                 "Setting UpdateNavgraphDistance from %s to true. %s",
+	                 UpdateNavgraphDistances ? "true" : "false",
+	                 __func__);
+	UpdateNavgraphDistances = true;
+	return;
 }
 
 /**
  * @brief Unsets the team color, we have to restart all over again.
  */
-void AspPlannerThread::unsetTeam(void) {
-  // TODO: I think it is clear what to do.
-  throw fawkes::Exception(
-      "Should unset the team, but this is not implemented!");
-  return;
+void
+AspPlannerThread::unsetTeam(void)
+{
+	// TODO: I think it is clear what to do.
+	throw fawkes::Exception("Should unset the team, but this is not implemented!");
+	return;
 }
 
 /**
@@ -775,160 +787,147 @@ void AspPlannerThread::unsetTeam(void) {
  * @param[in] order The order.
  * @note Assumes the world mutex is locked!
  */
-void AspPlannerThread::addOrderToASP(const OrderInformation &order) {
-  Clingo::SymbolVector params = {
-      Clingo::Number(order.Number),
-      Clingo::Number(order.Quantity),
-      Clingo::String(order.Base),
-      Clingo::String(order.Cap),
-      Clingo::String(order.Rings[1]),
-      Clingo::String(order.Rings[2]),
-      Clingo::String(order.Rings[3]),
-      Clingo::Number(realGameTimeToAspGameTime(order.DeliveryBegin)),
-      Clingo::Number(realGameTimeToAspGameTime(order.DeliveryEnd))};
-  constexpr const char *reason = "New order";
+void
+AspPlannerThread::addOrderToASP(const OrderInformation &order)
+{
+	Clingo::SymbolVector  params = {Clingo::Number(order.Number),
+                                 Clingo::Number(order.Quantity),
+                                 Clingo::String(order.Base),
+                                 Clingo::String(order.Cap),
+                                 Clingo::String(order.Rings[1]),
+                                 Clingo::String(order.Rings[2]),
+                                 Clingo::String(order.Rings[3]),
+                                 Clingo::Number(realGameTimeToAspGameTime(order.DeliveryBegin)),
+                                 Clingo::Number(realGameTimeToAspGameTime(order.DeliveryEnd))};
+	constexpr const char *reason = "New order";
 
-  queueGround({"newOrder", std::move(params)}, reason,
-              InterruptSolving::Critical);
+	queueGround({"newOrder", std::move(params)}, reason, InterruptSolving::Critical);
 
-  for (const auto &color : BaseColors) {
-    queueRelease(Clingo::Function("base", {Clingo::Number(order.Number),
-                                           Clingo::String(color)}),
-                 reason);
-  } // for ( const auto& color : BaseColors )
+	for (const auto &color : BaseColors) {
+		queueRelease(Clingo::Function("base", {Clingo::Number(order.Number), Clingo::String(color)}),
+		             reason);
+	} // for ( const auto& color : BaseColors )
 
-  for (const auto &color : CapColors) {
-    queueRelease(Clingo::Function("cap", {Clingo::Number(order.Number),
-                                          Clingo::String(color.Color)}),
-                 reason);
-  } // for ( const auto& color : CapColors )
+	for (const auto &color : CapColors) {
+		queueRelease(Clingo::Function("cap",
+		                              {Clingo::Number(order.Number), Clingo::String(color.Color)}),
+		             reason);
+	} // for ( const auto& color : CapColors )
 
-  for (const auto &color : RingColors) {
-    for (auto ring = 1; ring <= 3; ++ring) {
-      queueRelease(Clingo::Function("ring", {Clingo::Number(order.Number),
-                                             Clingo::Number(ring),
-                                             Clingo::String(color.Color)}),
-                   reason);
-    } // for ( auto ring = 1; ring <= 3; ++ring )
-  }   // for ( const auto& color : RingColors )
+	for (const auto &color : RingColors) {
+		for (auto ring = 1; ring <= 3; ++ring) {
+			queueRelease(Clingo::Function("ring",
+			                              {Clingo::Number(order.Number),
+			                               Clingo::Number(ring),
+			                               Clingo::String(color.Color)}),
+			             reason);
+		} // for ( auto ring = 1; ring <= 3; ++ring )
+	}   // for ( const auto& color : RingColors )
 
-  for (auto qty = order.Quantity + 1; qty <= MaxQuantity; ++qty) {
-    for (auto ring = 1; ring <= 3; ++ring) {
-      for (const auto &location : RingLocations) {
-        queueRelease(
-            generateMountRingExternal(location, order.Number, qty, ring),
-            reason);
-      } // for ( const auto& location : RingLocations )
-    }   // for ( auto ring = 1; ring <= 3; ++ring )
-    for (const auto &location : CapLocations) {
-      queueRelease(generateMountCapExternal(location, order.Number, qty),
-                   reason);
-    } // for ( const auto& location : CapLocations )
-    queueRelease(generateDeliverExternal(DeliveryLocation, order.Number, qty),
-                 reason);
-    queueRelease(
-        generateLateDeliverExternal(DeliveryLocation, order.Number, qty),
-        reason);
-  } // for ( auto qty = order.Quantity + 1; qty <= MaxQuantity; ++qty )
+	for (auto qty = order.Quantity + 1; qty <= MaxQuantity; ++qty) {
+		for (auto ring = 1; ring <= 3; ++ring) {
+			for (const auto &location : RingLocations) {
+				queueRelease(generateMountRingExternal(location, order.Number, qty, ring), reason);
+			} // for ( const auto& location : RingLocations )
+		}   // for ( auto ring = 1; ring <= 3; ++ring )
+		for (const auto &location : CapLocations) {
+			queueRelease(generateMountCapExternal(location, order.Number, qty), reason);
+		} // for ( const auto& location : CapLocations )
+		queueRelease(generateDeliverExternal(DeliveryLocation, order.Number, qty), reason);
+		queueRelease(generateLateDeliverExternal(DeliveryLocation, order.Number, qty), reason);
+	} // for ( auto qty = order.Quantity + 1; qty <= MaxQuantity; ++qty )
 
-  for (auto qty = 1; qty <= order.Quantity; ++qty) {
-    const auto capIndex =
-        std::find_if(CapColors.begin(), CapColors.end(),
-                     [&order](const CapColorInformation &info) noexcept {
-                       return info.Color == order.Cap;
-                     })
-            ->Machine[2] -
-        '1';
+	for (auto qty = 1; qty <= order.Quantity; ++qty) {
+		const auto capIndex =
+		  std::find_if(
+		    CapColors.begin(),
+		    CapColors.end(),
+		    [&order](const CapColorInformation &info) noexcept { return info.Color == order.Cap; })
+		    ->Machine[2]
+		  - '1';
 
-    OrderTasks tasks{
-        Clingo::Symbol(),
-        Clingo::Symbol(),
-        Clingo::Symbol(),
-        Clingo::Symbol(),
-        generateMountCapExternal(CapLocations[capIndex], order.Number, qty),
-        generateDeliverExternal(DeliveryLocation, order.Number, qty),
-        generateLateDeliverExternal(DeliveryLocation, order.Number, qty)};
+		OrderTasks tasks{Clingo::Symbol(),
+		                 Clingo::Symbol(),
+		                 Clingo::Symbol(),
+		                 Clingo::Symbol(),
+		                 generateMountCapExternal(CapLocations[capIndex], order.Number, qty),
+		                 generateDeliverExternal(DeliveryLocation, order.Number, qty),
+		                 generateLateDeliverExternal(DeliveryLocation, order.Number, qty)};
 
-    // Make an explicit copy because queueAssign takes an rvalue.
-    queueAssign(Clingo::Symbol(tasks.CapTask), reason);
-    queueAssign(Clingo::Symbol(tasks.DeliverTasks[0]), reason);
-    queueAssign(Clingo::Symbol(tasks.DeliverTasks[1]), reason);
-    queueRelease(
-        generateMountCapExternal(CapLocations[1 - capIndex], order.Number, qty),
-        reason);
+		// Make an explicit copy because queueAssign takes an rvalue.
+		queueAssign(Clingo::Symbol(tasks.CapTask), reason);
+		queueAssign(Clingo::Symbol(tasks.DeliverTasks[0]), reason);
+		queueAssign(Clingo::Symbol(tasks.DeliverTasks[1]), reason);
+		queueRelease(generateMountCapExternal(CapLocations[1 - capIndex], order.Number, qty), reason);
 
-    auto ring = 1;
-    for (; ring <= 3; ++ring) {
-      const auto &color(order.Rings[ring]);
-      if (color == "none") {
-        break;
-      } // if ( color == "none" )
+		auto ring = 1;
+		for (; ring <= 3; ++ring) {
+			const auto &color(order.Rings[ring]);
+			if (color == "none") {
+				break;
+			} // if ( color == "none" )
 
-      const auto ringIndex =
-          std::find_if(
-              RingColors.begin(), RingColors.end(),
-              [&order, &color ](const RingColorInformation &info) noexcept {
-                return info.Color == color;
-              })
-              ->Machine[2] -
-          '1';
+			const auto ringIndex = std::find_if(
+			                         RingColors.begin(),
+			                         RingColors.end(),
+			                         [&order, &color](const RingColorInformation &info) noexcept {
+				                         return info.Color == color;
+			                         })
+			                         ->Machine[2]
+			                       - '1';
 
-      tasks.RingTasks[ring] = generateMountRingExternal(
-          RingLocations[ringIndex], order.Number, qty, ring);
-      queueAssign(Clingo::Symbol(tasks.RingTasks[ring]), reason);
-      queueRelease(generateMountRingExternal(RingLocations[1 - ringIndex],
-                                             order.Number, qty, ring),
-                   reason);
-    } // for ( auto ring = 1; ring <= 3; ++ring )
+			tasks.RingTasks[ring] =
+			  generateMountRingExternal(RingLocations[ringIndex], order.Number, qty, ring);
+			queueAssign(Clingo::Symbol(tasks.RingTasks[ring]), reason);
+			queueRelease(generateMountRingExternal(RingLocations[1 - ringIndex], order.Number, qty, ring),
+			             reason);
+		} // for ( auto ring = 1; ring <= 3; ++ring )
 
-    for (; ring <= 3; ++ring) {
-      for (const auto &location : RingLocations) {
-        queueRelease(
-            generateMountRingExternal(location, order.Number, qty, ring),
-            reason);
-      } // for ( const auto& location : RingLocations )
-    }   // for ( ; ring <= 3; ++ring )
+		for (; ring <= 3; ++ring) {
+			for (const auto &location : RingLocations) {
+				queueRelease(generateMountRingExternal(location, order.Number, qty, ring), reason);
+			} // for ( const auto& location : RingLocations )
+		}   // for ( ; ring <= 3; ++ring )
 
-    OrderTaskMap.insert({{order.Number, qty}, std::move(tasks)});
-  } // for ( auto qty = 1; qty <= order.Quantity; ++qty )
-  return;
+		OrderTaskMap.insert({{order.Number, qty}, std::move(tasks)});
+	} // for ( auto qty = 1; qty <= order.Quantity; ++qty )
+	return;
 }
 
 /**
  * @brief Adds the ring info to asp.
  * @param[in] info The info.
  */
-void AspPlannerThread::addRingColorToASP(const RingColorInformation &info) {
-  const auto color(Clingo::String(info.Color));
-  constexpr const char *reason = "Ring color";
-  queueGround(
-      {"setRingInfo",
-       {color, Clingo::Number(info.Cost), Clingo::String(info.Machine)}},
-      reason);
+void
+AspPlannerThread::addRingColorToASP(const RingColorInformation &info)
+{
+	const auto            color(Clingo::String(info.Color));
+	constexpr const char *reason = "Ring color";
+	queueGround({"setRingInfo", {color, Clingo::Number(info.Cost), Clingo::String(info.Machine)}},
+	            reason);
 
-  for (const auto &machine : {"RS1", "RS2"}) {
-    queueRelease(Clingo::Function("ringStationAssignment",
-                                  {Clingo::String(machine), color}),
-                 reason);
-  } // for ( const auto& machine : {"RS1", "RS2"} )
+	for (const auto &machine : {"RS1", "RS2"}) {
+		queueRelease(Clingo::Function("ringStationAssignment", {Clingo::String(machine), color}),
+		             reason);
+	} // for ( const auto& machine : {"RS1", "RS2"} )
 
-  for (auto cost = 0; cost <= 2; ++cost) {
-    queueRelease(
-        Clingo::Function("ringColorCost", {color, Clingo::Number(cost)}),
-        reason);
-  } // for ( auto cost = 0; cost <= 2; ++cost )
-  return;
+	for (auto cost = 0; cost <= 2; ++cost) {
+		queueRelease(Clingo::Function("ringColorCost", {color, Clingo::Number(cost)}), reason);
+	} // for ( auto cost = 0; cost <= 2; ++cost )
+	return;
 }
 
 /**
  * @brief Adds a zone to explore.
  * @param[in] zone The zone number.
  */
-void AspPlannerThread::addZoneToExplore(const int zone) {
-  assert(zone >= 1 && zone <= 24);
-  queueAssign(generateExploreLocationExternal(zone), "Zone added");
-  queueAssign(generateExploreTaskExternal(zone), "Zone added");
-  return;
+void
+AspPlannerThread::addZoneToExplore(const int zone)
+{
+	assert(zone >= 1 && zone <= 24);
+	queueAssign(generateExploreLocationExternal(zone), "Zone added");
+	queueAssign(generateExploreTaskExternal(zone), "Zone added");
+	return;
 }
 
 /**
@@ -937,80 +936,78 @@ void AspPlannerThread::addZoneToExplore(const int zone) {
  * @param[in] removeAndFillNodes If @link ZonesToExplore the vector @endlink
  * should be cleaned and the fillNavgraphNodesForASP() should be called.
  */
-void AspPlannerThread::releaseZone(const int zone,
-                                   const bool removeAndFillNodes) {
-  assert(zone >= 1 && zone <= 24);
-  if (removeAndFillNodes) {
-    MutexLocker locker(&WorldMutex);
-    ZonesToExplore.erase(
-        std::find(ZonesToExplore.begin(), ZonesToExplore.end(), zone));
-    fillNavgraphNodesForASP(false);
-  } // if ( removeAndFillNodes )
-  queueRelease(generateExploreLocationExternal(zone), "Zone released");
-  queueRelease(generateExploreTaskExternal(zone), "Zone released");
-  return;
+void
+AspPlannerThread::releaseZone(const int zone, const bool removeAndFillNodes)
+{
+	assert(zone >= 1 && zone <= 24);
+	if (removeAndFillNodes) {
+		MutexLocker locker(&WorldMutex);
+		ZonesToExplore.erase(std::find(ZonesToExplore.begin(), ZonesToExplore.end(), zone));
+		fillNavgraphNodesForASP(false);
+	} // if ( removeAndFillNodes )
+	queueRelease(generateExploreLocationExternal(zone), "Zone released");
+	queueRelease(generateExploreTaskExternal(zone), "Zone released");
+	return;
 }
 
-static inline Clingo::SymbolVector splitParameters(string_view string) {
-  std::vector<Clingo::Symbol> ret;
-  ret.reserve(std::count(string.begin(), string.end(), ','));
+static inline Clingo::SymbolVector
+splitParameters(string_view string)
+{
+	std::vector<Clingo::Symbol> ret;
+	ret.reserve(std::count(string.begin(), string.end(), ','));
 
-  auto comma = string.find(',');
-  auto paranthesis = string.find('(');
-  while (comma != string_view::npos || paranthesis != string_view::npos) {
-    if (comma != string_view::npos && comma < paranthesis) {
-      auto param = string.substr(0, comma);
+	auto comma       = string.find(',');
+	auto paranthesis = string.find('(');
+	while (comma != string_view::npos || paranthesis != string_view::npos) {
+		if (comma != string_view::npos && comma < paranthesis) {
+			auto param = string.substr(0, comma);
 
-      if (std::isdigit(param[0])) {
-        char *unused;
-        ret.push_back(Clingo::Number(std::strtol(param.data(), &unused, 10)));
-      } // if ( std::isdigit(param[0]) )
-      else {
-        assert(param[0] == '"');
-        ret.push_back(
-            Clingo::String(std::string(param.substr(1, param.size() - 2))));
-      } // else -> if ( std::isdigit(param[0]) )
-      string.remove_prefix(comma + 1);
-    } // if ( comma != string_view::npos && comma < paranthesis )
-    else if (paranthesis != string_view::npos) {
-      auto index = paranthesis + 1;
-      for (auto count = 1; count != 0; ++index) {
-        if (string[index] == ')') {
-          --count;
-        } // if ( string[index] == ')' )
-        else if (string[index] == '(') {
-          ++count;
-        } // else if ( string[index] == '(' )
-      } // for ( auto count = 1u, index = paranthesis + 1; count != 0; ++index )
+			if (std::isdigit(param[0])) {
+				char *unused;
+				ret.push_back(Clingo::Number(std::strtol(param.data(), &unused, 10)));
+			} // if ( std::isdigit(param[0]) )
+			else {
+				assert(param[0] == '"');
+				ret.push_back(Clingo::String(std::string(param.substr(1, param.size() - 2))));
+			} // else -> if ( std::isdigit(param[0]) )
+			string.remove_prefix(comma + 1);
+		} // if ( comma != string_view::npos && comma < paranthesis )
+		else if (paranthesis != string_view::npos) {
+			auto index = paranthesis + 1;
+			for (auto count = 1; count != 0; ++index) {
+				if (string[index] == ')') {
+					--count;
+				} // if ( string[index] == ')' )
+				else if (string[index] == '(') {
+					++count;
+				} // else if ( string[index] == '(' )
+			}   // for ( auto count = 1u, index = paranthesis + 1; count != 0; ++index )
 
-      const auto substrStart(paranthesis + 1),
-          substrEnd(index - 1 - substrStart);
-      ret.push_back(Clingo::Function(
-          std::string(string.substr(0, paranthesis)).c_str(),
-          splitParameters(string.substr(substrStart, substrEnd))));
+			const auto substrStart(paranthesis + 1), substrEnd(index - 1 - substrStart);
+			ret.push_back(Clingo::Function(std::string(string.substr(0, paranthesis)).c_str(),
+			                               splitParameters(string.substr(substrStart, substrEnd))));
 
-      /* +1 for the following comma, but when there is no comma, i.e. this
+			/* +1 for the following comma, but when there is no comma, i.e. this
        * function was the last parameter bound the removed size by the strings
        * size. Removing more is undefined. */
-      string.remove_prefix(std::min(index + 1, string.size()));
-    } // else if ( paranthesis != string_view::npos )
-    comma = string.find(',');
-    paranthesis = string.find('(');
-  } // while ( comma != string_view::npos || paranthesis != string_view::npos )
+			string.remove_prefix(std::min(index + 1, string.size()));
+		} // else if ( paranthesis != string_view::npos )
+		comma       = string.find(',');
+		paranthesis = string.find('(');
+	} // while ( comma != string_view::npos || paranthesis != string_view::npos )
 
-  if (string.size() != 0) {
-    if (std::isdigit(string[0])) {
-      char *unused;
-      ret.push_back(Clingo::Number(std::strtol(string.data(), &unused, 10)));
-    } // if ( std::isdigit(string[0]) )
-    else {
-      assert(string[0] == '"');
-      ret.push_back(
-          Clingo::String(std::string(string.substr(1, string.size() - 2))));
-    } // else -> if ( std::isdigit(string[0]) )
-  }   // if ( string.size() != 0 )
+	if (string.size() != 0) {
+		if (std::isdigit(string[0])) {
+			char *unused;
+			ret.push_back(Clingo::Number(std::strtol(string.data(), &unused, 10)));
+		} // if ( std::isdigit(string[0]) )
+		else {
+			assert(string[0] == '"');
+			ret.push_back(Clingo::String(std::string(string.substr(1, string.size() - 2))));
+		} // else -> if ( std::isdigit(string[0]) )
+	}   // if ( string.size() != 0 )
 
-  return ret;
+	return ret;
 }
 
 /**
@@ -1019,87 +1016,86 @@ static inline Clingo::SymbolVector splitParameters(string_view string) {
  * @param[in] end The estimated end for the task.
  * @return The new description.
  */
-static inline TaskDescription createTaskDescription(const std::string &task,
-                                                    const int end) {
-  auto type = TaskDescription::None;
+static inline TaskDescription
+createTaskDescription(const std::string &task, const int end)
+{
+	auto type = TaskDescription::None;
 
-  string_view taskView(task);
-  const auto paramsBegin = taskView.find('(');
-  string_view taskName(taskView.substr(0, paramsBegin));
-  string_view params(taskView.substr(paramsBegin + 1));
-  // Remove the ) from the parameters.
-  params.remove_suffix(1);
+	string_view taskView(task);
+	const auto  paramsBegin = taskView.find('(');
+	string_view taskName(taskView.substr(0, paramsBegin));
+	string_view params(taskView.substr(paramsBegin + 1));
+	// Remove the ) from the parameters.
+	params.remove_suffix(1);
 
-  if (taskName == "deliver" || taskName == "lateDeliver") {
-    type = TaskDescription::Deliver;
-  } // if ( taskName == "deliver" || taskName == "lateDeliver" )
-  else if (taskName == "feedRS") {
-    type = TaskDescription::FeedRS;
-  } // else if ( taskName == "feedRS" )
-  else if (taskName == "getBase") {
-    type = TaskDescription::GetBase;
-  } // else if ( taskName == "getBase" )
-  else if (taskName == "getProduct") {
-    type = TaskDescription::GetProduct;
-  } // else if ( taskName == "getProduct" )
-  else if (taskName == "goto") {
-    type = TaskDescription::Goto;
-  } // else if ( taskName == "goto" )
-  else if (taskName == "mountCap") {
-    type = TaskDescription::MountCap;
-  } // else if ( taskName == "mountCap" )
-  else if (taskName == "mountRing") {
-    type = TaskDescription::MountRing;
-  } // else if ( taskName == "mountRing" )
-  else if (taskName == "prepareCS") {
-    type = TaskDescription::PrepareCS;
-  } // else if ( taskName == "prepareCS" )
-  else {
-    throw fawkes::Exception("Unknown task name: %s!",
-                            taskName.to_string().c_str());
-  } // else -> all tasks
+	if (taskName == "deliver" || taskName == "lateDeliver") {
+		type = TaskDescription::Deliver;
+	} // if ( taskName == "deliver" || taskName == "lateDeliver" )
+	else if (taskName == "feedRS") {
+		type = TaskDescription::FeedRS;
+	} // else if ( taskName == "feedRS" )
+	else if (taskName == "getBase") {
+		type = TaskDescription::GetBase;
+	} // else if ( taskName == "getBase" )
+	else if (taskName == "getProduct") {
+		type = TaskDescription::GetProduct;
+	} // else if ( taskName == "getProduct" )
+	else if (taskName == "goto") {
+		type = TaskDescription::Goto;
+	} // else if ( taskName == "goto" )
+	else if (taskName == "mountCap") {
+		type = TaskDescription::MountCap;
+	} // else if ( taskName == "mountCap" )
+	else if (taskName == "mountRing") {
+		type = TaskDescription::MountRing;
+	} // else if ( taskName == "mountRing" )
+	else if (taskName == "prepareCS") {
+		type = TaskDescription::PrepareCS;
+	} // else if ( taskName == "prepareCS" )
+	else {
+		throw fawkes::Exception("Unknown task name: %s!", taskName.to_string().c_str());
+	} // else -> all tasks
 
-  return TaskDescription{
-      type,
-      Clingo::Function(taskName.to_string().c_str(), splitParameters(params)),
-      end};
+	return TaskDescription{type,
+	                       Clingo::Function(taskName.to_string().c_str(), splitParameters(params)),
+	                       end};
 }
 
 /**
  * @brief Sets the interrupt flag, depending on the offset a task feedback has.
  * @param[in] offset The offset.
  */
-void AspPlannerThread::checkForInterruptBasedOnTimeOffset(int offset) {
-  auto getOffset = [this](const char *severity) {
-    constexpr auto infix = "/interrupt-thresholds/offset-";
-    return std::min(config->get_int(std::string(ConfigPrefix) + infix +
-                                    severity + "-absolute"),
-                    config->get_int(std::string(ConfigPrefix) + infix +
-                                    severity + "-percent") *
-                        TimeResolution / 100);
-  };
+void
+AspPlannerThread::checkForInterruptBasedOnTimeOffset(int offset)
+{
+	auto getOffset = [this](const char *severity) {
+		constexpr auto infix = "/interrupt-thresholds/offset-";
+		return std::min(config->get_int(std::string(ConfigPrefix) + infix + severity + "-absolute"),
+		                config->get_int(std::string(ConfigPrefix) + infix + severity + "-percent")
+		                  * TimeResolution / 100);
+	};
 
-  static const auto criticalOffset = getOffset("critical");
-  static const auto highlOffset = getOffset("high");
-  static const auto normalOffset = getOffset("normal");
-  static const auto justStarteOffset = getOffset("started");
+	static const auto criticalOffset   = getOffset("critical");
+	static const auto highlOffset      = getOffset("high");
+	static const auto normalOffset     = getOffset("normal");
+	static const auto justStarteOffset = getOffset("started");
 
-  logger->log_info(LoggingComponent, "Plan-Feedback offset is %d.", offset);
-  offset = std::abs(offset);
+	logger->log_info(LoggingComponent, "Plan-Feedback offset is %d.", offset);
+	offset = std::abs(offset);
 
-  if (offset >= criticalOffset) {
-    setInterrupt(InterruptSolving::Critical, "Very high plan offset");
-  } // if ( offset >= criticalOffset )
-  else if (offset >= highlOffset) {
-    setInterrupt(InterruptSolving::High, "High plan offset");
-  } // else if ( offset >= highlOffset )
-  else if (offset >= normalOffset) {
-    setInterrupt(InterruptSolving::Normal, "Plan offset");
-  } // else if ( offset >= normalOffset )
-  else if (offset >= justStarteOffset) {
-    setInterrupt(InterruptSolving::JustStarted, "Very small offset");
-  } // else if ( offset >= justStarteOffset )
-  return;
+	if (offset >= criticalOffset) {
+		setInterrupt(InterruptSolving::Critical, "Very high plan offset");
+	} // if ( offset >= criticalOffset )
+	else if (offset >= highlOffset) {
+		setInterrupt(InterruptSolving::High, "High plan offset");
+	} // else if ( offset >= highlOffset )
+	else if (offset >= normalOffset) {
+		setInterrupt(InterruptSolving::Normal, "Plan offset");
+	} // else if ( offset >= normalOffset )
+	else if (offset >= justStarteOffset) {
+		setInterrupt(InterruptSolving::JustStarted, "Very small offset");
+	} // else if ( offset >= justStarteOffset )
+	return;
 }
 
 /**
@@ -1109,69 +1105,70 @@ void AspPlannerThread::checkForInterruptBasedOnTimeOffset(int offset) {
  * @param[in] begin At which point in time the task was begun.
  * @param[in] end At which point in time the task will end.
  */
-void AspPlannerThread::robotBegunWithTask(const std::string &robot,
-                                          const std::string &task,
-                                          const int begin, const int end) {
-  MutexLocker worldLocker(&WorldMutex);
-  MutexLocker planLocker(&PlanMutex);
+void
+AspPlannerThread::robotBegunWithTask(const std::string &robot,
+                                     const std::string &task,
+                                     const int          begin,
+                                     const int          end)
+{
+	MutexLocker worldLocker(&WorldMutex);
+	MutexLocker planLocker(&PlanMutex);
 
-  auto &robotPlan(Plan[robot]);
-  auto &robotInfo(Robots[robot]);
+	auto &robotPlan(Plan[robot]);
+	auto &robotInfo(Robots[robot]);
 
-  assert(robotPlan.CurrentTask.empty());
-  assert(!robotInfo.Doing.isValid());
+	assert(robotPlan.CurrentTask.empty());
+	assert(!robotInfo.Doing.isValid());
 
-  auto &firstNotDoneTask(robotPlan.Tasks[robotPlan.FirstNotDone]);
+	auto &firstNotDoneTask(robotPlan.Tasks[robotPlan.FirstNotDone]);
 
-  if (firstNotDoneTask.Task != task) {
-    logger->log_error(LoggingComponent,
-                      "Plan invalid, the robot started another task.");
-    firstNotDoneTask.Task = task;
-    firstNotDoneTask.Begin = begin;
-    firstNotDoneTask.End = end;
-    setInterrupt(InterruptSolving::Critical, "Robot started \"wrong\" task");
-  } // if ( firstNotDoneTask.Task != task )
+	if (firstNotDoneTask.Task != task) {
+		logger->log_error(LoggingComponent, "Plan invalid, the robot started another task.");
+		firstNotDoneTask.Task  = task;
+		firstNotDoneTask.Begin = begin;
+		firstNotDoneTask.End   = end;
+		setInterrupt(InterruptSolving::Critical, "Robot started \"wrong\" task");
+	} // if ( firstNotDoneTask.Task != task )
 
-  robotPlan.CurrentTask = task;
-  firstNotDoneTask.Begun = true;
-  const auto offset = begin - firstNotDoneTask.Begin;
-  static_assert(std::is_signed<decltype(offset)>::value,
-                "Offset has to have a sign!");
-  firstNotDoneTask.Begin = begin;
-  planLocker.unlock();
-  worldLocker.unlock();
-  checkForInterruptBasedOnTimeOffset(offset);
-  worldLocker.relock();
-  planLocker.relock();
+	robotPlan.CurrentTask  = task;
+	firstNotDoneTask.Begun = true;
+	const auto offset      = begin - firstNotDoneTask.Begin;
+	static_assert(std::is_signed<decltype(offset)>::value, "Offset has to have a sign!");
+	firstNotDoneTask.Begin = begin;
+	planLocker.unlock();
+	worldLocker.unlock();
+	checkForInterruptBasedOnTimeOffset(offset);
+	worldLocker.relock();
+	planLocker.relock();
 
-  robotInfo.Doing = createTaskDescription(task, firstNotDoneTask.End);
+	robotInfo.Doing = createTaskDescription(task, firstNotDoneTask.End);
 
-  const auto location = robotInfo.Doing.TaskSymbol.arguments().front();
-  const auto iter = LocationInUse.find(location);
+	const auto location = robotInfo.Doing.TaskSymbol.arguments().front();
+	const auto iter     = LocationInUse.find(location);
 
-  if (iter != LocationInUse.end() && iter->second != robot) {
-    logger->log_warn(LoggingComponent,
-                     "The robots %s and %s are trying to use %s! Tell %s to "
-                     "stop immediately and delete its current plan!",
-                     iter->second.c_str(), robot.c_str(),
-                     location.to_string().c_str(), robot.c_str());
-    robotPlan.CurrentTask.clear();
-    firstNotDoneTask.Begun = false;
-    robotInfo.Doing = {};
-    tellRobotToStop(robot);
-    setInterrupt(InterruptSolving::Critical, "Location conflict");
-    for (auto index = robotPlan.FirstNotDone; index < robotPlan.Tasks.size();
-         ++index) {
-      removeFromPlanDB(robot, index);
-    } // for ( auto index = robotPlan.FirstNotDone; index <
-      // robotPlan.Tasks.size(); ++index )
-    robotPlan.Tasks.erase(robotPlan.Tasks.begin() + robotPlan.FirstNotDone,
-                          robotPlan.Tasks.end());
-  } // if ( iter != LocationInUse.end() && iter->second != robot )
-  else {
-    LocationInUse.insert({location, robot});
-  } // else -> if ( iter != LocationInUse.end() && iter->second != robot )
-  return;
+	if (iter != LocationInUse.end() && iter->second != robot) {
+		logger->log_warn(LoggingComponent,
+		                 "The robots %s and %s are trying to use %s! Tell %s to "
+		                 "stop immediately and delete its current plan!",
+		                 iter->second.c_str(),
+		                 robot.c_str(),
+		                 location.to_string().c_str(),
+		                 robot.c_str());
+		robotPlan.CurrentTask.clear();
+		firstNotDoneTask.Begun = false;
+		robotInfo.Doing        = {};
+		tellRobotToStop(robot);
+		setInterrupt(InterruptSolving::Critical, "Location conflict");
+		for (auto index = robotPlan.FirstNotDone; index < robotPlan.Tasks.size(); ++index) {
+			removeFromPlanDB(robot, index);
+		} // for ( auto index = robotPlan.FirstNotDone; index <
+		// robotPlan.Tasks.size(); ++index )
+		robotPlan.Tasks.erase(robotPlan.Tasks.begin() + robotPlan.FirstNotDone, robotPlan.Tasks.end());
+	} // if ( iter != LocationInUse.end() && iter->second != robot )
+	else {
+		LocationInUse.insert({location, robot});
+	} // else -> if ( iter != LocationInUse.end() && iter->second != robot )
+	return;
 }
 
 /**
@@ -1180,31 +1177,32 @@ void AspPlannerThread::robotBegunWithTask(const std::string &robot,
  * @param[in] task The task.
  * @param[in] end The new estimated end time.
  */
-void AspPlannerThread::robotUpdatesTaskTimeEstimation(const std::string &robot,
-                                                      const std::string &task,
-                                                      const int end) {
-  MutexLocker worldLocker(&WorldMutex);
-  MutexLocker planLocker(&PlanMutex);
+void
+AspPlannerThread::robotUpdatesTaskTimeEstimation(const std::string &robot,
+                                                 const std::string &task,
+                                                 const int          end)
+{
+	MutexLocker worldLocker(&WorldMutex);
+	MutexLocker planLocker(&PlanMutex);
 
-  auto &robotPlan(Plan[robot]);
-  auto &robotInfo(Robots[robot]);
+	auto &robotPlan(Plan[robot]);
+	auto &robotInfo(Robots[robot]);
 
-  assert(robotPlan.CurrentTask == task);
-  assert(robotPlan.Tasks[robotPlan.FirstNotDone].Task == task);
-  assert(robotInfo.Doing.isValid());
+	assert(robotPlan.CurrentTask == task);
+	assert(robotPlan.Tasks[robotPlan.FirstNotDone].Task == task);
+	assert(robotInfo.Doing.isValid());
 
-  const auto offset = end - robotPlan.Tasks[robotPlan.FirstNotDone].End;
-  static_assert(std::is_signed<decltype(offset)>::value,
-                "Offset has to have a sign!");
-  /* Do NOT update the end value, because we calculate the offset based on that.
+	const auto offset = end - robotPlan.Tasks[robotPlan.FirstNotDone].End;
+	static_assert(std::is_signed<decltype(offset)>::value, "Offset has to have a sign!");
+	/* Do NOT update the end value, because we calculate the offset based on that.
    * If we receive multiple small offsets that do not trigger replaning this
    * does not work as intended. robotPlan.Tasks[robotPlan.FirstNotDone].End =
    * end; */
-  robotInfo.Doing.EstimatedEnd = end;
-  planLocker.unlock();
-  worldLocker.unlock();
-  checkForInterruptBasedOnTimeOffset(offset);
-  return;
+	robotInfo.Doing.EstimatedEnd = end;
+	planLocker.unlock();
+	worldLocker.unlock();
+	checkForInterruptBasedOnTimeOffset(offset);
+	return;
 }
 
 /**
@@ -1214,224 +1212,227 @@ void AspPlannerThread::robotUpdatesTaskTimeEstimation(const std::string &robot,
  * @param[in] end At which point in time the task was finished.
  * @param[in] success If the task was executed succesful.
  */
-void AspPlannerThread::robotFinishedTask(const std::string &robot,
-                                         const std::string &task, const int end,
-                                         const bool success) {
-  MutexLocker worldLocker(&WorldMutex);
-  MutexLocker planLocker(&PlanMutex);
+void
+AspPlannerThread::robotFinishedTask(const std::string &robot,
+                                    const std::string &task,
+                                    const int          end,
+                                    const bool         success)
+{
+	MutexLocker worldLocker(&WorldMutex);
+	MutexLocker planLocker(&PlanMutex);
 
-  auto &robotPlan(Plan[robot]);
-  auto &robotInfo(Robots[robot]);
+	auto &robotPlan(Plan[robot]);
+	auto &robotInfo(Robots[robot]);
 
-  auto &firstNotDoneTask(robotPlan.Tasks[robotPlan.FirstNotDone]);
+	auto &firstNotDoneTask(robotPlan.Tasks[robotPlan.FirstNotDone]);
 
-  assert(robotPlan.CurrentTask == task);
-  assert(firstNotDoneTask.Task == task);
-  assert(robotInfo.Doing.isValid());
+	assert(robotPlan.CurrentTask == task);
+	assert(firstNotDoneTask.Task == task);
+	assert(robotInfo.Doing.isValid());
 
-  const auto offset = end - firstNotDoneTask.End;
-  static_assert(std::is_signed<decltype(offset)>::value,
-                "Offset has to have a sign!");
-  firstNotDoneTask.End = end;
-  planLocker.unlock();
-  worldLocker.unlock();
-  checkForInterruptBasedOnTimeOffset(offset);
-  worldLocker.relock();
-  planLocker.relock();
+	const auto offset = end - firstNotDoneTask.End;
+	static_assert(std::is_signed<decltype(offset)>::value, "Offset has to have a sign!");
+	firstNotDoneTask.End = end;
+	planLocker.unlock();
+	worldLocker.unlock();
+	checkForInterruptBasedOnTimeOffset(offset);
+	worldLocker.relock();
+	planLocker.relock();
 
-  firstNotDoneTask.Done = true;
-  ++robotPlan.FirstNotDone;
-  robotPlan.CurrentTask.clear();
+	firstNotDoneTask.Done = true;
+	++robotPlan.FirstNotDone;
+	robotPlan.CurrentTask.clear();
 
-  const auto location = robotInfo.Doing.TaskSymbol.arguments().front();
-  assert(LocationInUse[location] == robot);
-  LocationInUse.erase(location);
+	const auto location = robotInfo.Doing.TaskSymbol.arguments().front();
+	assert(LocationInUse[location] == robot);
+	LocationInUse.erase(location);
 
-  if (!success) {
-    robotInfo.Doing = {};
-    firstNotDoneTask.Failed = true;
-    setInterrupt(InterruptSolving::Critical, "Task failed");
-    for (auto i = robotPlan.FirstNotDone; i < robotPlan.Tasks.size(); ++i) {
-      removeFromPlanDB(robot, i);
-    } // for ( auto i = robotPlan.FirstNotDone; i < robotPlan.Tasks.size(); ++i
-      // )
-    robotPlan.Tasks.erase(robotPlan.Tasks.begin() + robotPlan.FirstNotDone,
-                          robotPlan.Tasks.end());
-    return;
-  } // if ( !success )
+	if (!success) {
+		robotInfo.Doing         = {};
+		firstNotDoneTask.Failed = true;
+		setInterrupt(InterruptSolving::Critical, "Task failed");
+		for (auto i = robotPlan.FirstNotDone; i < robotPlan.Tasks.size(); ++i) {
+			removeFromPlanDB(robot, i);
+		} // for ( auto i = robotPlan.FirstNotDone; i < robotPlan.Tasks.size(); ++i
+		// )
+		robotPlan.Tasks.erase(robotPlan.Tasks.begin() + robotPlan.FirstNotDone, robotPlan.Tasks.end());
+		return;
+	} // if ( !success )
 
-  auto generateProduct = [this](const string_view &machine,
-                                std::string &&baseColor) -> ProductIdentifier {
-    if (static_cast<int>(Products.size()) >= MaxProducts) {
-      logger->log_error(
-          LoggingComponent,
-          "Have to generate a product, this would be #%zu alive, but only "
-          "%d are configured. This product will not be part of the ASP program "
-          "until products with a lower "
-          "id will be destroyed!",
-          Products.size() + 1, MaxProducts);
-    } // if ( static_cast<int>(Products.size()) >= MaxProducts )
+	auto generateProduct = [this](const string_view &machine,
+	                              std::string &&     baseColor) -> ProductIdentifier {
+		if (static_cast<int>(Products.size()) >= MaxProducts) {
+			logger->log_error(LoggingComponent,
+			                  "Have to generate a product, this would be #%zu alive, but only "
+			                  "%d are configured. This product will not be part of the ASP program "
+			                  "until products with a lower "
+			                  "id will be destroyed!",
+			                  Products.size() + 1,
+			                  MaxProducts);
+		} // if ( static_cast<int>(Products.size()) >= MaxProducts )
 
-    logger->log_info(
-        LoggingComponent, "%s generated product #%zu with base color %s at %d.",
-        machine.data(), Products.size(), baseColor.c_str(), GameTime);
-    Products.push_back({std::move(baseColor)});
-    return {static_cast<decltype(ProductIdentifier::ID)>(Products.size() - 1)};
-  };
-  auto destroyProduct = [this](const string_view &machine,
-                               const ProductIdentifier &id) {
-    logger->log_info(LoggingComponent, "%s destroies product #%d at %d.",
-                     machine.data(), id.ID, GameTime);
-    Products.erase(Products.begin() + id.ID);
-    for (auto &pair : Robots) {
-      if (pair.second.Holding.ID > id.ID) {
-        --pair.second.Holding.ID;
-      } // if ( pair.second.Holding.ID > id.ID )
-    }   // for ( auto& pair : Robots )
-    for (auto &pair : Machines) {
-      if (pair.second.Storing.ID > id.ID) {
-        --pair.second.Storing.ID;
-      } // if ( pair.second.Storing.ID > id.ID )
-    }   // for ( auto& pair : Machines )
-    return;
-  };
+		logger->log_info(LoggingComponent,
+		                 "%s generated product #%zu with base color %s at %d.",
+		                 machine.data(),
+		                 Products.size(),
+		                 baseColor.c_str(),
+		                 GameTime);
+		Products.push_back({std::move(baseColor)});
+		return {static_cast<decltype(ProductIdentifier::ID)>(Products.size() - 1)};
+	};
+	auto destroyProduct = [this](const string_view &machine, const ProductIdentifier &id) {
+		logger->log_info(
+		  LoggingComponent, "%s destroies product #%d at %d.", machine.data(), id.ID, GameTime);
+		Products.erase(Products.begin() + id.ID);
+		for (auto &pair : Robots) {
+			if (pair.second.Holding.ID > id.ID) {
+				--pair.second.Holding.ID;
+			} // if ( pair.second.Holding.ID > id.ID )
+		}   // for ( auto& pair : Robots )
+		for (auto &pair : Machines) {
+			if (pair.second.Storing.ID > id.ID) {
+				--pair.second.Storing.ID;
+			} // if ( pair.second.Storing.ID > id.ID )
+		}   // for ( auto& pair : Machines )
+		return;
+	};
 
-  auto machinePickup = [this](const std::string &machine,
-                              const ProductIdentifier &id) {
-    auto &machineInfo(Machines[machine]);
-    assert(!machineInfo.Storing.isValid());
-    machineInfo.Storing = id;
-    machineInfo.WorkingUntil = GameTime + WorkingDurations[machine];
-    logger->log_info(
-        LoggingComponent, "Machine %s works on product #%d from %d until %d.",
-        machine.c_str(), id.ID, GameTime, machineInfo.WorkingUntil);
-    return;
-  };
+	auto machinePickup = [this](const std::string &machine, const ProductIdentifier &id) {
+		auto &machineInfo(Machines[machine]);
+		assert(!machineInfo.Storing.isValid());
+		machineInfo.Storing      = id;
+		machineInfo.WorkingUntil = GameTime + WorkingDurations[machine];
+		logger->log_info(LoggingComponent,
+		                 "Machine %s works on product #%d from %d until %d.",
+		                 machine.c_str(),
+		                 id.ID,
+		                 GameTime,
+		                 machineInfo.WorkingUntil);
+		return;
+	};
 
-  auto machineDrops = [this](const std::string &machine) {
-    auto &machineInfo(Machines[machine]);
-    assert(machineInfo.Storing.isValid());
-    auto id = machineInfo.Storing;
-    machineInfo.Storing = {};
-    machineInfo.WorkingUntil = 0;
-    logger->log_info(LoggingComponent,
-                     "Product #%d was taken from machine %s at %d.", id.ID,
-                     machine.c_str(), GameTime);
-    return id;
-  };
+	auto machineDrops = [this](const std::string &machine) {
+		auto &machineInfo(Machines[machine]);
+		assert(machineInfo.Storing.isValid());
+		auto id                  = machineInfo.Storing;
+		machineInfo.Storing      = {};
+		machineInfo.WorkingUntil = 0;
+		logger->log_info(LoggingComponent,
+		                 "Product #%d was taken from machine %s at %d.",
+		                 id.ID,
+		                 machine.c_str(),
+		                 GameTime);
+		return id;
+	};
 
-  auto robotPickups = [this, &robotInfo, &robot](const ProductIdentifier &id) {
-    assert(!robotInfo.Holding.isValid());
-    robotInfo.Holding = id;
-    logger->log_info(LoggingComponent, "Robot %s picks up product #%d at %d.",
-                     robot.c_str(), id.ID, GameTime);
-    return;
-  };
-  auto robotDrops = [this, &robotInfo, &robot](void) {
-    assert(robotInfo.Holding.isValid());
-    auto id = robotInfo.Holding;
-    robotInfo.Holding = {};
-    logger->log_info(LoggingComponent, "Robot %s drops product #%d at %d.",
-                     robot.c_str(), id.ID, GameTime);
-    return id;
-  };
+	auto robotPickups = [this, &robotInfo, &robot](const ProductIdentifier &id) {
+		assert(!robotInfo.Holding.isValid());
+		robotInfo.Holding = id;
+		logger->log_info(
+		  LoggingComponent, "Robot %s picks up product #%d at %d.", robot.c_str(), id.ID, GameTime);
+		return;
+	};
+	auto robotDrops = [this, &robotInfo, &robot](void) {
+		assert(robotInfo.Holding.isValid());
+		auto id           = robotInfo.Holding;
+		robotInfo.Holding = {};
+		logger->log_info(
+		  LoggingComponent, "Robot %s drops product #%d at %d.", robot.c_str(), id.ID, GameTime);
+		return id;
+	};
 
-  const decltype(auto) taskArguments(robotInfo.Doing.TaskSymbol.arguments());
-  const decltype(auto) machine(taskArguments[0].arguments()[1].string());
+	const decltype(auto) taskArguments(robotInfo.Doing.TaskSymbol.arguments());
+	const decltype(auto) machine(taskArguments[0].arguments()[1].string());
 
-  auto getOrder = [&taskArguments](void) {
-    return std::make_pair<int, int>(taskArguments[1].number(),
-                                    taskArguments[2].number());
-  };
+	auto getOrder = [&taskArguments](void) {
+		return std::make_pair<int, int>(taskArguments[1].number(), taskArguments[2].number());
+	};
 
-  constexpr const char *taskDoneReason = "Task done";
+	constexpr const char *taskDoneReason = "Task done";
 
-  switch (robotInfo.Doing.Type) {
-  case TaskDescription::None:
-    break; // Does not happen. (See assert above.)
-  case TaskDescription::Deliver: {
-    auto order(getOrder());
-    queueRelease(std::move(OrderTaskMap[order].DeliverTasks[0]),
-                 taskDoneReason);
-    queueRelease(std::move(OrderTaskMap[order].DeliverTasks[1]),
-                 taskDoneReason);
-    destroyProduct("DS", robotDrops());
-    break;
-  } // case TaskDescription::Deliver
-  case TaskDescription::FeedRS: {
-    const auto &product(Products[robotInfo.Holding.ID]);
-    if (!product.Rings[1].empty() || !product.Cap.empty()) {
-      logger->log_warn(LoggingComponent,
-                       "%s used a non trivial product to feed a ring station!",
-                       robot.c_str());
-    } // if ( !product.Rings[1].empty() || !product.Cap.empty() )
-    destroyProduct(machine, robotDrops());
-    auto &info(Machines[machine]);
-    assert(info.FillState <= 3);
-    ++info.FillState;
-    logger->log_info(LoggingComponent, "Fillstate of %s is now: %d", machine,
-                     info.FillState);
-    break;
-  } // case TaskDescription::FeedRS
-  case TaskDescription::GetBase:
-    robotPickups(generateProduct("BS", taskArguments[1].string()));
-    break;
-  case TaskDescription::GetProduct:
-    robotPickups(machineDrops(machine));
-    break;
-  case TaskDescription::Goto:
-    break; // The robots location will be fetched from the navgraph.
-  case TaskDescription::MountCap: {
-    auto &machineInfo(Machines[machine]);
-    assert(machineInfo.Prepared);
-    auto order(getOrder());
-    auto product = robotDrops();
-    assert(Products[product.ID].Cap.empty());
-    Products[product.ID].Cap = Orders[order.first].Cap;
-    queueRelease(std::move(OrderTaskMap[order].CapTask), taskDoneReason);
-    machinePickup(machine, product);
-    machineInfo.Prepared = false;
-    logger->log_info(LoggingComponent,
-                     "%s mounted a %s cap on product #%d at %d.", machine,
-                     Products[product.ID].Cap.c_str(), product.ID, GameTime);
-    break;
-  } // case TaskDescription::MountCap
-  case TaskDescription::MountRing: {
-    auto order(getOrder());
-    const auto ringNumber = taskArguments[3].number();
-    auto product = robotDrops();
-    assert(Products[product.ID].Rings[ringNumber].empty());
-    const auto ringColor = Orders[order.first].Rings[ringNumber];
-    auto &machineInfo(Machines[machine]);
-    const auto ringInfo =
-        std::find_if(RingColors.begin(), RingColors.end(),
-                     [&ringColor](const RingColorInformation &info) {
-                       return info.Color == ringColor;
-                     });
-    assert(machineInfo.FillState >= ringInfo->Cost);
-    Products[product.ID].Rings[ringNumber] =
-        Orders[order.first].Rings[ringNumber];
-    queueRelease(std::move(OrderTaskMap[order].RingTasks[ringNumber]),
-                 taskDoneReason);
-    machinePickup(machine, product);
-    machineInfo.FillState -= ringInfo->Cost;
-    logger->log_info(
-        LoggingComponent,
-        "%s mounted the %d. ring with color %s on product #%d at %d. "
-        "The new fillstate is %d.",
-        machine, ringNumber, Products[product.ID].Rings[ringNumber].c_str(),
-        product.ID, GameTime, machineInfo.FillState);
-    break;
-  } // case TaskDescription::MountRing
-  case TaskDescription::PrepareCS: {
-    auto &machineInfo(Machines[machine]);
-    assert(!machineInfo.Prepared);
-    machinePickup(machine, generateProduct(machine, "TRANSPARENT"));
-    machineInfo.Prepared = true;
-    logger->log_info(LoggingComponent, "Machine %s is now prepared.", machine);
-    break;
-  } // case TaskDescription::PrepareCS
-  } // switch ( robotInfo.Doing.Type )
-  robotInfo.Doing = {};
-  return;
+	switch (robotInfo.Doing.Type) {
+	case TaskDescription::None: break; // Does not happen. (See assert above.)
+	case TaskDescription::Deliver: {
+		auto order(getOrder());
+		queueRelease(std::move(OrderTaskMap[order].DeliverTasks[0]), taskDoneReason);
+		queueRelease(std::move(OrderTaskMap[order].DeliverTasks[1]), taskDoneReason);
+		destroyProduct("DS", robotDrops());
+		break;
+	} // case TaskDescription::Deliver
+	case TaskDescription::FeedRS: {
+		const auto &product(Products[robotInfo.Holding.ID]);
+		if (!product.Rings[1].empty() || !product.Cap.empty()) {
+			logger->log_warn(LoggingComponent,
+			                 "%s used a non trivial product to feed a ring station!",
+			                 robot.c_str());
+		} // if ( !product.Rings[1].empty() || !product.Cap.empty() )
+		destroyProduct(machine, robotDrops());
+		auto &info(Machines[machine]);
+		assert(info.FillState <= 3);
+		++info.FillState;
+		logger->log_info(LoggingComponent, "Fillstate of %s is now: %d", machine, info.FillState);
+		break;
+	} // case TaskDescription::FeedRS
+	case TaskDescription::GetBase:
+		robotPickups(generateProduct("BS", taskArguments[1].string()));
+		break;
+	case TaskDescription::GetProduct: robotPickups(machineDrops(machine)); break;
+	case TaskDescription::Goto: break; // The robots location will be fetched from the navgraph.
+	case TaskDescription::MountCap: {
+		auto &machineInfo(Machines[machine]);
+		assert(machineInfo.Prepared);
+		auto order(getOrder());
+		auto product = robotDrops();
+		assert(Products[product.ID].Cap.empty());
+		Products[product.ID].Cap = Orders[order.first].Cap;
+		queueRelease(std::move(OrderTaskMap[order].CapTask), taskDoneReason);
+		machinePickup(machine, product);
+		machineInfo.Prepared = false;
+		logger->log_info(LoggingComponent,
+		                 "%s mounted a %s cap on product #%d at %d.",
+		                 machine,
+		                 Products[product.ID].Cap.c_str(),
+		                 product.ID,
+		                 GameTime);
+		break;
+	} // case TaskDescription::MountCap
+	case TaskDescription::MountRing: {
+		auto       order(getOrder());
+		const auto ringNumber = taskArguments[3].number();
+		auto       product    = robotDrops();
+		assert(Products[product.ID].Rings[ringNumber].empty());
+		const auto ringColor = Orders[order.first].Rings[ringNumber];
+		auto &     machineInfo(Machines[machine]);
+		const auto ringInfo = std::find_if(RingColors.begin(),
+		                                   RingColors.end(),
+		                                   [&ringColor](const RingColorInformation &info) {
+			                                   return info.Color == ringColor;
+		                                   });
+		assert(machineInfo.FillState >= ringInfo->Cost);
+		Products[product.ID].Rings[ringNumber] = Orders[order.first].Rings[ringNumber];
+		queueRelease(std::move(OrderTaskMap[order].RingTasks[ringNumber]), taskDoneReason);
+		machinePickup(machine, product);
+		machineInfo.FillState -= ringInfo->Cost;
+		logger->log_info(LoggingComponent,
+		                 "%s mounted the %d. ring with color %s on product #%d at %d. "
+		                 "The new fillstate is %d.",
+		                 machine,
+		                 ringNumber,
+		                 Products[product.ID].Rings[ringNumber].c_str(),
+		                 product.ID,
+		                 GameTime,
+		                 machineInfo.FillState);
+		break;
+	} // case TaskDescription::MountRing
+	case TaskDescription::PrepareCS: {
+		auto &machineInfo(Machines[machine]);
+		assert(!machineInfo.Prepared);
+		machinePickup(machine, generateProduct(machine, "TRANSPARENT"));
+		machineInfo.Prepared = true;
+		logger->log_info(LoggingComponent, "Machine %s is now prepared.", machine);
+		break;
+	} // case TaskDescription::PrepareCS
+	} // switch ( robotInfo.Doing.Type )
+	robotInfo.Doing = {};
+	return;
 }

--- a/src/plugins/asp-planner/asp_planner_doc_and_config.cpp
+++ b/src/plugins/asp-planner/asp_planner_doc_and_config.cpp
@@ -489,100 +489,98 @@
 /**
  * @brief Reads the config and fills the members.
  */
-void AspPlannerThread::loadConfig(void) {
-  constexpr auto infixPlanner = "planner/";
-  constexpr auto infixTime = "time-estimations/";
-  constexpr auto infixCapStation = "cap-station/assigned-color/";
-  constexpr auto infixWorkingDuration = "working-durations/";
+void
+AspPlannerThread::loadConfig(void)
+{
+	constexpr auto infixPlanner         = "planner/";
+	constexpr auto infixTime            = "time-estimations/";
+	constexpr auto infixCapStation      = "cap-station/assigned-color/";
+	constexpr auto infixWorkingDuration = "working-durations/";
 
-  constexpr auto infixPlannerLen = std::strlen(infixPlanner),
-                 infixTimeLen = std::strlen(infixTime);
-  constexpr auto infixCapStationLen = std::strlen(infixCapStation);
-  constexpr auto infixWorkingDurationLen = std::strlen(infixWorkingDuration);
-  const auto prefixLen = std::strlen(ConfigPrefix);
+	constexpr auto infixPlannerLen = std::strlen(infixPlanner), infixTimeLen = std::strlen(infixTime);
+	constexpr auto infixCapStationLen      = std::strlen(infixCapStation);
+	constexpr auto infixWorkingDurationLen = std::strlen(infixWorkingDuration);
+	const auto     prefixLen               = std::strlen(ConfigPrefix);
 
-  char buffer[prefixLen +
-              std::max<size_t>({infixPlannerLen, infixTimeLen,
-                                infixCapStationLen, infixWorkingDurationLen}) +
-              20];
-  std::strcpy(buffer, ConfigPrefix);
+	char buffer[prefixLen
+	            + std::max<size_t>(
+	              {infixPlannerLen, infixTimeLen, infixCapStationLen, infixWorkingDurationLen})
+	            + 20];
+	std::strcpy(buffer, ConfigPrefix);
 
-  // The plain part.
-  auto suffix = buffer + prefixLen;
-  std::strcpy(suffix, "exploration-time");
-  ExplorationTime = config->get_int(buffer);
+	// The plain part.
+	auto suffix = buffer + prefixLen;
+	std::strcpy(suffix, "exploration-time");
+	ExplorationTime = config->get_int(buffer);
 
-  std::strcpy(suffix, "production-end");
-  ProductionEnd = ExplorationTime + config->get_int(buffer);
+	std::strcpy(suffix, "production-end");
+	ProductionEnd = ExplorationTime + config->get_int(buffer);
 
-  // The planner part.
-  suffix = buffer + prefixLen + infixPlannerLen;
-  std::strcpy(buffer + prefixLen, infixPlanner);
+	// The planner part.
+	suffix = buffer + prefixLen + infixPlannerLen;
+	std::strcpy(buffer + prefixLen, infixPlanner);
 
-  std::strcpy(suffix, "debug-level");
-  clingo->set_debug_level(
-      static_cast<fawkes::ClingoAccess::DebugLevel_t>(config->get_int(buffer)));
+	std::strcpy(suffix, "debug-level");
+	clingo->set_debug_level(static_cast<fawkes::ClingoAccess::DebugLevel_t>(config->get_int(buffer)));
 
-  std::strcpy(suffix, "max-orders");
-  MaxOrders = config->get_int(buffer);
-  std::strcpy(suffix, "max-products");
-  MaxProducts = config->get_int(buffer);
-  std::strcpy(suffix, "max-quantity");
-  MaxQuantity = config->get_int(buffer);
-  std::strcpy(suffix, "look-ahead");
-  LookAhaed = config->get_int(buffer);
-  std::strcpy(suffix, "time-resolution");
-  TimeResolution = config->get_int(buffer);
-  std::strcpy(suffix, "robots");
-  PossibleRobots = config->get_strings(buffer);
+	std::strcpy(suffix, "max-orders");
+	MaxOrders = config->get_int(buffer);
+	std::strcpy(suffix, "max-products");
+	MaxProducts = config->get_int(buffer);
+	std::strcpy(suffix, "max-quantity");
+	MaxQuantity = config->get_int(buffer);
+	std::strcpy(suffix, "look-ahead");
+	LookAhaed = config->get_int(buffer);
+	std::strcpy(suffix, "time-resolution");
+	TimeResolution = config->get_int(buffer);
+	std::strcpy(suffix, "robots");
+	PossibleRobots = config->get_strings(buffer);
 
-  // The time-estimation part.
-  suffix = buffer + prefixLen + infixTimeLen;
-  std::strcpy(buffer + prefixLen, infixTime);
+	// The time-estimation part.
+	suffix = buffer + prefixLen + infixTimeLen;
+	std::strcpy(buffer + prefixLen, infixTime);
 
-  std::strcpy(suffix, "deliver-product");
-  DeliverProductTaskDuration = config->get_int(buffer);
-  std::strcpy(suffix, "fetch-product");
-  FetchProductTaskDuration = config->get_int(buffer);
-  std::strcpy(suffix, "max-drive-duration");
-  MaxDriveDuration = config->get_int(buffer);
-  std::strcpy(suffix, "prepare-cs");
-  PrepareCSTaskDuration = config->get_int(buffer);
+	std::strcpy(suffix, "deliver-product");
+	DeliverProductTaskDuration = config->get_int(buffer);
+	std::strcpy(suffix, "fetch-product");
+	FetchProductTaskDuration = config->get_int(buffer);
+	std::strcpy(suffix, "max-drive-duration");
+	MaxDriveDuration = config->get_int(buffer);
+	std::strcpy(suffix, "prepare-cs");
+	PrepareCSTaskDuration = config->get_int(buffer);
 
-  MaxTaskDuration = std::max({DeliverProductTaskDuration,
-                              FetchProductTaskDuration, PrepareCSTaskDuration});
+	MaxTaskDuration =
+	  std::max({DeliverProductTaskDuration, FetchProductTaskDuration, PrepareCSTaskDuration});
 
-  // The cap-station part.
-  suffix = buffer + prefixLen + infixCapStationLen;
-  std::strcpy(buffer + prefixLen, infixCapStation);
+	// The cap-station part.
+	suffix = buffer + prefixLen + infixCapStationLen;
+	std::strcpy(buffer + prefixLen, infixCapStation);
 
-  CapColors.reserve(2);
-  // We assume the distribution is the same, for CYAN and MAGENTA.
-  std::strcpy(suffix, "C-CS1");
-  CapColors.emplace_back(
-      CapColorInformation{config->get_string(buffer), "CS1"});
-  std::strcpy(suffix, "C-CS2");
-  CapColors.emplace_back(
-      CapColorInformation{config->get_string(buffer), "CS2"});
+	CapColors.reserve(2);
+	// We assume the distribution is the same, for CYAN and MAGENTA.
+	std::strcpy(suffix, "C-CS1");
+	CapColors.emplace_back(CapColorInformation{config->get_string(buffer), "CS1"});
+	std::strcpy(suffix, "C-CS2");
+	CapColors.emplace_back(CapColorInformation{config->get_string(buffer), "CS2"});
 
-  // The working-duration part.
-  suffix = buffer + prefixLen + infixWorkingDurationLen;
-  std::strcpy(buffer + prefixLen, infixWorkingDuration);
+	// The working-duration part.
+	suffix = buffer + prefixLen + infixWorkingDurationLen;
+	std::strcpy(buffer + prefixLen, infixWorkingDuration);
 
-  WorkingDurations.reserve(6);
-  std::strcpy(suffix, "base-station");
-  WorkingDurations.insert({"BS", config->get_int(buffer)});
-  std::strcpy(suffix, "cap-station");
-  WorkingDurations.insert({"CS1", config->get_int(buffer)});
-  WorkingDurations.insert({"CS2", config->get_int(buffer)});
-  std::strcpy(suffix, "delivery-station");
-  WorkingDurations.insert({"DS", config->get_int(buffer)});
-  std::strcpy(suffix, "ring-station");
-  WorkingDurations.insert({"RS1", config->get_int(buffer)});
-  WorkingDurations.insert({"RS2", config->get_int(buffer)});
+	WorkingDurations.reserve(6);
+	std::strcpy(suffix, "base-station");
+	WorkingDurations.insert({"BS", config->get_int(buffer)});
+	std::strcpy(suffix, "cap-station");
+	WorkingDurations.insert({"CS1", config->get_int(buffer)});
+	WorkingDurations.insert({"CS2", config->get_int(buffer)});
+	std::strcpy(suffix, "delivery-station");
+	WorkingDurations.insert({"DS", config->get_int(buffer)});
+	std::strcpy(suffix, "ring-station");
+	WorkingDurations.insert({"RS1", config->get_int(buffer)});
+	WorkingDurations.insert({"RS2", config->get_int(buffer)});
 
-  for (const auto &pair : WorkingDurations) {
-    MaxWorkingDuration = std::max(MaxWorkingDuration, pair.second);
-  } // for ( const auto& pair : WorkingDurations )
-  return;
+	for (const auto &pair : WorkingDurations) {
+		MaxWorkingDuration = std::max(MaxWorkingDuration, pair.second);
+	} // for ( const auto& pair : WorkingDurations )
+	return;
 }

--- a/src/plugins/asp-planner/asp_planner_externals.cpp
+++ b/src/plugins/asp-planner/asp_planner_externals.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "asp_planner_externals.h"
+
 #include "asp_planner_types.h"
 
 #include <clingo.hh>
@@ -29,8 +30,10 @@
  * @param[in] product The product.
  * @return The symbol.
  */
-static inline Clingo::Symbol productName(const ProductIdentifier &product) {
-  return Clingo::Function("product", {Clingo::Number(product.ID)});
+static inline Clingo::Symbol
+productName(const ProductIdentifier &product)
+{
+	return Clingo::Function("product", {Clingo::Number(product.ID)});
 }
 
 /**
@@ -38,8 +41,10 @@ static inline Clingo::Symbol productName(const ProductIdentifier &product) {
  * @param[in] robotName The name of the robot.
  * @return The atom for the external.
  */
-Clingo::Symbol generateAliveExternal(const std::string &robotName) {
-  return Clingo::Function("availableRobot", {Clingo::String(robotName)});
+Clingo::Symbol
+generateAliveExternal(const std::string &robotName)
+{
+	return Clingo::Function("availableRobot", {Clingo::String(robotName)});
 }
 
 /**
@@ -48,10 +53,11 @@ Clingo::Symbol generateAliveExternal(const std::string &robotName) {
  * @param[in] location Its location.
  * @return The external atom.
  */
-Clingo::Symbol generateRobotLocationExternal(const std::string &robotName,
-                                             const Clingo::Symbol &location) {
-  return Clingo::Function("robotLocation", {Clingo::String(robotName), location,
-                                            Clingo::Number(0)});
+Clingo::Symbol
+generateRobotLocationExternal(const std::string &robotName, const Clingo::Symbol &location)
+{
+	return Clingo::Function("robotLocation",
+	                        {Clingo::String(robotName), location, Clingo::Number(0)});
 }
 
 /**
@@ -60,10 +66,11 @@ Clingo::Symbol generateRobotLocationExternal(const std::string &robotName,
  * @param[in] product The product.
  * @return The external atom.
  */
-Clingo::Symbol generateHoldingExternal(const std::string &robotName,
-                                       const ProductIdentifier &product) {
-  return Clingo::Function("holding", {Clingo::String(robotName),
-                                      productName(product), Clingo::Number(0)});
+Clingo::Symbol
+generateHoldingExternal(const std::string &robotName, const ProductIdentifier &product)
+{
+	return Clingo::Function("holding",
+	                        {Clingo::String(robotName), productName(product), Clingo::Number(0)});
 }
 
 /**
@@ -73,13 +80,12 @@ Clingo::Symbol generateHoldingExternal(const std::string &robotName,
  * @param[in] duration The remaining duration of the doing.
  * @return The external atom.
  */
-Clingo::Symbol generateDoingExternal(const std::string &robotName,
-                                     const TaskDescription &task,
-                                     const int duration) {
-  assert(duration > 0);
-  return Clingo::Function(
-      "robotDoing",
-      {Clingo::String(robotName), task.TaskSymbol, Clingo::Number(duration)});
+Clingo::Symbol
+generateDoingExternal(const std::string &robotName, const TaskDescription &task, const int duration)
+{
+	assert(duration > 0);
+	return Clingo::Function("robotDoing",
+	                        {Clingo::String(robotName), task.TaskSymbol, Clingo::Number(duration)});
 }
 
 /**
@@ -87,9 +93,10 @@ Clingo::Symbol generateDoingExternal(const std::string &robotName,
  * @param[in] zone The zone number.
  * @return The external atom.
  */
-Clingo::Symbol generateExploreLocationExternal(const int zone) {
-  return Clingo::Function("location",
-                          {Clingo::Function("z", {Clingo::Number(zone)})});
+Clingo::Symbol
+generateExploreLocationExternal(const int zone)
+{
+	return Clingo::Function("location", {Clingo::Function("z", {Clingo::Number(zone)})});
 }
 
 /**
@@ -97,10 +104,11 @@ Clingo::Symbol generateExploreLocationExternal(const int zone) {
  * @param[in] zone The zone number.
  * @return The external atom.
  */
-Clingo::Symbol generateExploreTaskExternal(const int zone) {
-  return Clingo::Function(
-      "toBeDone",
-      {Clingo::Function("explore", {Clingo::Number(zone)}), Clingo::Number(0)});
+Clingo::Symbol
+generateExploreTaskExternal(const int zone)
+{
+	return Clingo::Function("toBeDone",
+	                        {Clingo::Function("explore", {Clingo::Number(zone)}), Clingo::Number(0)});
 }
 
 /**
@@ -108,8 +116,10 @@ Clingo::Symbol generateExploreTaskExternal(const int zone) {
  * @param[in] product The product..
  * @return The external atom.
  */
-Clingo::Symbol generateProductExternal(const ProductIdentifier &product) {
-  return Clingo::Function("product", {productName(product)});
+Clingo::Symbol
+generateProductExternal(const ProductIdentifier &product)
+{
+	return Clingo::Function("product", {productName(product)});
 }
 
 /**
@@ -118,10 +128,10 @@ Clingo::Symbol generateProductExternal(const ProductIdentifier &product) {
  * @param[in] base The base color.
  * @return The external atom.
  */
-Clingo::Symbol generateProductBaseExternal(const ProductIdentifier &product,
-                                           const std::string &base) {
-  return Clingo::Function("productBase",
-                          {productName(product), Clingo::String(base)});
+Clingo::Symbol
+generateProductBaseExternal(const ProductIdentifier &product, const std::string &base)
+{
+	return Clingo::Function("productBase", {productName(product), Clingo::String(base)});
 }
 
 /**
@@ -131,12 +141,14 @@ Clingo::Symbol generateProductBaseExternal(const ProductIdentifier &product,
  * @param[in] color The ring color.
  * @return The external atom.
  */
-Clingo::Symbol generateProductRingExternal(const ProductIdentifier &product,
-                                           const int ringNumber,
-                                           const std::string &color) {
-  return Clingo::Function("productRing",
-                          {productName(product), Clingo::Number(ringNumber),
-                           Clingo::String(color), Clingo::Number(0)});
+Clingo::Symbol
+generateProductRingExternal(const ProductIdentifier &product,
+                            const int                ringNumber,
+                            const std::string &      color)
+{
+	return Clingo::Function(
+	  "productRing",
+	  {productName(product), Clingo::Number(ringNumber), Clingo::String(color), Clingo::Number(0)});
 }
 
 /**
@@ -145,11 +157,11 @@ Clingo::Symbol generateProductRingExternal(const ProductIdentifier &product,
  * @param[in] cap The cap color.
  * @return The external atom.
  */
-Clingo::Symbol generateProductCapExternal(const ProductIdentifier &product,
-                                          const std::string &cap) {
-  return Clingo::Function(
-      "productCap",
-      {productName(product), Clingo::String(cap), Clingo::Number(0)});
+Clingo::Symbol
+generateProductCapExternal(const ProductIdentifier &product, const std::string &cap)
+{
+	return Clingo::Function("productCap",
+	                        {productName(product), Clingo::String(cap), Clingo::Number(0)});
 }
 
 /**
@@ -158,11 +170,11 @@ Clingo::Symbol generateProductCapExternal(const ProductIdentifier &product,
  * @param[in] duration How long the machine is broken.
  * @return The external atom.
  */
-Clingo::Symbol generateMachineBrokenExternal(const std::string &machineName,
-                                             const int duration) {
-  return Clingo::Function("broken",
-                          {Clingo::String(machineName),
-                           Clingo::Number(duration), Clingo::Number(0)});
+Clingo::Symbol
+generateMachineBrokenExternal(const std::string &machineName, const int duration)
+{
+	return Clingo::Function(
+	  "broken", {Clingo::String(machineName), Clingo::Number(duration), Clingo::Number(0)});
 }
 
 /**
@@ -173,12 +185,15 @@ Clingo::Symbol generateMachineBrokenExternal(const std::string &machineName,
  * @return The external atom.
  */
 Clingo::Symbol
-generateMachineWorkingExternal(const std::string &machineName,
-                               const int duration,
-                               const ProductIdentifier &product) {
-  return Clingo::Function("processing",
-                          {Clingo::String(machineName), productName(product),
-                           Clingo::Number(duration), Clingo::Number(0)});
+generateMachineWorkingExternal(const std::string &      machineName,
+                               const int                duration,
+                               const ProductIdentifier &product)
+{
+	return Clingo::Function("processing",
+	                        {Clingo::String(machineName),
+	                         productName(product),
+	                         Clingo::Number(duration),
+	                         Clingo::Number(0)});
 }
 
 /**
@@ -188,10 +203,10 @@ generateMachineWorkingExternal(const std::string &machineName,
  * @return The external atom.
  */
 Clingo::Symbol
-generateMachineStoringExternal(const std::string &machineName,
-                               const ProductIdentifier &product) {
-  return Clingo::Function("storing", {Clingo::String(machineName),
-                                      productName(product), Clingo::Number(0)});
+generateMachineStoringExternal(const std::string &machineName, const ProductIdentifier &product)
+{
+	return Clingo::Function("storing",
+	                        {Clingo::String(machineName), productName(product), Clingo::Number(0)});
 }
 
 /**
@@ -199,9 +214,10 @@ generateMachineStoringExternal(const std::string &machineName,
  * @param[in] machineName The name of the machine.
  * @return The external atom.
  */
-Clingo::Symbol generatePreparedExternal(const std::string &machineName) {
-  return Clingo::Function("csPrepared",
-                          {Clingo::String(machineName), Clingo::Number(0)});
+Clingo::Symbol
+generatePreparedExternal(const std::string &machineName)
+{
+	return Clingo::Function("csPrepared", {Clingo::String(machineName), Clingo::Number(0)});
 }
 
 /**
@@ -210,11 +226,11 @@ Clingo::Symbol generatePreparedExternal(const std::string &machineName) {
  * @param[in] fillState The fill state.
  * @return The external atom.
  */
-Clingo::Symbol generateFillStateExternal(const std::string &machineName,
-                                         const int fillState) {
-  return Clingo::Function("rsFillState",
-                          {Clingo::String(machineName),
-                           Clingo::Number(fillState), Clingo::Number(0)});
+Clingo::Symbol
+generateFillStateExternal(const std::string &machineName, const int fillState)
+{
+	return Clingo::Function(
+	  "rsFillState", {Clingo::String(machineName), Clingo::Number(fillState), Clingo::Number(0)});
 }
 
 /**
@@ -224,10 +240,11 @@ Clingo::Symbol generateFillStateExternal(const std::string &machineName,
  * @param[in] side The side of the machine.
  * @return The external atom.
  */
-Clingo::Symbol generateLocationExternal(const char *teamColor,
-                                        const char *machine, const char *side) {
-  return Clingo::Function("m", {Clingo::String(teamColor),
-                                Clingo::String(machine), Clingo::String(side)});
+Clingo::Symbol
+generateLocationExternal(const char *teamColor, const char *machine, const char *side)
+{
+	return Clingo::Function(
+	  "m", {Clingo::String(teamColor), Clingo::String(machine), Clingo::String(side)});
 }
 
 /**
@@ -235,8 +252,10 @@ Clingo::Symbol generateLocationExternal(const char *teamColor,
  * @param[in] task The task.
  * @return The external atom.
  */
-static inline Clingo::Symbol toBeDoneExternal(const Clingo::Symbol &task) {
-  return Clingo::Function("toBeDone", {task, Clingo::Number(0)});
+static inline Clingo::Symbol
+toBeDoneExternal(const Clingo::Symbol &task)
+{
+	return Clingo::Function("toBeDone", {task, Clingo::Number(0)});
 }
 
 /**
@@ -247,12 +266,15 @@ static inline Clingo::Symbol toBeDoneExternal(const Clingo::Symbol &task) {
  * @param[in] ring The ring number of the task.
  * @return The external atom.
  */
-Clingo::Symbol generateMountRingExternal(const Clingo::Symbol &location,
-                                         const int orderNumber, const int qty,
-                                         const int ring) {
-  return toBeDoneExternal(Clingo::Function(
-      "mountRing", {location, Clingo::Number(orderNumber), Clingo::Number(qty),
-                    Clingo::Number(ring)}));
+Clingo::Symbol
+generateMountRingExternal(const Clingo::Symbol &location,
+                          const int             orderNumber,
+                          const int             qty,
+                          const int             ring)
+{
+	return toBeDoneExternal(Clingo::Function(
+	  "mountRing",
+	  {location, Clingo::Number(orderNumber), Clingo::Number(qty), Clingo::Number(ring)}));
 }
 
 /**
@@ -262,11 +284,11 @@ Clingo::Symbol generateMountRingExternal(const Clingo::Symbol &location,
  * @param[in] qty The quantity number of the task.
  * @return The external atom.
  */
-Clingo::Symbol generateMountCapExternal(const Clingo::Symbol &location,
-                                        const int orderNumber, const int qty) {
-  return toBeDoneExternal(
-      Clingo::Function("mountCap", {location, Clingo::Number(orderNumber),
-                                    Clingo::Number(qty)}));
+Clingo::Symbol
+generateMountCapExternal(const Clingo::Symbol &location, const int orderNumber, const int qty)
+{
+	return toBeDoneExternal(
+	  Clingo::Function("mountCap", {location, Clingo::Number(orderNumber), Clingo::Number(qty)}));
 }
 
 /**
@@ -276,10 +298,11 @@ Clingo::Symbol generateMountCapExternal(const Clingo::Symbol &location,
  * @param[in] qty The quantity number of the task.
  * @return The external atom.
  */
-Clingo::Symbol generateDeliverExternal(const Clingo::Symbol &location,
-                                       const int orderNumber, const int qty) {
-  return toBeDoneExternal(Clingo::Function(
-      "deliver", {location, Clingo::Number(orderNumber), Clingo::Number(qty)}));
+Clingo::Symbol
+generateDeliverExternal(const Clingo::Symbol &location, const int orderNumber, const int qty)
+{
+	return toBeDoneExternal(
+	  Clingo::Function("deliver", {location, Clingo::Number(orderNumber), Clingo::Number(qty)}));
 }
 
 /**
@@ -289,10 +312,9 @@ Clingo::Symbol generateDeliverExternal(const Clingo::Symbol &location,
  * @param[in] qty The quantity number of the task.
  * @return The external atom.
  */
-Clingo::Symbol generateLateDeliverExternal(const Clingo::Symbol &location,
-                                           const int orderNumber,
-                                           const int qty) {
-  return toBeDoneExternal(
-      Clingo::Function("lateDeliver", {location, Clingo::Number(orderNumber),
-                                       Clingo::Number(qty)}));
+Clingo::Symbol
+generateLateDeliverExternal(const Clingo::Symbol &location, const int orderNumber, const int qty)
+{
+	return toBeDoneExternal(
+	  Clingo::Function("lateDeliver", {location, Clingo::Number(orderNumber), Clingo::Number(qty)}));
 }

--- a/src/plugins/asp-planner/asp_planner_externals.h
+++ b/src/plugins/asp-planner/asp_planner_externals.h
@@ -32,49 +32,46 @@ struct ProductIdentifier;
 struct TaskDescription;
 
 Clingo::Symbol generateAliveExternal(const std::string &robotName);
-Clingo::Symbol generateRobotLocationExternal(const std::string &robotName,
+Clingo::Symbol generateRobotLocationExternal(const std::string &   robotName,
                                              const Clingo::Symbol &location);
-Clingo::Symbol generateHoldingExternal(const std::string &robotName,
+Clingo::Symbol generateHoldingExternal(const std::string &      robotName,
                                        const ProductIdentifier &product);
-Clingo::Symbol generateDoingExternal(const std::string &robotName,
+Clingo::Symbol generateDoingExternal(const std::string &    robotName,
                                      const TaskDescription &task,
-                                     const int duration);
+                                     const int              duration);
 
 Clingo::Symbol generateExploreLocationExternal(const int zone);
 Clingo::Symbol generateExploreTaskExternal(const int zone);
 
 Clingo::Symbol generateProductExternal(const ProductIdentifier &product);
 Clingo::Symbol generateProductBaseExternal(const ProductIdentifier &product,
-                                           const std::string &base);
+                                           const std::string &      base);
 Clingo::Symbol generateProductRingExternal(const ProductIdentifier &product,
-                                           const int ringNumber,
-                                           const std::string &color);
-Clingo::Symbol generateProductCapExternal(const ProductIdentifier &product,
-                                          const std::string &cap);
+                                           const int                ringNumber,
+                                           const std::string &      color);
+Clingo::Symbol generateProductCapExternal(const ProductIdentifier &product, const std::string &cap);
 
-Clingo::Symbol generateMachineBrokenExternal(const std::string &machineName,
-                                             const int duration);
-Clingo::Symbol generateMachineWorkingExternal(const std::string &machineName,
-                                              const int duration,
+Clingo::Symbol generateMachineBrokenExternal(const std::string &machineName, const int duration);
+Clingo::Symbol generateMachineWorkingExternal(const std::string &      machineName,
+                                              const int                duration,
                                               const ProductIdentifier &product);
-Clingo::Symbol generateMachineStoringExternal(const std::string &machineName,
+Clingo::Symbol generateMachineStoringExternal(const std::string &      machineName,
                                               const ProductIdentifier &product);
 Clingo::Symbol generatePreparedExternal(const std::string &machineName);
-Clingo::Symbol generateFillStateExternal(const std::string &machineName,
-                                         const int fillState);
+Clingo::Symbol generateFillStateExternal(const std::string &machineName, const int fillState);
 
-Clingo::Symbol generateLocationExternal(const char *teamColor,
-                                        const char *machine, const char *side);
+Clingo::Symbol
+generateLocationExternal(const char *teamColor, const char *machine, const char *side);
 
 Clingo::Symbol generateMountRingExternal(const Clingo::Symbol &location,
-                                         const int orderNumber, const int qty,
-                                         const int ring);
-Clingo::Symbol generateMountCapExternal(const Clingo::Symbol &location,
-                                        const int orderNumber, const int qty);
-Clingo::Symbol generateDeliverExternal(const Clingo::Symbol &location,
-                                       const int orderNumber, const int qty);
-Clingo::Symbol generateLateDeliverExternal(const Clingo::Symbol &location,
-                                           const int orderNumber,
-                                           const int qty);
+                                         const int             orderNumber,
+                                         const int             qty,
+                                         const int             ring);
+Clingo::Symbol
+generateMountCapExternal(const Clingo::Symbol &location, const int orderNumber, const int qty);
+Clingo::Symbol
+generateDeliverExternal(const Clingo::Symbol &location, const int orderNumber, const int qty);
+Clingo::Symbol
+generateLateDeliverExternal(const Clingo::Symbol &location, const int orderNumber, const int qty);
 
 #endif

--- a/src/plugins/asp-planner/asp_planner_plan.cpp
+++ b/src/plugins/asp-planner/asp_planner_plan.cpp
@@ -21,24 +21,26 @@
 
 #include "asp_planner_thread.h"
 
+#include <core/threading/mutex_locker.h>
+#include <plugins/robot-memory/robot_memory.h>
+
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <limits>
 #include <type_traits>
 
-#include <core/threading/mutex_locker.h>
-#include <plugins/robot-memory/robot_memory.h>
-
 using fawkes::MutexLocker;
 
 /**
  * @brief Initalized plan elements.
  */
-void AspPlannerThread::initPlan(void) {
-  // Clear old plan, if in db.
-  robot_memory->drop_collection("syncedrobmem.plan");
-  return;
+void
+AspPlannerThread::initPlan(void)
+{
+	// Clear old plan, if in db.
+	robot_memory->drop_collection("syncedrobmem.plan");
+	return;
 }
 
 /**
@@ -47,61 +49,65 @@ void AspPlannerThread::initPlan(void) {
  * @param[in] e2 The second element.
  * @return If e1 begins before e2.
  */
-static inline bool planBegin(const BasicPlanElement &e1,
-                             const BasicPlanElement &e2) noexcept {
-  return e1.Begin < e2.Begin;
+static inline bool
+planBegin(const BasicPlanElement &e1, const BasicPlanElement &e2) noexcept
+{
+	return e1.Begin < e2.Begin;
 }
 
 /**
  * @brief A intermediate representation of the plan elements.
  */
-struct IntermediatePlanElement : public BasicPlanElement {
-  /** @brief The time to compare two Elements. */
-  int *CompareTime;
+struct IntermediatePlanElement : public BasicPlanElement
+{
+	/** @brief The time to compare two Elements. */
+	int *CompareTime;
 
-  IntermediatePlanElement(void) = delete;
+	IntermediatePlanElement(void) = delete;
 
-  /** Deleted dtor.
+	/** Deleted dtor.
    * @param pe plan element
    */
-  IntermediatePlanElement(const IntermediatePlanElement &pe) = delete;
+	IntermediatePlanElement(const IntermediatePlanElement &pe) = delete;
 
-  /**
+	/**
    * @brief Move Constructor.
    * @param[in, out] that Moved element.
    */
-  IntermediatePlanElement(IntermediatePlanElement &&that)
-      : BasicPlanElement{std::move(that.Task), that.Begin, that.End},
-        CompareTime((that.CompareTime == &that.Begin) ? &Begin : &End) {
-    return;
-  }
+	IntermediatePlanElement(IntermediatePlanElement &&that)
+	: BasicPlanElement{std::move(that.Task), that.Begin, that.End},
+	  CompareTime((that.CompareTime == &that.Begin) ? &Begin : &End)
+	{
+		return;
+	}
 
-  /**
+	/**
    * @brief Constructor.
    * @param[in, out] task The task name.
    * @param[in] useBegin If the time to set is the begin time.
    * @param[in] time The time to set.
    */
-  inline IntermediatePlanElement(std::string &&task, const bool useBegin,
-                                 const int time)
-      : BasicPlanElement{std::move(task)},
-        CompareTime(useBegin ? &Begin : &End) {
-    *CompareTime = time;
-    return;
-  }
+	inline IntermediatePlanElement(std::string &&task, const bool useBegin, const int time)
+	: BasicPlanElement{std::move(task)}, CompareTime(useBegin ? &Begin : &End)
+	{
+		*CompareTime = time;
+		return;
+	}
 
-  /**
+	/**
    * @brief Move Assignment.
    * @param [in, out] that Moved element.
    * @return This.
    */
-  IntermediatePlanElement &operator=(IntermediatePlanElement &&that) {
-    Task = std::move(that.Task);
-    Begin = that.Begin;
-    End = that.End;
-    CompareTime = (that.CompareTime == &that.Begin) ? &Begin : &End;
-    return *this;
-  }
+	IntermediatePlanElement &
+	operator=(IntermediatePlanElement &&that)
+	{
+		Task        = std::move(that.Task);
+		Begin       = that.Begin;
+		End         = that.End;
+		CompareTime = (that.CompareTime == &that.Begin) ? &Begin : &End;
+		return *this;
+	}
 };
 
 /**
@@ -110,12 +116,13 @@ struct IntermediatePlanElement : public BasicPlanElement {
  * @param[in] e2 The second element.
  * @return If e1's time is smaller than e2's.
  */
-inline bool operator<(const IntermediatePlanElement &e1,
-                      const IntermediatePlanElement &e2) {
-  // If the times are equal we have one begin and one end, the end has to be
-  // before that.
-  return *(e1.CompareTime) < *(e2.CompareTime) ||
-         (*(e1.CompareTime) == *(e2.CompareTime) && e1.End > e2.End);
+inline bool
+operator<(const IntermediatePlanElement &e1, const IntermediatePlanElement &e2)
+{
+	// If the times are equal we have one begin and one end, the end has to be
+	// before that.
+	return *(e1.CompareTime) < *(e2.CompareTime)
+	       || (*(e1.CompareTime) == *(e2.CompareTime) && e1.End > e2.End);
 }
 
 /**
@@ -127,44 +134,47 @@ inline bool operator<(const IntermediatePlanElement &e1,
  * @param[in] transform Transforms the asp game time, to the real game time.
  * @param[in] log Wrapper around the fawkes logger.
  */
-static inline void extractMapFromAnswerSet(
-    const Clingo::SymbolVector &symbols,
-    std::unordered_map<std::string, std::vector<IntermediatePlanElement>> &map,
-    const int planGameTime, const std::function<int(int)> &transform,
-    fawkes::Logger *logger, const char *logging_component) {
-  for (auto &pair : map) {
-    pair.second.clear();
-  } // for ( auto& pair : map )
+static inline void
+extractMapFromAnswerSet(const Clingo::SymbolVector &symbols,
+                        std::unordered_map<std::string, std::vector<IntermediatePlanElement>> &map,
+                        const int                      planGameTime,
+                        const std::function<int(int)> &transform,
+                        fawkes::Logger *               logger,
+                        const char *                   logging_component)
+{
+	for (auto &pair : map) {
+		pair.second.clear();
+	} // for ( auto& pair : map )
 
-  for (const auto &symbol : symbols) {
-    const string_view name(symbol.name());
-    const bool begin = name == "begin", end = name == "end";
-    if (begin || end) {
-      // Assumes begin(robot, task, time) and end(robot, task, time).
-      const decltype(auto) args(symbol.arguments());
-      const auto time = args[2].number();
-      const auto robot(args[0].string());
+	for (const auto &symbol : symbols) {
+		const string_view name(symbol.name());
+		const bool        begin = name == "begin", end = name == "end";
+		if (begin || end) {
+			// Assumes begin(robot, task, time) and end(robot, task, time).
+			const decltype(auto) args(symbol.arguments());
+			const auto           time = args[2].number();
+			const auto           robot(args[0].string());
 
-      // If not in the map until now it will add a list for the robot.
-      map[robot].emplace_back(args[1].to_string(), begin,
-                              std::max(transform(time) + planGameTime, 1));
-    } // if ( begin || end )
-  }   // for ( const auto& symbol : symbols )
+			// If not in the map until now it will add a list for the robot.
+			map[robot].emplace_back(args[1].to_string(),
+			                        begin,
+			                        std::max(transform(time) + planGameTime, 1));
+		} // if ( begin || end )
+	}   // for ( const auto& symbol : symbols )
 
-  int size = 0;
+	int size = 0;
 
-  for (auto &pair : map) {
-    std::sort(pair.second.begin(), pair.second.end());
-    size += pair.second.size();
-  } // for ( auto& pair : map )
+	for (auto &pair : map) {
+		std::sort(pair.second.begin(), pair.second.end());
+		size += pair.second.size();
+	} // for ( auto& pair : map )
 
-  if (!size) {
-    return;
-  } // if ( !size )
+	if (!size) {
+		return;
+	} // if ( !size )
 
-  logger->log_info(logging_component, "Extracted plan size: %d Start GT: %d",
-                   size, planGameTime);
-  return;
+	logger->log_info(logging_component, "Extracted plan size: %d Start GT: %d", size, planGameTime);
+	return;
 }
 
 /**
@@ -176,337 +186,371 @@ static inline void extractMapFromAnswerSet(
  * @param[in] plan The currently deployed plan.
  * @param[in] log Wrapper around the fawkes logger.
  */
-static inline void assembleTemporaryPlan(
-    std::unordered_map<std::string, std::vector<IntermediatePlanElement>> &map,
-    std::unordered_map<std::string, std::vector<BasicPlanElement>> &tempPlan,
-    const std::unordered_map<std::string, RobotPlan> &plan,
-    fawkes::Logger *logger, const char *logging_component) {
-  for (auto &tempRobotPlan : tempPlan) {
-    tempRobotPlan.second.clear();
-  } // for ( auto& tempRobotPlan : tempPlan )
+static inline void
+assembleTemporaryPlan(std::unordered_map<std::string, std::vector<IntermediatePlanElement>> &map,
+                      std::unordered_map<std::string, std::vector<BasicPlanElement>> &tempPlan,
+                      const std::unordered_map<std::string, RobotPlan> &              plan,
+                      fawkes::Logger *                                                logger,
+                      const char *logging_component)
+{
+	for (auto &tempRobotPlan : tempPlan) {
+		tempRobotPlan.second.clear();
+	} // for ( auto& tempRobotPlan : tempPlan )
 
-  std::size_t max = 0, min = std::numeric_limits<std::size_t>::max();
+	std::size_t max = 0, min = std::numeric_limits<std::size_t>::max();
 
-  for (auto &pair : map) {
-    const auto &robotName(pair.first);
-    const auto robotNameCStr(robotName.c_str());
-    auto &robotTempPlan(tempPlan[robotName]);
+	for (auto &pair : map) {
+		const auto &robotName(pair.first);
+		const auto  robotNameCStr(robotName.c_str());
+		auto &      robotTempPlan(tempPlan[robotName]);
 
-    auto iter = pair.second.begin();
-    const auto end = pair.second.end();
+		auto       iter = pair.second.begin();
+		const auto end  = pair.second.end();
 
-    if (iter != end && iter->Begin == 0) {
-      // The first entry is a already started task, fix its begin time!
-      const auto &robotPlan(plan.at(robotName));
+		if (iter != end && iter->Begin == 0) {
+			// The first entry is a already started task, fix its begin time!
+			const auto &robotPlan(plan.at(robotName));
 
-      // But the task may already be done, search from the beginning of this
-      // solve iteration.
-      auto i = robotPlan.FirstNotDoneOnSolveStart;
-      for (; i < robotPlan.Tasks.size(); ++i) {
-        if (iter->Task == robotPlan.Tasks[i].Task) {
-          break;
-        } // if ( iter->Task == robotPlan.Tasks[i].Task )
-      }   // for ( ; i < robotPlan.Tasks.size(); ++i )
-      iter->Begin = robotPlan.Tasks[i].Begin;
+			// But the task may already be done, search from the beginning of this
+			// solve iteration.
+			auto i = robotPlan.FirstNotDoneOnSolveStart;
+			for (; i < robotPlan.Tasks.size(); ++i) {
+				if (iter->Task == robotPlan.Tasks[i].Task) {
+					break;
+				} // if ( iter->Task == robotPlan.Tasks[i].Task )
+			}   // for ( ; i < robotPlan.Tasks.size(); ++i )
+			iter->Begin = robotPlan.Tasks[i].Begin;
 
-      logger->log_info(logging_component, "Plan element: (%s, %s, %d, %d)",
-                       robotNameCStr, iter->Task.c_str(), iter->Begin,
-                       iter->End);
-      robotTempPlan.emplace_back(std::move(*iter));
-      ++iter;
-    } // if ( iter != end && iter->Begin == 0 )
+			logger->log_info(logging_component,
+			                 "Plan element: (%s, %s, %d, %d)",
+			                 robotNameCStr,
+			                 iter->Task.c_str(),
+			                 iter->Begin,
+			                 iter->End);
+			robotTempPlan.emplace_back(std::move(*iter));
+			++iter;
+		} // if ( iter != end && iter->Begin == 0 )
 
-    while (iter != end) {
-      const auto next = iter + 1;
-      assert(iter->End == 0);
+		while (iter != end) {
+			const auto next = iter + 1;
+			assert(iter->End == 0);
 
-      if (next == end) {
-        /* The task has only a begin time, i.e. it is started shortly before our
+			if (next == end) {
+				/* The task has only a begin time, i.e. it is started shortly before our
          * lookahead ends. So the end time is out of the loohahead. */
 
-        logger->log_info(logging_component, "Plan element: (%s, %s, %d, 0)",
-                         robotNameCStr, iter->Task.c_str(), iter->Begin);
-        robotTempPlan.emplace_back(
-            BasicPlanElement{std::move(iter->Task), iter->Begin, 0});
-        break;
-      } // if ( next == end )
+				logger->log_info(logging_component,
+				                 "Plan element: (%s, %s, %d, 0)",
+				                 robotNameCStr,
+				                 iter->Task.c_str(),
+				                 iter->Begin);
+				robotTempPlan.emplace_back(BasicPlanElement{std::move(iter->Task), iter->Begin, 0});
+				break;
+			} // if ( next == end )
 
-      assert(iter->Task == next->Task);
-      assert(next->Begin == 0);
+			assert(iter->Task == next->Task);
+			assert(next->Begin == 0);
 
-      logger->log_info(logging_component, "Plan element: (%s, %s, %d, %d)",
-                       robotNameCStr, iter->Task.c_str(), iter->Begin,
-                       next->End);
-      robotTempPlan.emplace_back(
-          BasicPlanElement{std::move(iter->Task), iter->Begin, next->End});
+			logger->log_info(logging_component,
+			                 "Plan element: (%s, %s, %d, %d)",
+			                 robotNameCStr,
+			                 iter->Task.c_str(),
+			                 iter->Begin,
+			                 next->End);
+			robotTempPlan.emplace_back(BasicPlanElement{std::move(iter->Task), iter->Begin, next->End});
 
-      iter += 2;
-    } // while ( iter != end )
+			iter += 2;
+		} // while ( iter != end )
 
-    max = std::max(max, robotTempPlan.size());
-    min = std::min(min, robotTempPlan.size());
-  } // for ( auto& pair : map )
+		max = std::max(max, robotTempPlan.size());
+		min = std::min(min, robotTempPlan.size());
+	} // for ( auto& pair : map )
 
-  if (max == 0) {
-    logger->log_info(logging_component, "No tasks in plan.");
-  } // if ( max == 0 )
-  else {
-    logger->log_info(logging_component, "Min elements per robot: %zu, max: %zu",
-                     min, max);
-  } // else -> if ( max == 0 )
-  return;
+	if (max == 0) {
+		logger->log_info(logging_component, "No tasks in plan.");
+	} // if ( max == 0 )
+	else {
+		logger->log_info(logging_component, "Min elements per robot: %zu, max: %zu", min, max);
+	} // else -> if ( max == 0 )
+	return;
 }
 
 /**
  * @brief Handles everything concerning the plan in the loop.
  */
-void AspPlannerThread::loopPlan(void) {
-  MutexLocker solvingLocker(&SolvingMutex);
-  if (!NewSymbols) {
-    MutexLocker worldLocker(&WorldMutex);
-    return;
-  } // if ( !NewSymbols )
+void
+AspPlannerThread::loopPlan(void)
+{
+	MutexLocker solvingLocker(&SolvingMutex);
+	if (!NewSymbols) {
+		MutexLocker worldLocker(&WorldMutex);
+		return;
+	} // if ( !NewSymbols )
 
-  static const std::chrono::milliseconds planThreshold(
-      config->get_int("/asp-agent/planner/plan-extraction-delay"));
-  if (Clock::now() - LastModel < planThreshold) {
-    // The last model is fresh, maybe there is a new and better in the next
-    // loop, wait a short time.
-    return;
-  } // if ( Clock::now() - LastModel < planThreshold )
+	static const std::chrono::milliseconds planThreshold(
+	  config->get_int("/asp-agent/planner/plan-extraction-delay"));
+	if (Clock::now() - LastModel < planThreshold) {
+		// The last model is fresh, maybe there is a new and better in the next
+		// loop, wait a short time.
+		return;
+	} // if ( Clock::now() - LastModel < planThreshold )
 
-  if (LastModel < SolvingStarted) {
-    // The last model is based on old information, do not use it! Without this
-    // there were wrong plans!
-    return;
-  } // if ( LastModel < SolvingStarted )
+	if (LastModel < SolvingStarted) {
+		// The last model is based on old information, do not use it! Without this
+		// there were wrong plans!
+		return;
+	} // if ( LastModel < SolvingStarted )
 
-  /* There is a new model and it is old enough, start with the plan extraction.
+	/* There is a new model and it is old enough, start with the plan extraction.
    * Since we have no guarantees about the ordering in the model we have to
    * create the order ourselves. */
-  MutexLocker planLocker(&PlanMutex);
+	MutexLocker planLocker(&PlanMutex);
 
-  // Make this map static, so we do not release the needed memory everytime.
-  static std::unordered_map<std::string, std::vector<IntermediatePlanElement>>
-      map;
+	// Make this map static, so we do not release the needed memory everytime.
+	static std::unordered_map<std::string, std::vector<IntermediatePlanElement>> map;
 
-  PlanGameTime = StartSolvingGameTime;
-  extractMapFromAnswerSet(
-      Symbols, map, PlanGameTime,
-      [this](int gt) noexcept { return aspGameTimeToRealGameTime(gt); }, logger,
-      LoggingComponent);
-  NewSymbols = false;
-  solvingLocker.unlock();
-  LastPlan = Clock::now();
+	PlanGameTime = StartSolvingGameTime;
+	extractMapFromAnswerSet(
+	  Symbols,
+	  map,
+	  PlanGameTime,
+	  [this](int gt) noexcept { return aspGameTimeToRealGameTime(gt); },
+	  logger,
+	  LoggingComponent);
+	NewSymbols = false;
+	solvingLocker.unlock();
+	LastPlan = Clock::now();
 
-  // Assemble a plan only based on the information from clingo.
-  static std::unordered_map<std::string, std::vector<BasicPlanElement>>
-      tempPlan;
+	// Assemble a plan only based on the information from clingo.
+	static std::unordered_map<std::string, std::vector<BasicPlanElement>> tempPlan;
 
-  assembleTemporaryPlan(map, tempPlan, Plan, logger, LoggingComponent);
+	assembleTemporaryPlan(map, tempPlan, Plan, logger, LoggingComponent);
 
-  // Some helper functions to handle plan elements.
-  // If two plan elements refer to the same task.
-  auto sameTask =
-      [](const BasicPlanElement &e1, const BasicPlanElement &e2) noexcept {
-    return e1.Task == e2.Task;
-  };
-  // Compares the begin and end time point and if their difference is above a
-  // given threshold. This is only valid if both elements are about the same
-  // task.
-  auto needsUpdate = [ this, sameTask ](const BasicPlanElement &e1,
-                                        const BasicPlanElement &e2) noexcept {
-    assert(sameTask(e1, e2));
-    static_assert(std::is_signed<decltype(e1.Begin)>::value,
-                  "For unsigned values std::abs doesn't make any sense.");
-    const auto threshold = TimeResolution / 2;
-    if (e2.Begin == 0) {
-      /* This is a task, which was running when the solving started, since we
+	// Some helper functions to handle plan elements.
+	// If two plan elements refer to the same task.
+	auto sameTask = [](const BasicPlanElement &e1, const BasicPlanElement &e2) noexcept
+	{
+		return e1.Task == e2.Task;
+	};
+	// Compares the begin and end time point and if their difference is above a
+	// given threshold. This is only valid if both elements are about the same
+	// task.
+	auto needsUpdate =
+	  [this, sameTask](const BasicPlanElement &e1, const BasicPlanElement &e2) noexcept
+	{
+		assert(sameTask(e1, e2));
+		static_assert(std::is_signed<decltype(e1.Begin)>::value,
+		              "For unsigned values std::abs doesn't make any sense.");
+		const auto threshold = TimeResolution / 2;
+		if (e2.Begin == 0) {
+			/* This is a task, which was running when the solving started, since we
        * never have a begin() the value is not set. So just compare the end
        * values. */
-      return std::abs(e1.End - e2.End) > threshold;
-    } // if ( e2.Begin == 0 )
-    return std::abs(e1.Begin - e2.Begin) > threshold ||
-           std::abs(e1.End - e2.End) > threshold;
-  };
+			return std::abs(e1.End - e2.End) > threshold;
+		} // if ( e2.Begin == 0 )
+		return std::abs(e1.Begin - e2.Begin) > threshold || std::abs(e1.End - e2.End) > threshold;
+	};
 
-  /* We copy the deployed plan into planCopy and perform changes on it, if we do
+	/* We copy the deployed plan into planCopy and perform changes on it, if we do
    * not encounter a problem with the new plan from tempPlan we commit the
    * changes, i.e. swap it over to the Plan and update the database. */
-  bool commit = true;
-  // Static as usual to hold onto the allocated memory.
-  static std::map<decltype(Plan)::key_type, decltype(Plan[""].Tasks)> planCopy;
+	bool commit = true;
+	// Static as usual to hold onto the allocated memory.
+	static std::map<decltype(Plan)::key_type, decltype(Plan[""].Tasks)> planCopy;
 
-  for (const auto &pair : Plan) {
-    planCopy[pair.first] = pair.second.Tasks;
-  } // for ( const auto& pair : Plan )
+	for (const auto &pair : Plan) {
+		planCopy[pair.first] = pair.second.Tasks;
+	} // for ( const auto& pair : Plan )
 
-  for (auto &pair : tempPlan) {
-    const auto &robotName(pair.first);
-    auto &robotPlan(planCopy[robotName]);
-    auto &tempRobotPlan(pair.second);
+	for (auto &pair : tempPlan) {
+		const auto &robotName(pair.first);
+		auto &      robotPlan(planCopy[robotName]);
+		auto &      tempRobotPlan(pair.second);
 
-    logger->log_info(LoggingComponent, "Update plan for %s, %zu elements.",
-                     robotName.c_str(), tempRobotPlan.size());
+		logger->log_info(LoggingComponent,
+		                 "Update plan for %s, %zu elements.",
+		                 robotName.c_str(),
+		                 tempRobotPlan.size());
 
-    // Get the index from the first task regarding to this solve iteration.
-    int index = Plan[robotName].FirstNotDoneOnSolveStart;
-    // Get from that the iterator.
-    auto planIter = robotPlan.begin() + index;
-    // Cache the end iterator of the deployed robot plan.
-    const auto planEnd = robotPlan.end();
+		// Get the index from the first task regarding to this solve iteration.
+		int index = Plan[robotName].FirstNotDoneOnSolveStart;
+		// Get from that the iterator.
+		auto planIter = robotPlan.begin() + index;
+		// Cache the end iterator of the deployed robot plan.
+		const auto planEnd = robotPlan.end();
 
-    // The two iterators of the temp plan.
-    auto tempIter = tempRobotPlan.begin();
-    const auto tempEnd = tempRobotPlan.end();
+		// The two iterators of the temp plan.
+		auto       tempIter = tempRobotPlan.begin();
+		const auto tempEnd  = tempRobotPlan.end();
 
-    if (planIter == planEnd) {
-      logger->log_info(LoggingComponent,
-                       "Start at index %d, do not change the existing plan.",
-                       index);
-    } // if ( planIter == planEnd )
-    else {
-      logger->log_info(LoggingComponent,
-                       "Start at index %d, first existing entry to compare is: "
-                       "(%s,%s,%d,%d)",
-                       index, robotName.c_str(), planIter->Task.c_str(),
-                       planIter->Begin, planIter->End);
-    } // else -> if ( planIter == planEnd )
+		if (planIter == planEnd) {
+			logger->log_info(LoggingComponent,
+			                 "Start at index %d, do not change the existing plan.",
+			                 index);
+		} // if ( planIter == planEnd )
+		else {
+			logger->log_info(LoggingComponent,
+			                 "Start at index %d, first existing entry to compare is: "
+			                 "(%s,%s,%d,%d)",
+			                 index,
+			                 robotName.c_str(),
+			                 planIter->Task.c_str(),
+			                 planIter->Begin,
+			                 planIter->End);
+		} // else -> if ( planIter == planEnd )
 
-    // There is an entry in our old plan, which competes with an entry of the
-    // new plan for the same index.
-    while (planIter != planEnd && tempIter != tempEnd) {
-      if (sameTask(*planIter, *tempIter)) {
-        // Everything is fine, we have the same task, maybe only update the
-        // timing.
-        if (needsUpdate(*planIter, *tempIter) && !planIter->Done) {
-          logger->log_info(
-              LoggingComponent, "Update time for (%s,%s,%d,%d) to (%d,%d)",
-              robotName.c_str(), planIter->Task.c_str(), planIter->Begin,
-              planIter->End, tempIter->Begin, tempIter->End);
-          if (planIter->Begun) {
-            logger->log_warn(LoggingComponent, "The task is already started!");
-            /* Do not change the begin time for a already begun task, this
+		// There is an entry in our old plan, which competes with an entry of the
+		// new plan for the same index.
+		while (planIter != planEnd && tempIter != tempEnd) {
+			if (sameTask(*planIter, *tempIter)) {
+				// Everything is fine, we have the same task, maybe only update the
+				// timing.
+				if (needsUpdate(*planIter, *tempIter) && !planIter->Done) {
+					logger->log_info(LoggingComponent,
+					                 "Update time for (%s,%s,%d,%d) to (%d,%d)",
+					                 robotName.c_str(),
+					                 planIter->Task.c_str(),
+					                 planIter->Begin,
+					                 planIter->End,
+					                 tempIter->Begin,
+					                 tempIter->End);
+					if (planIter->Begun) {
+						logger->log_warn(LoggingComponent, "The task is already started!");
+						/* Do not change the begin time for a already begun task, this
              * breaks the evaluation based on the plan. */
-            tempIter->Begin = planIter->Begin;
-          } // if ( planIter->Begun )
-          planIter->updateTime(*tempIter);
-        } // if ( needsUpdate(*planIter, *tempIter) && !planIter->Done )
-        else {
-          logger->log_info(LoggingComponent, "Leave (%s,%s,%d,%d) unchanged.",
-                           robotName.c_str(), planIter->Task.c_str(),
-                           planIter->Begin, planIter->End);
-        } // else -> if ( needsUpdate(*planIter, *tempIter) && !planIter->Done )
-      }   // if ( sameTask(*planIter, *tempIter) )
-      else {
-        // A different task, handle differently for already started tasks.
-        const auto robotCStr = robotName.c_str();
-        if (planIter->Begun) {
-          logger->log_warn(LoggingComponent,
-                           "Should change started task %s from robot %s to %s. "
-                           "Restart solving!",
-                           planIter->Task.c_str(), robotCStr,
-                           tempIter->Task.c_str());
+						tempIter->Begin = planIter->Begin;
+					} // if ( planIter->Begun )
+					planIter->updateTime(*tempIter);
+				} // if ( needsUpdate(*planIter, *tempIter) && !planIter->Done )
+				else {
+					logger->log_info(LoggingComponent,
+					                 "Leave (%s,%s,%d,%d) unchanged.",
+					                 robotName.c_str(),
+					                 planIter->Task.c_str(),
+					                 planIter->Begin,
+					                 planIter->End);
+				} // else -> if ( needsUpdate(*planIter, *tempIter) && !planIter->Done )
+			}   // if ( sameTask(*planIter, *tempIter) )
+			else {
+				// A different task, handle differently for already started tasks.
+				const auto robotCStr = robotName.c_str();
+				if (planIter->Begun) {
+					logger->log_warn(LoggingComponent,
+					                 "Should change started task %s from robot %s to %s. "
+					                 "Restart solving!",
+					                 planIter->Task.c_str(),
+					                 robotCStr,
+					                 tempIter->Task.c_str());
 
-          commit = false;
-          break;
-        } // if ( planIter->Begun )
+					commit = false;
+					break;
+				} // if ( planIter->Begun )
 
-        logger->log_info(
-            LoggingComponent, "Change from (%s,%s,%d,%d) to (%s,%s,%d,%d).",
-            robotCStr, planIter->Task.c_str(), planIter->Begin, planIter->End,
-            robotCStr, tempIter->Task.c_str(), tempIter->Begin, tempIter->End);
-        planIter->updateTimeAndTask(*tempIter);
-      } // else -> if ( sameTask(*planIter, *tempIter) )
-      ++planIter;
-      ++tempIter;
-      ++index;
-    } // while ( planIter != planEnd && tempIter != tempEnd )
+				logger->log_info(LoggingComponent,
+				                 "Change from (%s,%s,%d,%d) to (%s,%s,%d,%d).",
+				                 robotCStr,
+				                 planIter->Task.c_str(),
+				                 planIter->Begin,
+				                 planIter->End,
+				                 robotCStr,
+				                 tempIter->Task.c_str(),
+				                 tempIter->Begin,
+				                 tempIter->End);
+				planIter->updateTimeAndTask(*tempIter);
+			} // else -> if ( sameTask(*planIter, *tempIter) )
+			++planIter;
+			++tempIter;
+			++index;
+		} // while ( planIter != planEnd && tempIter != tempEnd )
 
-    if (!commit) {
-      // Stop right here.
-      break;
-    } // if ( !commit )
+		if (!commit) {
+			// Stop right here.
+			break;
+		} // if ( !commit )
 
-    if (tempIter != tempEnd) {
-      // We have more tasks in our temp plan than in the deployed plan left.
-      robotPlan.reserve(robotPlan.size() + tempEnd - tempIter);
-      std::copy(tempIter, tempEnd, std::back_inserter(robotPlan));
-      do // while ( ++index < static_cast<int>(robotPlan.size()) )
-      {
-        const auto &entry(robotPlan[index]);
-        logger->log_info(LoggingComponent,
-                         "Add task (%s,%s,%d,%d) at index %d.",
-                         robotName.c_str(), entry.Task.c_str(), entry.Begin,
-                         entry.End, index);
-      } while (++index < static_cast<int>(robotPlan.size()));
-    } // if ( tempIter != tempEnd )
-    else if (planIter != planEnd) {
-      // We have less tasks in our temp plan than in the deployed plan left.
-      if (planIter->Begun) {
-        // Deleting a task which is already started seems not to be the best
-        // idea, restart solving.
-        logger->log_warn(
-            LoggingComponent,
-            "Should delete started task %s for robot %s! Restart solving.",
-            planIter->Task.c_str(), robotName.c_str());
-        commit = false;
-        break;
-      } // if ( planIter->Begun )
+		if (tempIter != tempEnd) {
+			// We have more tasks in our temp plan than in the deployed plan left.
+			robotPlan.reserve(robotPlan.size() + tempEnd - tempIter);
+			std::copy(tempIter, tempEnd, std::back_inserter(robotPlan));
+			do // while ( ++index < static_cast<int>(robotPlan.size()) )
+			{
+				const auto &entry(robotPlan[index]);
+				logger->log_info(LoggingComponent,
+				                 "Add task (%s,%s,%d,%d) at index %d.",
+				                 robotName.c_str(),
+				                 entry.Task.c_str(),
+				                 entry.Begin,
+				                 entry.End,
+				                 index);
+			} while (++index < static_cast<int>(robotPlan.size()));
+		} // if ( tempIter != tempEnd )
+		else if (planIter != planEnd) {
+			// We have less tasks in our temp plan than in the deployed plan left.
+			if (planIter->Begun) {
+				// Deleting a task which is already started seems not to be the best
+				// idea, restart solving.
+				logger->log_warn(LoggingComponent,
+				                 "Should delete started task %s for robot %s! Restart solving.",
+				                 planIter->Task.c_str(),
+				                 robotName.c_str());
+				commit = false;
+				break;
+			} // if ( planIter->Begun )
 
-      logger->log_info(LoggingComponent,
-                       "Remove %zu elements from (%s,%s,%d,%d) on.",
-                       planEnd - planIter, robotName.c_str(),
-                       planIter->Task.c_str(), planIter->Begin, planIter->End);
-      robotPlan.erase(planIter, planEnd);
-    } // else if ( planIter != planEnd )
-  }   // for ( auto& pair : Plan )
+			logger->log_info(LoggingComponent,
+			                 "Remove %zu elements from (%s,%s,%d,%d) on.",
+			                 planEnd - planIter,
+			                 robotName.c_str(),
+			                 planIter->Task.c_str(),
+			                 planIter->Begin,
+			                 planIter->End);
+			robotPlan.erase(planIter, planEnd);
+		} // else if ( planIter != planEnd )
+	}   // for ( auto& pair : Plan )
 
-  if (commit) {
-    logger->log_info(
-        LoggingComponent,
-        "Plan updating done, commit changes into the deployed plan.");
+	if (commit) {
+		logger->log_info(LoggingComponent,
+		                 "Plan updating done, commit changes into the deployed plan.");
 
-    // To commit the changes we only have to update the database and make a swap
-    // at the end of the loop.
-    for (const auto &pair : Robots) {
-      const auto &robot(pair.first);
-      auto &deployed(Plan[robot].Tasks);
-      auto &updated(planCopy[robot]);
+		// To commit the changes we only have to update the database and make a swap
+		// at the end of the loop.
+		for (const auto &pair : Robots) {
+			const auto &robot(pair.first);
+			auto &      deployed(Plan[robot].Tasks);
+			auto &      updated(planCopy[robot]);
 
-      int index = 0;
-      const int dSize(deployed.size()), uSize(updated.size());
-      for (; index < dSize && index < uSize; ++index) {
-        if (sameTask(deployed[index], updated[index])) {
-          if (needsUpdate(deployed[index], updated[index])) {
-            updatePlanTiming(robot, index, updated[index]);
-          } // if ( needsUpdate(deployed[index], updated[index]) )
-        }   // if ( sameTask(deployed[index], updated[index]) )
-        else {
-          updatePlan(robot, index, updated[index]);
-        } // else -> if ( sameTask(deployed[index], updated[index]) )
-      }   // for ( ; index < dSize && index < uSize; ++index )
+			int       index = 0;
+			const int dSize(deployed.size()), uSize(updated.size());
+			for (; index < dSize && index < uSize; ++index) {
+				if (sameTask(deployed[index], updated[index])) {
+					if (needsUpdate(deployed[index], updated[index])) {
+						updatePlanTiming(robot, index, updated[index]);
+					} // if ( needsUpdate(deployed[index], updated[index]) )
+				}   // if ( sameTask(deployed[index], updated[index]) )
+				else {
+					updatePlan(robot, index, updated[index]);
+				} // else -> if ( sameTask(deployed[index], updated[index]) )
+			}   // for ( ; index < dSize && index < uSize; ++index )
 
-      // At most one of the following loops will be executed.
-      for (; index < dSize; ++index) {
-        removeFromPlanDB(robot, index);
-      } // for ( ; index < dSize; ++index )
+			// At most one of the following loops will be executed.
+			for (; index < dSize; ++index) {
+				removeFromPlanDB(robot, index);
+			} // for ( ; index < dSize; ++index )
 
-      for (; index < uSize; ++index) {
-        insertPlanElement(robot, index, updated[index]);
-      } // for ( ; index < uSize; ++index )
+			for (; index < uSize; ++index) {
+				insertPlanElement(robot, index, updated[index]);
+			} // for ( ; index < uSize; ++index )
 
-      using std::swap;
-      swap(deployed, updated);
-    } // for ( const auto& pair : Robots )
-  }   // if ( commit )
-  else {
-    logger->log_info(
-        LoggingComponent,
-        "The new plan will be discarded because of inconsistencies.");
-    setInterrupt(InterruptSolving::Critical, "Inconsistent plan");
-  } // else -> if ( commit )
-  return;
+			using std::swap;
+			swap(deployed, updated);
+		} // for ( const auto& pair : Robots )
+	}   // if ( commit )
+	else {
+		logger->log_info(LoggingComponent,
+		                 "The new plan will be discarded because of inconsistencies.");
+		setInterrupt(InterruptSolving::Critical, "Inconsistent plan");
+	} // else -> if ( commit )
+	return;
 }
 
 /**
@@ -514,18 +558,18 @@ void AspPlannerThread::loopPlan(void) {
  * @param[in] string The string to transform.
  * @return The transformed string.
  */
-static std::string taskASPtoCLIPS(std::string string) {
-  std::transform(string.begin(), string.end(), string.begin(),
-                 [](const char c) noexcept {
-                   switch (c) {
-                   case ',':
-                     return ' ';
-                   case '"':
-                     return '\'';
-                   } // switch ( c )
-                   return c;
-                 });
-  return string;
+static std::string
+taskASPtoCLIPS(std::string string)
+{
+	std::transform(
+	  string.begin(), string.end(), string.begin(), [](const char c) noexcept {
+		  switch (c) {
+		  case ',': return ' ';
+		  case '"': return '\'';
+		  } // switch ( c )
+		  return c;
+	  });
+	return string;
 }
 
 /**
@@ -533,18 +577,18 @@ static std::string taskASPtoCLIPS(std::string string) {
  * @param[in] string The string to transform.
  * @return The transformed string.
  */
-static std::string taskCLIPStoASP(std::string string) {
-  std::transform(string.begin(), string.end(), string.begin(),
-                 [](const char c) noexcept {
-                   switch (c) {
-                   case ' ':
-                     return ',';
-                   case '\'':
-                     return '"';
-                   } // switch ( c )
-                   return c;
-                 });
-  return string;
+static std::string
+taskCLIPStoASP(std::string string)
+{
+	std::transform(
+	  string.begin(), string.end(), string.begin(), [](const char c) noexcept {
+		  switch (c) {
+		  case ' ': return ',';
+		  case '\'': return '"';
+		  } // switch ( c )
+		  return c;
+	  });
+	return string;
 }
 
 /**
@@ -553,13 +597,12 @@ static std::string taskCLIPStoASP(std::string string) {
  * @param[in] elementIndex The index of the element.
  * @return The MongoDB query.
  */
-static mongo::BSONObj createQuery(const std::string &robot,
-                                  const int elementIndex) {
-  mongo::BSONObjBuilder builder;
-  builder.append("relation", "planElement")
-      .append("robot", robot)
-      .append("index", elementIndex);
-  return builder.obj();
+static mongo::BSONObj
+createQuery(const std::string &robot, const int elementIndex)
+{
+	mongo::BSONObjBuilder builder;
+	builder.append("relation", "planElement").append("robot", robot).append("index", elementIndex);
+	return builder.obj();
 }
 
 /**
@@ -570,19 +613,19 @@ static mongo::BSONObj createQuery(const std::string &robot,
  * @param[in] element The element.
  * @return The object.
  */
-static mongo::BSONObj createObject(const std::string &robot,
-                                   const int elementIndex,
-                                   const PlanElement &element) {
-  mongo::BSONObjBuilder builder;
-  builder.append("relation", "planElement")
-      .append("robot", robot)
-      .append("task", "\"" + taskASPtoCLIPS(element.Task) + "\"")
-      .append("begin", element.Begin)
-      .append("end", element.End);
-  if (elementIndex >= 0) {
-    builder.append("index", elementIndex);
-  } // if ( elementIndex >= 0 )
-  return builder.obj();
+static mongo::BSONObj
+createObject(const std::string &robot, const int elementIndex, const PlanElement &element)
+{
+	mongo::BSONObjBuilder builder;
+	builder.append("relation", "planElement")
+	  .append("robot", robot)
+	  .append("task", "\"" + taskASPtoCLIPS(element.Task) + "\"")
+	  .append("begin", element.Begin)
+	  .append("end", element.End);
+	if (elementIndex >= 0) {
+		builder.append("index", elementIndex);
+	} // if ( elementIndex >= 0 )
+	return builder.obj();
 }
 
 /**
@@ -592,12 +635,13 @@ static mongo::BSONObj createObject(const std::string &robot,
  * the executive.
  * @param[in] element The element.
  */
-void AspPlannerThread::insertPlanElement(const std::string &robot,
-                                         const int elementIndex,
-                                         const PlanElement &element) {
-  robot_memory->insert(createObject(robot, elementIndex, element),
-                       "syncedrobmem.plan");
-  return;
+void
+AspPlannerThread::insertPlanElement(const std::string &robot,
+                                    const int          elementIndex,
+                                    const PlanElement &element)
+{
+	robot_memory->insert(createObject(robot, elementIndex, element), "syncedrobmem.plan");
+	return;
 }
 
 /**
@@ -607,13 +651,16 @@ void AspPlannerThread::insertPlanElement(const std::string &robot,
  * the executive.
  * @param[in] element The element.
  */
-void AspPlannerThread::updatePlan(const std::string &robot,
-                                  const int elementIndex,
-                                  const PlanElement &element) {
-  robot_memory->update(createQuery(robot, elementIndex),
-                       createObject(robot, elementIndex, element),
-                       "syncedrobmem.plan", true);
-  return;
+void
+AspPlannerThread::updatePlan(const std::string &robot,
+                             const int          elementIndex,
+                             const PlanElement &element)
+{
+	robot_memory->update(createQuery(robot, elementIndex),
+	                     createObject(robot, elementIndex, element),
+	                     "syncedrobmem.plan",
+	                     true);
+	return;
 }
 
 /**
@@ -623,13 +670,15 @@ void AspPlannerThread::updatePlan(const std::string &robot,
  * the executive.
  * @param[in] element The element.
  */
-void AspPlannerThread::updatePlanTiming(const std::string &robot,
-                                        const int elementIndex,
-                                        const PlanElement &element) {
-  /* The idea was only to update the time, but this either don't work, or my
+void
+AspPlannerThread::updatePlanTiming(const std::string &robot,
+                                   const int          elementIndex,
+                                   const PlanElement &element)
+{
+	/* The idea was only to update the time, but this either don't work, or my
    * query wasn't good enough, so call the general update method. */
-  updatePlan(robot, elementIndex, element);
-  return;
+	updatePlan(robot, elementIndex, element);
+	return;
 }
 
 /**
@@ -637,10 +686,11 @@ void AspPlannerThread::updatePlanTiming(const std::string &robot,
  * @param[in] robot For which robot the plan element is.
  * @param[in] element The element.
  */
-void AspPlannerThread::removeFromPlanDB(const std::string &robot,
-                                        const int elementIndex) {
-  robot_memory->remove(createQuery(robot, elementIndex), "syncedrobmem.plan");
-  return;
+void
+AspPlannerThread::removeFromPlanDB(const std::string &robot, const int elementIndex)
+{
+	robot_memory->remove(createQuery(robot, elementIndex), "syncedrobmem.plan");
+	return;
 }
 
 /**
@@ -649,71 +699,73 @@ void AspPlannerThread::removeFromPlanDB(const std::string &robot,
  * @param[in] robot The robots name.
  * @note The plan lock has to be hold.
  */
-void AspPlannerThread::tellRobotToStop(const std::string &robot) {
-  mongo::BSONObjBuilder builder;
-  builder.append("robot", robot).append("stop", true);
-  robot_memory->insert(builder.obj(), "syncedrobmem.stopPlan");
+void
+AspPlannerThread::tellRobotToStop(const std::string &robot)
+{
+	mongo::BSONObjBuilder builder;
+	builder.append("robot", robot).append("stop", true);
+	robot_memory->insert(builder.obj(), "syncedrobmem.stopPlan");
 
-  auto &robotPlan(Plan[robot]);
-  for (auto index = robotPlan.FirstNotDone; index < robotPlan.Tasks.size();
-       ++index) {
-    removeFromPlanDB(robot, index);
-  } // for ( auto index = robotPlan.FirstNotDone; index <
-    // robotPlan.Tasks.size(); ++index )
-  robotPlan.Tasks.erase(robotPlan.Tasks.begin() + robotPlan.FirstNotDone,
-                        robotPlan.Tasks.end());
-  return;
+	auto &robotPlan(Plan[robot]);
+	for (auto index = robotPlan.FirstNotDone; index < robotPlan.Tasks.size(); ++index) {
+		removeFromPlanDB(robot, index);
+	} // for ( auto index = robotPlan.FirstNotDone; index <
+	// robotPlan.Tasks.size(); ++index )
+	robotPlan.Tasks.erase(robotPlan.Tasks.begin() + robotPlan.FirstNotDone, robotPlan.Tasks.end());
+	return;
 }
 
 /**
  * @brief Gets called if there is feedback from one of the robots.
  * @param[in] document The document with the feedback.
  */
-void AspPlannerThread::planFeedbackCallback(const mongo::BSONObj document) {
-  try {
-    const auto object(document.getField("o"));
-    const auto action(object["action"].String());
-    const auto robot(object["robot"].String());
-    const auto task(taskCLIPStoASP(object["task"].String()));
+void
+AspPlannerThread::planFeedbackCallback(const mongo::BSONObj document)
+{
+	try {
+		const auto object(document.getField("o"));
+		const auto action(object["action"].String());
+		const auto robot(object["robot"].String());
+		const auto task(taskCLIPStoASP(object["task"].String()));
 
-    MutexLocker planLocker(&PlanMutex);
-    auto &robotPlan(Plan[robot]);
-    logger->log_info(LoggingComponent,
-                     "Plan-Feedback, R: %s T: %s A: %s CT: %s", robot.c_str(),
-                     task.c_str(), action.c_str(),
-                     robotPlan.CurrentTask.c_str());
-    planLocker.unlock();
+		MutexLocker planLocker(&PlanMutex);
+		auto &      robotPlan(Plan[robot]);
+		logger->log_info(LoggingComponent,
+		                 "Plan-Feedback, R: %s T: %s A: %s CT: %s",
+		                 robot.c_str(),
+		                 task.c_str(),
+		                 action.c_str(),
+		                 robotPlan.CurrentTask.c_str());
+		planLocker.unlock();
 
-    // Switch only the first character because it is unique and we skip all the
-    // string handling.
-    switch (action[0]) {
-    case 'b': {
-      robotBegunWithTask(robot, task, object["begin"].Long(),
-                         object["end"].Long());
-      break;
-    } // case 'b'
-    case 'u': {
-      robotUpdatesTaskTimeEstimation(robot, task, object["end"].Long());
-      break;
-    } // case 'u'
-    case 'e': {
-      robotFinishedTask(robot, task, object["end"].Long(),
-                        object["success"].String() == "TRUE");
-      break;
-    } // case 'e'
-    default:
-      throw fawkes::Exception("Unknown action %s!", action.c_str());
-    } // switch ( action[0] )
-  }   // try
-  catch (const std::exception &e) {
-    logger->log_error(LoggingComponent,
-                      "Exception while extracting plan feedback: %s\n%s",
-                      e.what(), document.toString().c_str());
-  } // catch ( const std::exception& e )
-  catch (...) {
-    logger->log_error(LoggingComponent,
-                      "Exception while extracting plan feedback.\n%s",
-                      document.toString().c_str());
-  } // catch ( ... )
-  return;
+		// Switch only the first character because it is unique and we skip all the
+		// string handling.
+		switch (action[0]) {
+		case 'b': {
+			robotBegunWithTask(robot, task, object["begin"].Long(), object["end"].Long());
+			break;
+		} // case 'b'
+		case 'u': {
+			robotUpdatesTaskTimeEstimation(robot, task, object["end"].Long());
+			break;
+		} // case 'u'
+		case 'e': {
+			robotFinishedTask(robot, task, object["end"].Long(), object["success"].String() == "TRUE");
+			break;
+		} // case 'e'
+		default: throw fawkes::Exception("Unknown action %s!", action.c_str());
+		} // switch ( action[0] )
+	}   // try
+	catch (const std::exception &e) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while extracting plan feedback: %s\n%s",
+		                  e.what(),
+		                  document.toString().c_str());
+	} // catch ( const std::exception& e )
+	catch (...) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while extracting plan feedback.\n%s",
+		                  document.toString().c_str());
+	} // catch ( ... )
+	return;
 }

--- a/src/plugins/asp-planner/asp_planner_plugin.cpp
+++ b/src/plugins/asp-planner/asp_planner_plugin.cpp
@@ -22,19 +22,22 @@
  */
 
 #include "asp_planner_thread.h"
+
 #include <core/plugin.h>
 
 /** ASP planner plugin.
  */
-class AspPlannerPlugin : public fawkes::Plugin {
+class AspPlannerPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  AspPlannerPlugin(fawkes::Configuration *config) : Plugin(config) {
-    thread_list.push_back(new AspPlannerThread);
-    return;
-  }
+	AspPlannerPlugin(fawkes::Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new AspPlannerThread);
+		return;
+	}
 };
 
 PLUGIN_DESCRIPTION("ASP-based planner plugin")

--- a/src/plugins/asp-planner/asp_planner_thread.cpp
+++ b/src/plugins/asp-planner/asp_planner_thread.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "asp_planner_thread.h"
+
 #include "asp_planner_externals.h"
 
 #include <core/threading/mutex_locker.h>
@@ -35,14 +36,15 @@ using fawkes::MutexLocker;
  * @param[in] realGameTime The real game time in seconds.
  * @return The ASP time units.
  */
-int AspPlannerThread::realGameTimeToAspGameTime(const int realGameTime) const
-    noexcept {
-  if (realGameTime == 0) {
-    return 0;
-  } // if ( realGameTime == 0 )
-  return std::max(
-      1, realGameTime / TimeResolution +
-             ((realGameTime % TimeResolution) * 2 >= TimeResolution ? 1 : 0));
+int
+AspPlannerThread::realGameTimeToAspGameTime(const int realGameTime) const noexcept
+{
+	if (realGameTime == 0) {
+		return 0;
+	} // if ( realGameTime == 0 )
+	return std::max(1,
+	                realGameTime / TimeResolution
+	                  + ((realGameTime % TimeResolution) * 2 >= TimeResolution ? 1 : 0));
 }
 
 /**
@@ -50,44 +52,47 @@ int AspPlannerThread::realGameTimeToAspGameTime(const int realGameTime) const
  * @param[in] aspGameTime The ASP time units.
  * @return The real game time in seconds.
  */
-int AspPlannerThread::aspGameTimeToRealGameTime(const int aspGameTime) const
-    noexcept {
-  return aspGameTime * TimeResolution;
+int
+AspPlannerThread::aspGameTimeToRealGameTime(const int aspGameTime) const noexcept
+{
+	return aspGameTime * TimeResolution;
 }
 
 /**
  * @brief Gets called, when a beacon is received, updates the robot information.
  * @param[in] document The DB document.
  */
-void AspPlannerThread::beaconCallback(const mongo::BSONObj document) {
-  try {
-    const auto object(document.getField("o"));
-    const std::string name(object["name"].String());
-    MutexLocker locker(&WorldMutex);
-    auto &info = Robots[name];
+void
+AspPlannerThread::beaconCallback(const mongo::BSONObj document)
+{
+	try {
+		const auto        object(document.getField("o"));
+		const std::string name(object["name"].String());
+		MutexLocker       locker(&WorldMutex);
+		auto &            info = Robots[name];
 
-    if (!info.Alive) {
-      logger->log_info(LoggingComponent, "New robot %s detected.",
-                       name.c_str());
-      setInterrupt(InterruptSolving::Critical, "New robot");
-      info.AliveExternal = generateAliveExternal(name);
-    } // if ( !info.Alive )
-    info.LastSeen = Clock::now();
-    info.Alive = true;
-    info.X = static_cast<float>(object["x"].Double());
-    info.Y = static_cast<float>(object["y"].Double());
-  } // try
-  catch (const std::exception &e) {
-    logger->log_error(LoggingComponent,
-                      "Exception while updating robot information: %s\n%s",
-                      e.what(), document.toString().c_str());
-  } // catch ( const std::exception& e )
-  catch (...) {
-    logger->log_error(LoggingComponent,
-                      "Exception while updating robot information.\n%s",
-                      document.toString().c_str());
-  } // catch ( ... )
-  return;
+		if (!info.Alive) {
+			logger->log_info(LoggingComponent, "New robot %s detected.", name.c_str());
+			setInterrupt(InterruptSolving::Critical, "New robot");
+			info.AliveExternal = generateAliveExternal(name);
+		} // if ( !info.Alive )
+		info.LastSeen = Clock::now();
+		info.Alive    = true;
+		info.X        = static_cast<float>(object["x"].Double());
+		info.Y        = static_cast<float>(object["y"].Double());
+	} // try
+	catch (const std::exception &e) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while updating robot information: %s\n%s",
+		                  e.what(),
+		                  document.toString().c_str());
+	} // catch ( const std::exception& e )
+	catch (...) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while updating robot information.\n%s",
+		                  document.toString().c_str());
+	} // catch ( ... )
+	return;
 }
 
 /**
@@ -95,33 +100,36 @@ void AspPlannerThread::beaconCallback(const mongo::BSONObj document) {
  * game-time.
  * @param[in] document The DB document.
  */
-void AspPlannerThread::gameTimeCallback(const mongo::BSONObj document) {
-  try {
-    const auto object(document.getField("o"));
-    const std::string phase(object["phase"].String());
-    const int gameTime(object["time"].Long());
-    MutexLocker locker(&WorldMutex);
-    if (phase == "EXPLORATION") {
-      GameTime = gameTime;
-    } // if ( phase == "EXPLORATION" )
-    else if (phase == "PRODUCTION") {
-      GameTime = ExplorationTime + gameTime;
-    } // else if ( phase == "PRODUCTION" )
-    else if (phase == "POST_GAME") {
-      GameTime = -1;
-    } // else if ( phase == "POST_GAME" )
-  }   // try
-  catch (const std::exception &e) {
-    logger->log_error(LoggingComponent,
-                      "Exception while updating game time: %s\n%s", e.what(),
-                      document.toString().c_str());
-  } // catch ( const std::exception& e )
-  catch (...) {
-    logger->log_error(LoggingComponent,
-                      "Exception while updating game time.\n%s",
-                      document.toString().c_str());
-  } // catch ( ... )
-  return;
+void
+AspPlannerThread::gameTimeCallback(const mongo::BSONObj document)
+{
+	try {
+		const auto        object(document.getField("o"));
+		const std::string phase(object["phase"].String());
+		const int         gameTime(object["time"].Long());
+		MutexLocker       locker(&WorldMutex);
+		if (phase == "EXPLORATION") {
+			GameTime = gameTime;
+		} // if ( phase == "EXPLORATION" )
+		else if (phase == "PRODUCTION") {
+			GameTime = ExplorationTime + gameTime;
+		} // else if ( phase == "PRODUCTION" )
+		else if (phase == "POST_GAME") {
+			GameTime = -1;
+		} // else if ( phase == "POST_GAME" )
+	}   // try
+	catch (const std::exception &e) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while updating game time: %s\n%s",
+		                  e.what(),
+		                  document.toString().c_str());
+	} // catch ( const std::exception& e )
+	catch (...) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while updating game time.\n%s",
+		                  document.toString().c_str());
+	} // catch ( ... )
+	return;
 }
 
 /**
@@ -129,499 +137,561 @@ void AspPlannerThread::gameTimeCallback(const mongo::BSONObj document) {
  * refbox.
  * @param[in] document The information about the machine.
  */
-void AspPlannerThread::machineCallback(const mongo::BSONObj document) {
-  try {
-    const auto object(document.getField("o"));
-    // Remove the first 2 letters, because this is the team color and the dash.
-    // We identify by "BS" not "C-BS".
-    const std::string machine(object["machine"].String().substr(2));
-    const std::string state(object["state"].String());
-    MutexLocker locker(&WorldMutex);
-    auto &info(Machines[machine]);
-    if (state != info.State) {
-      logger->log_warn(LoggingComponent, "Machine %s from %s to %s",
-                       machine.c_str(), info.State.c_str(), state.c_str());
-      if (state == "BROKEN" || state == "DOWN") {
-        static const int brokenTime =
-            config->get_int("/asp-agent/working-durations/broken");
-        if (info.WorkingUntil) {
-          info.WorkingUntil -= GameTime;
-        } // if ( info.WorkingUntil )
-        info.BrokenUntil = GameTime + brokenTime;
+void
+AspPlannerThread::machineCallback(const mongo::BSONObj document)
+{
+	try {
+		const auto object(document.getField("o"));
+		// Remove the first 2 letters, because this is the team color and the dash.
+		// We identify by "BS" not "C-BS".
+		const std::string machine(object["machine"].String().substr(2));
+		const std::string state(object["state"].String());
+		MutexLocker       locker(&WorldMutex);
+		auto &            info(Machines[machine]);
+		if (state != info.State) {
+			logger->log_warn(LoggingComponent,
+			                 "Machine %s from %s to %s",
+			                 machine.c_str(),
+			                 info.State.c_str(),
+			                 state.c_str());
+			if (state == "BROKEN" || state == "DOWN") {
+				static const int brokenTime = config->get_int("/asp-agent/working-durations/broken");
+				if (info.WorkingUntil) {
+					info.WorkingUntil -= GameTime;
+				} // if ( info.WorkingUntil )
+				info.BrokenUntil = GameTime + brokenTime;
 
-        if (state == "BROKEN") {
-          info.Prepared = false;
-          info.FillState = 0;
-        } // if ( state == "BROKEN" )
+				if (state == "BROKEN") {
+					info.Prepared  = false;
+					info.FillState = 0;
+				} // if ( state == "BROKEN" )
 
-        setInterrupt(InterruptSolving::Critical, "Machine broken/down");
-      } // if ( state == "BROKEN" || state == "DOWN" )
+				setInterrupt(InterruptSolving::Critical, "Machine broken/down");
+			} // if ( state == "BROKEN" || state == "DOWN" )
 
-      if (info.State == "BROKEN" || info.State == "DOWN") {
-        if (info.WorkingUntil) {
-          info.WorkingUntil += GameTime;
-        } // if ( info.WorkingUntil )
+			if (info.State == "BROKEN" || info.State == "DOWN") {
+				if (info.WorkingUntil) {
+					info.WorkingUntil += GameTime;
+				} // if ( info.WorkingUntil )
 
-        const auto diff(GameTime - info.BrokenUntil);
-        logger->log_info(LoggingComponent,
-                         "Machine up again, now: %d, expected: %d, diff: %d",
-                         GameTime, info.BrokenUntil, diff);
-        info.BrokenUntil = 0;
+				const auto diff(GameTime - info.BrokenUntil);
+				logger->log_info(LoggingComponent,
+				                 "Machine up again, now: %d, expected: %d, diff: %d",
+				                 GameTime,
+				                 info.BrokenUntil,
+				                 diff);
+				info.BrokenUntil = 0;
 
-        if (diff <= -15) {
-          setInterrupt(InterruptSolving::High, "Machine much earlier up again");
-        } // if ( diff <= -15 )
-        else if (diff <= -8) {
-          setInterrupt(InterruptSolving::Normal, "Machine earlier up again");
-        } // else if ( diff <= -8 )
-      }   // if (info.State == "BROKEN" || info.State == "DOWN" )
-    }     // if ( state != Machines[machine].State )
-    info.State = std::move(state);
-  } // try
-  catch (const std::exception &e) {
-    logger->log_error(LoggingComponent,
-                      "Exception while extracting machine info: %s\n%s",
-                      e.what(), document.toString().c_str());
-  } // catch ( const std::exception& e )
-  catch (...) {
-    logger->log_error(LoggingComponent,
-                      "Exception while extracting machine info.\n%s",
-                      document.toString().c_str());
-  } // catch ( ... )
-  return;
+				if (diff <= -15) {
+					setInterrupt(InterruptSolving::High, "Machine much earlier up again");
+				} // if ( diff <= -15 )
+				else if (diff <= -8) {
+					setInterrupt(InterruptSolving::Normal, "Machine earlier up again");
+				} // else if ( diff <= -8 )
+			}   // if (info.State == "BROKEN" || info.State == "DOWN" )
+		}     // if ( state != Machines[machine].State )
+		info.State = std::move(state);
+	} // try
+	catch (const std::exception &e) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while extracting machine info: %s\n%s",
+		                  e.what(),
+		                  document.toString().c_str());
+	} // catch ( const std::exception& e )
+	catch (...) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while extracting machine info.\n%s",
+		                  document.toString().c_str());
+	} // catch ( ... )
+	return;
 }
 
 /**
  * @brief Gets called if we got a new order.
  * @param[in] document The information about the order.
  */
-void AspPlannerThread::orderCallback(const mongo::BSONObj document) {
-  try {
-    const auto object(document.getField("o"));
-    const int number(object["number"].Long());
-    const int quantity(object["quantity"].Long());
-    const std::string base(object["base"].String());
-    const std::string cap(object["cap"].String());
-    const auto rings(object["rings"].Array());
-    const std::string ring1(rings.size() >= 1 ? rings[0].String() : "none");
-    const std::string ring2(rings.size() >= 2 ? rings[1].String() : "none");
-    const std::string ring3(rings.size() >= 3 ? rings[2].String() : "none");
-    const int delBegin(object["begin"].Long() + ExplorationTime);
-    const int delEnd(object["end"].Long() + ExplorationTime);
+void
+AspPlannerThread::orderCallback(const mongo::BSONObj document)
+{
+	try {
+		const auto        object(document.getField("o"));
+		const int         number(object["number"].Long());
+		const int         quantity(object["quantity"].Long());
+		const std::string base(object["base"].String());
+		const std::string cap(object["cap"].String());
+		const auto        rings(object["rings"].Array());
+		const std::string ring1(rings.size() >= 1 ? rings[0].String() : "none");
+		const std::string ring2(rings.size() >= 2 ? rings[1].String() : "none");
+		const std::string ring3(rings.size() >= 3 ? rings[2].String() : "none");
+		const int         delBegin(object["begin"].Long() + ExplorationTime);
+		const int         delEnd(object["end"].Long() + ExplorationTime);
 
-    MutexLocker locker(&WorldMutex);
-    Orders.insert(
-        {number, OrderInformation{number, quantity, base, cap, std::string(),
-                                  ring1, ring2, ring3, delBegin, delEnd}});
+		MutexLocker locker(&WorldMutex);
+		Orders.insert(
+		  {number,
+		   OrderInformation{
+		     number, quantity, base, cap, std::string(), ring1, ring2, ring3, delBegin, delEnd}});
 
-    if (RingColors.size() == 4) {
-      // Do only spawn tasks when we have the ring infos.
-      addOrderToASP(Orders[number]);
-    } // if ( RingColors.size() > 4 )
+		if (RingColors.size() == 4) {
+			// Do only spawn tasks when we have the ring infos.
+			addOrderToASP(Orders[number]);
+		} // if ( RingColors.size() > 4 )
 
-    if (number > MaxOrders) {
-      logger->log_error(
-          LoggingComponent,
-          "We expect no higher order numbers than %d, but got %d! This order "
-          "will not be considered by the ASP program!",
-          MaxOrders, number);
-    } // if ( number > MaxOrders )
-    if (quantity > MaxQuantity) {
-      logger->log_error(
-          LoggingComponent,
-          "We expect no higher quantities for orders than %d, but got %d! This "
-          "order will not be considered by the ASP program!",
-          MaxQuantity, quantity);
-    } // if ( quantity > MaxQuantity )
-  }   // try
-  catch (const std::exception &e) {
-    logger->log_error(LoggingComponent,
-                      "Exception while extracting an order: %s\n%s", e.what(),
-                      document.toString().c_str());
-  } // catch ( const std::exception& e )
-  catch (...) {
-    logger->log_error(LoggingComponent,
-                      "Exception while extracting an order.\n%s",
-                      document.toString().c_str());
-  } // catch ( ... )
-  return;
+		if (number > MaxOrders) {
+			logger->log_error(LoggingComponent,
+			                  "We expect no higher order numbers than %d, but got %d! This order "
+			                  "will not be considered by the ASP program!",
+			                  MaxOrders,
+			                  number);
+		} // if ( number > MaxOrders )
+		if (quantity > MaxQuantity) {
+			logger->log_error(LoggingComponent,
+			                  "We expect no higher quantities for orders than %d, but got %d! This "
+			                  "order will not be considered by the ASP program!",
+			                  MaxQuantity,
+			                  quantity);
+		} // if ( quantity > MaxQuantity )
+	}   // try
+	catch (const std::exception &e) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while extracting an order: %s\n%s",
+		                  e.what(),
+		                  document.toString().c_str());
+	} // catch ( const std::exception& e )
+	catch (...) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while extracting an order.\n%s",
+		                  document.toString().c_str());
+	} // catch ( ... )
+	return;
 }
 
 /**
  * @brief Gets called if we know all we need to know about a ring color.
  * @param[in] document The information about the color.
  */
-void AspPlannerThread::ringColorCallback(const mongo::BSONObj document) {
-  try {
-    const auto object(document.getField("o"));
-    const std::string color(object["color"].String());
-    const int cost(object["cost"].Long());
-    const std::string machine(object["machine"].String().substr(2));
+void
+AspPlannerThread::ringColorCallback(const mongo::BSONObj document)
+{
+	try {
+		const auto        object(document.getField("o"));
+		const std::string color(object["color"].String());
+		const int         cost(object["cost"].Long());
+		const std::string machine(object["machine"].String().substr(2));
 
-    MutexLocker locker(&WorldMutex);
-    RingColors.emplace_back(RingColorInformation{color, machine, cost});
+		MutexLocker locker(&WorldMutex);
+		RingColors.emplace_back(RingColorInformation{color, machine, cost});
 
-    addRingColorToASP(RingColors.back());
+		addRingColorToASP(RingColors.back());
 
-    if (RingColors.size() == 4) {
-      // We have the last ring info, spawn orders we have received until now.
-      for (const auto &pair : Orders) {
-        addOrderToASP(pair.second);
-      } // for ( const auto& pair : Orders )
-    }   // if ( RingColors.size() == 4 )
-  }     // try
-  catch (const std::exception &e) {
-    logger->log_error(LoggingComponent,
-                      "Exception while setting ring color: %s\n%s", e.what(),
-                      document.toString().c_str());
-  } // catch ( const std::exception& e )
-  catch (...) {
-    logger->log_error(LoggingComponent,
-                      "Exception while setting ring color.\n%s",
-                      document.toString().c_str());
-  } // catch ( ... )
-  return;
+		if (RingColors.size() == 4) {
+			// We have the last ring info, spawn orders we have received until now.
+			for (const auto &pair : Orders) {
+				addOrderToASP(pair.second);
+			} // for ( const auto& pair : Orders )
+		}   // if ( RingColors.size() == 4 )
+	}     // try
+	catch (const std::exception &e) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while setting ring color: %s\n%s",
+		                  e.what(),
+		                  document.toString().c_str());
+	} // catch ( const std::exception& e )
+	catch (...) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while setting ring color.\n%s",
+		                  document.toString().c_str());
+	} // catch ( ... )
+	return;
 }
 
 /**
  * @brief Gets called, when the team color is changed.
  * @param[in] document The document with the new color.
  */
-void AspPlannerThread::teamColorCallback(const mongo::BSONObj document) {
-  try {
-    const auto object(document.getField("o"));
-    const std::string color(object["values"].Array().at(0).String());
-    if (TeamColor) {
-      if (color == "nil") {
-        TeamColor = nullptr;
-        logger->log_info(LoggingComponent, "Unsetting Team-Color.");
-      } // if ( color == "nil" )
-      else {
-        logger->log_info(LoggingComponent, "Changing Team-Color to %s.",
-                         color.c_str());
-      } // else -> if ( color == "nil" )
-      unsetTeam();
-    } // if ( TeamColor )
-    else {
-      logger->log_info(LoggingComponent, "Setting Team-Color to %s.",
-                       color.c_str());
-    } // else -> if ( TeamColor )
+void
+AspPlannerThread::teamColorCallback(const mongo::BSONObj document)
+{
+	try {
+		const auto        object(document.getField("o"));
+		const std::string color(object["values"].Array().at(0).String());
+		if (TeamColor) {
+			if (color == "nil") {
+				TeamColor = nullptr;
+				logger->log_info(LoggingComponent, "Unsetting Team-Color.");
+			} // if ( color == "nil" )
+			else {
+				logger->log_info(LoggingComponent, "Changing Team-Color to %s.", color.c_str());
+			} // else -> if ( color == "nil" )
+			unsetTeam();
+		} // if ( TeamColor )
+		else {
+			logger->log_info(LoggingComponent, "Setting Team-Color to %s.", color.c_str());
+		} // else -> if ( TeamColor )
 
-    if (color != "nil") {
-      TeamColor = color == "CYAN" ? "C" : "M";
-      setTeam();
-    } // if ( color != "nil" )
-  }   // try
-  catch (const std::exception &e) {
-    logger->log_error(LoggingComponent,
-                      "Exception while updating the team color: %s\n%s",
-                      e.what(), document.toString().c_str());
-  } // catch ( const std::exception& e )
-  catch (...) {
-    logger->log_error(LoggingComponent,
-                      "Exception while updating the team color.\n%s",
-                      document.toString().c_str());
-  } // catch ( ... )
-  return;
+		if (color != "nil") {
+			TeamColor = color == "CYAN" ? "C" : "M";
+			setTeam();
+		} // if ( color != "nil" )
+	}   // try
+	catch (const std::exception &e) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while updating the team color: %s\n%s",
+		                  e.what(),
+		                  document.toString().c_str());
+	} // catch ( const std::exception& e )
+	catch (...) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while updating the team color.\n%s",
+		                  document.toString().c_str());
+	} // catch ( ... )
+	return;
 }
 
 /**
  * @brief Gets called, when the zones to explore are set.
  * @param[in] document The document with the zones.
  */
-void AspPlannerThread::zonesCallback(const mongo::BSONObj document) {
-  try {
-    const auto object(document.getField("o"));
-    const auto zonesArray(object["zones"].Array());
-    std::vector<int> zones;
-    zones.reserve(zonesArray.size());
-    std::transform(std::begin(zonesArray), std::end(zonesArray),
-                   std::back_inserter(zones),
-                   [](const mongo::BSONElement &zone) {
-                     return std::stoi(zone.String().substr(1));
-                   });
-    const auto begin = zones.begin();
-    auto end = zones.end();
-    MutexLocker locker(&WorldMutex);
-    ReceivedZonesToExplore = true;
-    for (auto zone = 1; zone <= 24; ++zone) {
-      auto iter = std::find(begin, end, zone);
-      if (iter == end) {
-        releaseZone(zone, false);
-      } // if ( iter == end )
-      else {
-        ZonesToExplore.push_back(zone);
-        addZoneToExplore(zone);
-        /* Move the found zone to the end, and move the end iterator one to the
+void
+AspPlannerThread::zonesCallback(const mongo::BSONObj document)
+{
+	try {
+		const auto       object(document.getField("o"));
+		const auto       zonesArray(object["zones"].Array());
+		std::vector<int> zones;
+		zones.reserve(zonesArray.size());
+		std::transform(std::begin(zonesArray),
+		               std::end(zonesArray),
+		               std::back_inserter(zones),
+		               [](const mongo::BSONElement &zone) {
+			               return std::stoi(zone.String().substr(1));
+		               });
+		const auto  begin = zones.begin();
+		auto        end   = zones.end();
+		MutexLocker locker(&WorldMutex);
+		ReceivedZonesToExplore = true;
+		for (auto zone = 1; zone <= 24; ++zone) {
+			auto iter = std::find(begin, end, zone);
+			if (iter == end) {
+				releaseZone(zone, false);
+			} // if ( iter == end )
+			else {
+				ZonesToExplore.push_back(zone);
+				addZoneToExplore(zone);
+				/* Move the found zone to the end, and move the end iterator one to the
          * left. So the std::find has to search a smaller range. */
-        std::swap(*iter, *--end);
-      } // else -> if ( iter == end )
-    }   // for ( auto zone = 1; zone <= 24; ++zone )
-    fillNavgraphNodesForASP(false);
-  } // try
-  catch (const std::exception &e) {
-    logger->log_error(LoggingComponent,
-                      "Exception while extracting the zones to explore: %s\n%s",
-                      e.what(), document.toString().c_str());
-  } // catch ( const std::exception& e )
-  catch (...) {
-    logger->log_error(LoggingComponent,
-                      "Exception while extracting the zones to explore.\n%s",
-                      document.toString().c_str());
-  } // catch ( ... )
-  return;
+				std::swap(*iter, *--end);
+			} // else -> if ( iter == end )
+		}   // for ( auto zone = 1; zone <= 24; ++zone )
+		fillNavgraphNodesForASP(false);
+	} // try
+	catch (const std::exception &e) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while extracting the zones to explore: %s\n%s",
+		                  e.what(),
+		                  document.toString().c_str());
+	} // catch ( const std::exception& e )
+	catch (...) {
+		logger->log_error(LoggingComponent,
+		                  "Exception while extracting the zones to explore.\n%s",
+		                  document.toString().c_str());
+	} // catch ( ... )
+	return;
 }
 
 /**
  * @brief Constructor.
  */
 AspPlannerThread::AspPlannerThread(void)
-    : Thread("AspPlannerThread", Thread::OPMODE_CONTINUOUS),
-      ASPAspect("ASPPlanner", "ASP-Planner"),
-      LoggingComponent("ASP-Planner-Thread"), ConfigPrefix("/asp-agent/"),
-      TeamColor(nullptr), Unsat(0),
-      // Config
-      ExplorationTime(0), DeliverProductTaskDuration(0),
-      FetchProductTaskDuration(0), LookAhaed(0), MaxDriveDuration(0),
-      MaxOrders(0), MaxProducts(0), MaxQuantity(0), MaxTaskDuration(0),
-      MaxWorkingDuration(0), PrepareCSTaskDuration(0), TimeResolution(0),
-      // Worldmodel
-      GameTime(0), ReceivedZonesToExplore(false),
-      // Distances
-      UpdateNavgraphDistances(true),
-      // Requests
-      Interrupt(InterruptSolving::Not), InterruptReason(""), SentCancel(false),
-      // Solving, loop intern
-      ProgramGrounded(false), ProductionStarted(false),
-      // Solving
-      NewSymbols(false), StartSolvingGameTime(0),
-      // Plan
-      PlanGameTime(0) {
-  return;
+: Thread("AspPlannerThread", Thread::OPMODE_CONTINUOUS),
+  ASPAspect("ASPPlanner", "ASP-Planner"),
+  LoggingComponent("ASP-Planner-Thread"),
+  ConfigPrefix("/asp-agent/"),
+  TeamColor(nullptr),
+  Unsat(0),
+  // Config
+  ExplorationTime(0),
+  DeliverProductTaskDuration(0),
+  FetchProductTaskDuration(0),
+  LookAhaed(0),
+  MaxDriveDuration(0),
+  MaxOrders(0),
+  MaxProducts(0),
+  MaxQuantity(0),
+  MaxTaskDuration(0),
+  MaxWorkingDuration(0),
+  PrepareCSTaskDuration(0),
+  TimeResolution(0),
+  // Worldmodel
+  GameTime(0),
+  ReceivedZonesToExplore(false),
+  // Distances
+  UpdateNavgraphDistances(true),
+  // Requests
+  Interrupt(InterruptSolving::Not),
+  InterruptReason(""),
+  SentCancel(false),
+  // Solving, loop intern
+  ProgramGrounded(false),
+  ProductionStarted(false),
+  // Solving
+  NewSymbols(false),
+  StartSolvingGameTime(0),
+  // Plan
+  PlanGameTime(0)
+{
+	return;
 }
 
 /**
  * @brief Destructor.
  */
-AspPlannerThread::~AspPlannerThread(void) { return; }
+AspPlannerThread::~AspPlannerThread(void)
+{
+	return;
+}
 
 /**
  * @brief Initliaizes the robmem callbacks and world model. Also calls the
  * specialized inits.
  */
-void AspPlannerThread::init(void) {
-  logger->log_info(LoggingComponent, "Initialize ASP Planner");
-  loadConfig();
-  Orders.reserve(MaxOrders);
-  OrderTaskMap.reserve(MaxOrders * MaxQuantity);
-  Products.reserve(MaxProducts);
-  RingColors.reserve(4);
-  Robots.reserve(PossibleRobots.size());
-  ZonesToExplore.reserve(12);
+void
+AspPlannerThread::init(void)
+{
+	logger->log_info(LoggingComponent, "Initialize ASP Planner");
+	loadConfig();
+	Orders.reserve(MaxOrders);
+	OrderTaskMap.reserve(MaxOrders * MaxQuantity);
+	Products.reserve(MaxProducts);
+	RingColors.reserve(4);
+	Robots.reserve(PossibleRobots.size());
+	ZonesToExplore.reserve(12);
 
-  RobotMemoryCallbacks.reserve(8);
+	RobotMemoryCallbacks.reserve(8);
 
-  RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
-      mongo::Query(R"({"relation": "active-robot", "name": {$ne: "RefBox"}})"),
-      "robmem.planner", &AspPlannerThread::beaconCallback, this));
+	RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
+	  mongo::Query(R"({"relation": "active-robot", "name": {$ne: "RefBox"}})"),
+	  "robmem.planner",
+	  &AspPlannerThread::beaconCallback,
+	  this));
 
-  RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
-      mongo::Query(R"({"relation": "game-time"})"), "robmem.planner",
-      &AspPlannerThread::gameTimeCallback, this));
+	RobotMemoryCallbacks.emplace_back(
+	  robot_memory->register_trigger(mongo::Query(R"({"relation": "game-time"})"),
+	                                 "robmem.planner",
+	                                 &AspPlannerThread::gameTimeCallback,
+	                                 this));
 
-  RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
-      mongo::Query(R"({"relation": "machine"})"), "robmem.planner",
-      &AspPlannerThread::machineCallback, this));
+	RobotMemoryCallbacks.emplace_back(
+	  robot_memory->register_trigger(mongo::Query(R"({"relation": "machine"})"),
+	                                 "robmem.planner",
+	                                 &AspPlannerThread::machineCallback,
+	                                 this));
 
-  RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
-      mongo::Query(R"({"relation": "order"})"), "robmem.planner",
-      &AspPlannerThread::orderCallback, this));
+	RobotMemoryCallbacks.emplace_back(
+	  robot_memory->register_trigger(mongo::Query(R"({"relation": "order"})"),
+	                                 "robmem.planner",
+	                                 &AspPlannerThread::orderCallback,
+	                                 this));
 
-  RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
-      mongo::Query(R"({"relation": "ring"})"), "robmem.planner",
-      &AspPlannerThread::ringColorCallback, this));
+	RobotMemoryCallbacks.emplace_back(
+	  robot_memory->register_trigger(mongo::Query(R"({"relation": "ring"})"),
+	                                 "robmem.planner",
+	                                 &AspPlannerThread::ringColorCallback,
+	                                 this));
 
-  RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
-      mongo::Query(R"({"relation": "team-color"})"), "robmem.planner",
-      &AspPlannerThread::teamColorCallback, this));
+	RobotMemoryCallbacks.emplace_back(
+	  robot_memory->register_trigger(mongo::Query(R"({"relation": "team-color"})"),
+	                                 "robmem.planner",
+	                                 &AspPlannerThread::teamColorCallback,
+	                                 this));
 
-  RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
-      mongo::Query(R"({"relation": "zones"})"), "robmem.planner",
-      &AspPlannerThread::zonesCallback, this));
+	RobotMemoryCallbacks.emplace_back(
+	  robot_memory->register_trigger(mongo::Query(R"({"relation": "zones"})"),
+	                                 "robmem.planner",
+	                                 &AspPlannerThread::zonesCallback,
+	                                 this));
 
-  RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
-      mongo::Query(), "syncedrobmem.planFeedback",
-      &AspPlannerThread::planFeedbackCallback, this));
+	RobotMemoryCallbacks.emplace_back(robot_memory->register_trigger(
+	  mongo::Query(), "syncedrobmem.planFeedback", &AspPlannerThread::planFeedbackCallback, this));
 
-  initPlan();
-  initClingo();
-  return;
+	initPlan();
+	initClingo();
+	return;
 }
 
-constexpr int constexprStrLen(const char *str) {
-  int size = 0;
-  while (*str++) {
-    ++size;
-  } // while ( *str++ )
-  return size;
+constexpr int
+constexprStrLen(const char *str)
+{
+	int size = 0;
+	while (*str++) {
+		++size;
+	} // while ( *str++ )
+	return size;
 }
 
-void AspPlannerThread::loop(void) {
-  if (Unsat >= 8) {
-    throw fawkes::Exception(
-        "The program is infeasible! We have no way to recover!");
-  } // if ( Unsat >= 8 )
+void
+AspPlannerThread::loop(void)
+{
+	if (Unsat >= 8) {
+		throw fawkes::Exception("The program is infeasible! We have no way to recover!");
+	} // if ( Unsat >= 8 )
 
-  {
-    MutexLocker locker(&WorldMutex);
-    const auto now(Clock::now());
-    static const std::chrono::seconds timeOut(
-        config->get_int(ConfigPrefix + std::string("planner/robot-timeout")));
-    for (auto &pair : Robots) {
-      auto &info(pair.second);
-      if (info.Alive && now - info.LastSeen >= timeOut) {
-        logger->log_warn(LoggingComponent, "Robot %s is considered dead.",
-                         pair.first.c_str());
-        setInterrupt(InterruptSolving::Critical, "Dead robot");
-        info.Alive = false;
-        if (info.Doing.isValid()) {
-          LocationInUse.erase(info.Doing.location());
-          info.Doing = {};
-          auto &robotPlan(Plan[pair.first]);
-          robotPlan.Tasks[robotPlan.FirstNotDone].Begun = false;
-          robotPlan.CurrentTask.clear();
-        } // if ( info.Doing.isValid() )
-      }   // if ( info.Alive && now - info.LastSeen >= timeOut )
-    }     // for ( auto& pair : Robots )
+	{
+		MutexLocker                       locker(&WorldMutex);
+		const auto                        now(Clock::now());
+		static const std::chrono::seconds timeOut(
+		  config->get_int(ConfigPrefix + std::string("planner/robot-timeout")));
+		for (auto &pair : Robots) {
+			auto &info(pair.second);
+			if (info.Alive && now - info.LastSeen >= timeOut) {
+				logger->log_warn(LoggingComponent, "Robot %s is considered dead.", pair.first.c_str());
+				setInterrupt(InterruptSolving::Critical, "Dead robot");
+				info.Alive = false;
+				if (info.Doing.isValid()) {
+					LocationInUse.erase(info.Doing.location());
+					info.Doing = {};
+					auto &robotPlan(Plan[pair.first]);
+					robotPlan.Tasks[robotPlan.FirstNotDone].Begun = false;
+					robotPlan.CurrentTask.clear();
+				} // if ( info.Doing.isValid() )
+			}   // if ( info.Alive && now - info.LastSeen >= timeOut )
+		}     // for ( auto& pair : Robots )
 
-    for (auto &pair : Machines) {
-      auto &info(pair.second);
+		for (auto &pair : Machines) {
+			auto &info(pair.second);
 
-      // Broken handling happens in machineCallback().
+			// Broken handling happens in machineCallback().
 
-      if (info.WorkingUntil && info.WorkingUntil <= GameTime) {
-        logger->log_info(
-            LoggingComponent,
-            "Machine %s has finished working on product #%d at %d.",
-            pair.first.c_str(), info.Storing.ID, GameTime);
-        info.WorkingUntil = 0;
-      } // if ( info.BrokenUntil && info.BrokenUntil <= GameTime )
-    }   // for ( auto& pair : Machines )
-  }     // Block for iteration over Robots & Machines
+			if (info.WorkingUntil && info.WorkingUntil <= GameTime) {
+				logger->log_info(LoggingComponent,
+				                 "Machine %s has finished working on product #%d at %d.",
+				                 pair.first.c_str(),
+				                 info.Storing.ID,
+				                 GameTime);
+				info.WorkingUntil = 0;
+			} // if ( info.BrokenUntil && info.BrokenUntil <= GameTime )
+		}   // for ( auto& pair : Machines )
+	}     // Block for iteration over Robots & Machines
 
-  if (GameTime == -1) {
-    static bool once = true;
-    if (once) {
-      MutexLocker worldLocker(&WorldMutex), planLocker(&PlanMutex);
-      once = false;
+	if (GameTime == -1) {
+		static bool once = true;
+		if (once) {
+			MutexLocker worldLocker(&WorldMutex), planLocker(&PlanMutex);
+			once = false;
 
-      int totalSum = 0;
+			int totalSum = 0;
 
-      for (const auto &pair : Plan) {
-        bool noAdd = false;
-        int sum = 0, last = ReceivedZonesToExplore ? 0 : ExplorationTime,
-            id = 0;
-        logger->log_info(LoggingComponent, "Plan & idle time for robot %s",
-                         pair.first.c_str());
+			for (const auto &pair : Plan) {
+				bool noAdd = false;
+				int  sum = 0, last = ReceivedZonesToExplore ? 0 : ExplorationTime, id = 0;
+				logger->log_info(LoggingComponent, "Plan & idle time for robot %s", pair.first.c_str());
 
-        constexpr const char *idleFormat = " Idle: %d seconds";
-        constexpr const char *failed = " Failed", *notFailed = "";
-        constexpr auto idleLen = constexprStrLen(idleFormat);
-        char idleString[idleLen + 1 + constexprStrLen("-32766")] = {0};
-        //                                             ^^^^^^ longest string
-        //                                             value for a short
+				constexpr const char *idleFormat = " Idle: %d seconds";
+				constexpr const char *failed = " Failed", *notFailed = "";
+				constexpr auto        idleLen = constexprStrLen(idleFormat);
+				char                  idleString[idleLen + 1 + constexprStrLen("-32766")] = {0};
+				//                                             ^^^^^^ longest string
+				//                                             value for a short
 
-        for (const auto &task : pair.second.Tasks) {
-          if (task.Begin >= ProductionEnd && !noAdd) {
-            // Since the end time of the last task didn't end this loop we have
-            // to add idle.
-            const int idle = ProductionEnd - last;
-            logger->log_info(LoggingComponent, "Effektive end game idle: %d",
-                             idle);
-            sum += idle;
-            logger->log_info(LoggingComponent, "==== Game end ====");
-            noAdd = true;
-          } // if ( task.Begin >= ProductionEnd && !noAdd )
+				for (const auto &task : pair.second.Tasks) {
+					if (task.Begin >= ProductionEnd && !noAdd) {
+						// Since the end time of the last task didn't end this loop we have
+						// to add idle.
+						const int idle = ProductionEnd - last;
+						logger->log_info(LoggingComponent, "Effektive end game idle: %d", idle);
+						sum += idle;
+						logger->log_info(LoggingComponent, "==== Game end ====");
+						noAdd = true;
+					} // if ( task.Begin >= ProductionEnd && !noAdd )
 
-          if (task.Begin > last) {
-            const short idle = task.Begin - last;
-            std::sprintf(idleString, idleFormat, idle);
-            if (!noAdd) {
-              sum += idle;
-            } // if ( !noAdd )
-          }   // if ( task.Begin > last )
-          else {
-            idleString[0] = 0;
-          } // else -> if ( task.Begin > last )
-          last = task.End;
+					if (task.Begin > last) {
+						const short idle = task.Begin - last;
+						std::sprintf(idleString, idleFormat, idle);
+						if (!noAdd) {
+							sum += idle;
+						} // if ( !noAdd )
+					}   // if ( task.Begin > last )
+					else {
+						idleString[0] = 0;
+					} // else -> if ( task.Begin > last )
+					last = task.End;
 
-          logger->log_info(LoggingComponent, "Task #%2d: (%-33s, %4d, %4d)%s%s",
-                           ++id, task.Task.c_str(), task.Begin, task.End,
-                           task.Failed ? failed : notFailed, idleString);
+					logger->log_info(LoggingComponent,
+					                 "Task #%2d: (%-33s, %4d, %4d)%s%s",
+					                 ++id,
+					                 task.Task.c_str(),
+					                 task.Begin,
+					                 task.End,
+					                 task.Failed ? failed : notFailed,
+					                 idleString);
 
-          if (task.End >= ProductionEnd && !noAdd) {
-            logger->log_info(LoggingComponent, "==== Game end ====");
-            noAdd = true;
-          } // if ( task.End >= ProductionEnd && !noAdd )
-        }   // for ( const auto& task : pair.second.Tasks )
+					if (task.End >= ProductionEnd && !noAdd) {
+						logger->log_info(LoggingComponent, "==== Game end ====");
+						noAdd = true;
+					} // if ( task.End >= ProductionEnd && !noAdd )
+				}   // for ( const auto& task : pair.second.Tasks )
 
-        logger->log_info(LoggingComponent, "Total idle time for %s: %d",
-                         pair.first.c_str(), sum);
-        totalSum += sum;
-      } // for ( const auto& pair : Plan )
+				logger->log_info(LoggingComponent, "Total idle time for %s: %d", pair.first.c_str(), sum);
+				totalSum += sum;
+			} // for ( const auto& pair : Plan )
 
-      logger->log_info(LoggingComponent,
-                       "Total idle time: %d, avg. idle time: %zu", totalSum,
-                       totalSum / Plan.size());
+			logger->log_info(LoggingComponent,
+			                 "Total idle time: %d, avg. idle time: %zu",
+			                 totalSum,
+			                 totalSum / Plan.size());
 
-      int id = 0;
-      for (const auto &product : Products) {
-        bool found = false, hold = false;
-        string_view location;
+			int id = 0;
+			for (const auto &product : Products) {
+				bool        found = false, hold = false;
+				string_view location;
 
-        for (auto iter = Machines.begin(); iter != Machines.end() && !found;
-             ++iter) {
-          if (iter->second.Storing.ID == id) {
-            found = true;
-            hold = false;
-            location = iter->first;
-          } // if ( iter->second.Storing.ID == id )
-        }   // for ( auto iter = Machines.begin(); iter != Machines.end() &&
-          // !found; ++iter )
+				for (auto iter = Machines.begin(); iter != Machines.end() && !found; ++iter) {
+					if (iter->second.Storing.ID == id) {
+						found    = true;
+						hold     = false;
+						location = iter->first;
+					} // if ( iter->second.Storing.ID == id )
+				}   // for ( auto iter = Machines.begin(); iter != Machines.end() &&
+				// !found; ++iter )
 
-        for (auto iter = Robots.begin(); iter != Robots.end() && !found;
-             ++iter) {
-          if (iter->second.Holding.ID == id) {
-            found = true;
-            hold = true;
-            location = iter->first;
-          } // if ( iter->second.Holding.ID == id )
-        }   // for ( auto iter = Robots.begin(); iter != Robots.end() && !found;
-          // ++iter )
+				for (auto iter = Robots.begin(); iter != Robots.end() && !found; ++iter) {
+					if (iter->second.Holding.ID == id) {
+						found    = true;
+						hold     = true;
+						location = iter->first;
+					} // if ( iter->second.Holding.ID == id )
+				}   // for ( auto iter = Robots.begin(); iter != Robots.end() && !found;
+				// ++iter )
 
-        logger->log_info(LoggingComponent,
-                         "Product #%d: (%-11s, %-6s, %-6s, %-6s, %-5s) %s %s.",
-                         id++, product.Base.c_str(), product.Rings[1].c_str(),
-                         product.Rings[2].c_str(), product.Rings[3].c_str(),
-                         product.Cap.c_str(), hold ? "hold   by" : "stored on",
-                         location.data());
-      } // for ( const auto& product : Products )
-    }   // if ( once )
-  }     // if ( GameTime == -1 )
-  else {
-    loopPlan();
-    loopClingo();
-  } // else -> if ( GameTime == -1 )
-  return;
+				logger->log_info(LoggingComponent,
+				                 "Product #%d: (%-11s, %-6s, %-6s, %-6s, %-5s) %s %s.",
+				                 id++,
+				                 product.Base.c_str(),
+				                 product.Rings[1].c_str(),
+				                 product.Rings[2].c_str(),
+				                 product.Rings[3].c_str(),
+				                 product.Cap.c_str(),
+				                 hold ? "hold   by" : "stored on",
+				                 location.data());
+			} // for ( const auto& product : Products )
+		}   // if ( once )
+	}     // if ( GameTime == -1 )
+	else {
+		loopPlan();
+		loopClingo();
+	} // else -> if ( GameTime == -1 )
+	return;
 }
 
-void AspPlannerThread::finalize(void) {
-  logger->log_info(LoggingComponent, "Finalize ASP Planner");
-  for (const auto &callback : RobotMemoryCallbacks) {
-    robot_memory->remove_trigger(callback);
-  } // for ( const auto& callback : RobotMemoryCallbacks )
-  RobotMemoryCallbacks.clear();
-  finalizeClingo();
-  logger->log_info(LoggingComponent, "ASP Planner finalized");
-  return;
+void
+AspPlannerThread::finalize(void)
+{
+	logger->log_info(LoggingComponent, "Finalize ASP Planner");
+	for (const auto &callback : RobotMemoryCallbacks) {
+		robot_memory->remove_trigger(callback);
+	} // for ( const auto& callback : RobotMemoryCallbacks )
+	RobotMemoryCallbacks.clear();
+	finalizeClingo();
+	logger->log_info(LoggingComponent, "ASP Planner finalized");
+	return;
 }

--- a/src/plugins/asp-planner/asp_planner_thread.h
+++ b/src/plugins/asp-planner/asp_planner_thread.h
@@ -23,6 +23,8 @@
 #ifndef __PLUGINS_ASP_AGENT_THREAD_H_
 #define __PLUGINS_ASP_AGENT_THREAD_H_
 
+#include "asp_planner_types.h"
+
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <core/threading/mutex.h>
@@ -31,8 +33,6 @@
 #include <navgraph/navgraph.h>
 #include <plugins/asp/aspect/asp.h>
 #include <plugins/robot-memory/aspect/robot_memory_aspect.h>
-
-#include "asp_planner_types.h"
 
 #include <atomic>
 #include <unordered_set>
@@ -43,166 +43,176 @@ class AspPlannerThread : public fawkes::Thread,
                          public fawkes::ASPAspect,
                          public fawkes::RobotMemoryAspect,
                          public fawkes::NavGraphAspect,
-                         public fawkes::NavGraph::ChangeListener {
+                         public fawkes::NavGraph::ChangeListener
+{
 private:
-  const char *const LoggingComponent;
-  const char *const ConfigPrefix;
-  std::vector<EventTrigger *> RobotMemoryCallbacks;
-  const char *TeamColor;
+	const char *const           LoggingComponent;
+	const char *const           ConfigPrefix;
+	std::vector<EventTrigger *> RobotMemoryCallbacks;
+	const char *                TeamColor;
 
-  int Unsat;
+	int Unsat;
 
-  int ExplorationTime;
-  int DeliverProductTaskDuration;
-  int FetchProductTaskDuration;
-  int LookAhaed;
-  int MaxDriveDuration;
-  int MaxOrders;
-  int MaxProducts;
-  int MaxQuantity;
-  int MaxTaskDuration;
-  int MaxWorkingDuration;
-  std::vector<std::string> PossibleRobots;
-  int PrepareCSTaskDuration;
-  int ProductionEnd;
-  int TimeResolution;
-  std::unordered_map<std::string, int> WorkingDurations;
+	int                                  ExplorationTime;
+	int                                  DeliverProductTaskDuration;
+	int                                  FetchProductTaskDuration;
+	int                                  LookAhaed;
+	int                                  MaxDriveDuration;
+	int                                  MaxOrders;
+	int                                  MaxProducts;
+	int                                  MaxQuantity;
+	int                                  MaxTaskDuration;
+	int                                  MaxWorkingDuration;
+	std::vector<std::string>             PossibleRobots;
+	int                                  PrepareCSTaskDuration;
+	int                                  ProductionEnd;
+	int                                  TimeResolution;
+	std::unordered_map<std::string, int> WorkingDurations;
 
-  const std::vector<std::string> BaseColors = {"RED", "BLACK", "SILVER"};
-  const std::string SpecialBaseColor = "TRANSPARENT";
-  std::vector<CapColorInformation> CapColors;
+	const std::vector<std::string>   BaseColors       = {"RED", "BLACK", "SILVER"};
+	const std::string                SpecialBaseColor = "TRANSPARENT";
+	std::vector<CapColorInformation> CapColors;
 
-  fawkes::Mutex WorldMutex;
-  int GameTime;
-  std::unordered_map<int, OrderInformation> Orders;
-  std::vector<RingColorInformation> RingColors;
-  std::unordered_map<std::string, RobotInformation> Robots;
-  std::unordered_map<std::string, MachineInformation> Machines;
-  std::vector<Product> Products;
-  bool ReceivedZonesToExplore;
-  std::vector<int> ZonesToExplore;
-  std::unordered_map<std::pair<int, int>, OrderTasks> OrderTaskMap;
+	fawkes::Mutex                                       WorldMutex;
+	int                                                 GameTime;
+	std::unordered_map<int, OrderInformation>           Orders;
+	std::vector<RingColorInformation>                   RingColors;
+	std::unordered_map<std::string, RobotInformation>   Robots;
+	std::unordered_map<std::string, MachineInformation> Machines;
+	std::vector<Product>                                Products;
+	bool                                                ReceivedZonesToExplore;
+	std::vector<int>                                    ZonesToExplore;
+	std::unordered_map<std::pair<int, int>, OrderTasks> OrderTaskMap;
 
-  static constexpr auto NodePropertyASP = "ASP-Location";
-  fawkes::Mutex NavgraphDistanceMutex;
-  // As long as we don't have nodes for the zones we need a multimap.
-  std::unordered_multimap<std::string, Clingo::Symbol> NavgraphNodesForASP;
-  std::unordered_set<std::string> NodesToFind;
-  bool UpdateNavgraphDistances;
-  std::vector<Clingo::Symbol> NavgraphDistances;
+	static constexpr auto NodePropertyASP = "ASP-Location";
+	fawkes::Mutex         NavgraphDistanceMutex;
+	// As long as we don't have nodes for the zones we need a multimap.
+	std::unordered_multimap<std::string, Clingo::Symbol> NavgraphNodesForASP;
+	std::unordered_set<std::string>                      NodesToFind;
+	bool                                                 UpdateNavgraphDistances;
+	std::vector<Clingo::Symbol>                          NavgraphDistances;
 
-  Clingo::Symbol DeliveryLocation;
-  Clingo::Symbol RingLocations[2];
-  Clingo::Symbol CapLocations[2];
+	Clingo::Symbol DeliveryLocation;
+	Clingo::Symbol RingLocations[2];
+	Clingo::Symbol CapLocations[2];
 
-  using GroundRequest = std::pair<const char *, Clingo::SymbolVector>;
+	using GroundRequest = std::pair<const char *, Clingo::SymbolVector>;
 
-  std::atomic<InterruptSolving> Interrupt;
-  std::atomic<const char *> InterruptReason;
+	std::atomic<InterruptSolving> Interrupt;
+	std::atomic<const char *>     InterruptReason;
 
-  fawkes::Mutex RequestMutex;
-  bool SentCancel;
-  std::vector<GroundRequest> GroundRequests;
-  std::vector<Clingo::Symbol> ReleaseRequests;
-  std::vector<Clingo::Symbol> AssignRequests;
+	fawkes::Mutex               RequestMutex;
+	bool                        SentCancel;
+	std::vector<GroundRequest>  GroundRequests;
+	std::vector<Clingo::Symbol> ReleaseRequests;
+	std::vector<Clingo::Symbol> AssignRequests;
 
-  bool ProgramGrounded;
-  bool ProductionStarted;
+	bool ProgramGrounded;
+	bool ProductionStarted;
 
-  mutable fawkes::Mutex SolvingMutex;
-  TimePoint LastModel;
-  TimePoint SolvingStarted;
-  bool NewSymbols;
-  Clingo::SymbolVector Symbols;
-  int StartSolvingGameTime;
+	mutable fawkes::Mutex SolvingMutex;
+	TimePoint             LastModel;
+	TimePoint             SolvingStarted;
+	bool                  NewSymbols;
+	Clingo::SymbolVector  Symbols;
+	int                   StartSolvingGameTime;
 
-  mutable fawkes::Mutex PlanMutex;
-  TimePoint LastPlan;
-  int PlanGameTime;
-  std::unordered_map<std::string, RobotPlan> Plan;
-  std::unordered_map<Clingo::Symbol, std::string> LocationInUse;
+	mutable fawkes::Mutex                           PlanMutex;
+	TimePoint                                       LastPlan;
+	int                                             PlanGameTime;
+	std::unordered_map<std::string, RobotPlan>      Plan;
+	std::unordered_map<Clingo::Symbol, std::string> LocationInUse;
 
-  void loadConfig(void);
+	void loadConfig(void);
 
-  void graph_changed(void) noexcept override final;
-  void fillNavgraphNodesForASP(const bool lockWorldMutex);
-  void updateNavgraphDistances(void);
-  Clingo::Symbol nearestLocation(const float x, const float y);
+	void           graph_changed(void) noexcept override final;
+	void           fillNavgraphNodesForASP(const bool lockWorldMutex);
+	void           updateNavgraphDistances(void);
+	Clingo::Symbol nearestLocation(const float x, const float y);
 
-  void initClingo(void);
-  void finalizeClingo(void);
-  void loopClingo(void);
+	void initClingo(void);
+	void finalizeClingo(void);
+	void loopClingo(void);
 
-  void queueGround(GroundRequest &&request, const char *reason,
-                   const InterruptSolving interrupt = InterruptSolving::Not);
-  void queueRelease(Clingo::Symbol &&atom, const char *reason,
-                    const InterruptSolving interrupt = InterruptSolving::Not);
-  void queueAssign(Clingo::Symbol &&atom, const char *reason,
-                   const InterruptSolving interrupt = InterruptSolving::Not);
-  void setInterrupt(const InterruptSolving interrupt, const char *reason);
-  bool shouldInterrupt(void);
+	void queueGround(GroundRequest &&       request,
+	                 const char *           reason,
+	                 const InterruptSolving interrupt = InterruptSolving::Not);
+	void queueRelease(Clingo::Symbol &&      atom,
+	                  const char *           reason,
+	                  const InterruptSolving interrupt = InterruptSolving::Not);
+	void queueAssign(Clingo::Symbol &&      atom,
+	                 const char *           reason,
+	                 const InterruptSolving interrupt = InterruptSolving::Not);
+	void setInterrupt(const InterruptSolving interrupt, const char *reason);
+	bool shouldInterrupt(void);
 
-  bool newModel(void);
-  void solvingFinished(const Clingo::SolveResult &result);
-  void groundFunctions(const Clingo::Location &loc, char const *name,
-                       const Clingo::SymbolSpan &arguments,
-                       Clingo::SymbolSpanCallback &retFunction);
+	bool newModel(void);
+	void solvingFinished(const Clingo::SolveResult &result);
+	void groundFunctions(const Clingo::Location &    loc,
+	                     char const *                name,
+	                     const Clingo::SymbolSpan &  arguments,
+	                     Clingo::SymbolSpanCallback &retFunction);
 
-  void setTeam(void);
-  void unsetTeam(void);
+	void setTeam(void);
+	void unsetTeam(void);
 
-  void addOrderToASP(const OrderInformation &order);
-  void addRingColorToASP(const RingColorInformation &color);
+	void addOrderToASP(const OrderInformation &order);
+	void addRingColorToASP(const RingColorInformation &color);
 
-  void addZoneToExplore(const int zone);
-  void releaseZone(const int zone, const bool removeAndFillNodes);
+	void addZoneToExplore(const int zone);
+	void releaseZone(const int zone, const bool removeAndFillNodes);
 
-  void checkForInterruptBasedOnTimeOffset(int offset);
-  void robotBegunWithTask(const std::string &robot, const std::string &task,
-                          const int begin, const int end);
-  void robotUpdatesTaskTimeEstimation(const std::string &robot,
-                                      const std::string &task, const int end);
-  void robotFinishedTask(const std::string &robot, const std::string &task,
-                         const int end, const bool success);
+	void checkForInterruptBasedOnTimeOffset(int offset);
+	void robotBegunWithTask(const std::string &robot,
+	                        const std::string &task,
+	                        const int          begin,
+	                        const int          end);
+	void
+	     robotUpdatesTaskTimeEstimation(const std::string &robot, const std::string &task, const int end);
+	void robotFinishedTask(const std::string &robot,
+	                       const std::string &task,
+	                       const int          end,
+	                       const bool         success);
 
-  void initPlan(void);
-  void loopPlan(void);
-  void insertPlanElement(const std::string &robot, const int elementIndex,
-                         const PlanElement &element);
-  void updatePlan(const std::string &robot, const int elementIndex,
-                  const PlanElement &element);
-  void updatePlanTiming(const std::string &robot, const int elementIndex,
-                        const PlanElement &element);
-  void removeFromPlanDB(const std::string &robot, const int elementIndex);
-  void tellRobotToStop(const std::string &robot);
+	void initPlan(void);
+	void loopPlan(void);
+	void
+	     insertPlanElement(const std::string &robot, const int elementIndex, const PlanElement &element);
+	void updatePlan(const std::string &robot, const int elementIndex, const PlanElement &element);
+	void
+	     updatePlanTiming(const std::string &robot, const int elementIndex, const PlanElement &element);
+	void removeFromPlanDB(const std::string &robot, const int elementIndex);
+	void tellRobotToStop(const std::string &robot);
 
-  void planFeedbackCallback(const mongo::BSONObj document);
+	void planFeedbackCallback(const mongo::BSONObj document);
 
-  int realGameTimeToAspGameTime(const int realGameTime) const noexcept;
-  int aspGameTimeToRealGameTime(const int aspGameTime) const noexcept;
+	int realGameTimeToAspGameTime(const int realGameTime) const noexcept;
+	int aspGameTimeToRealGameTime(const int aspGameTime) const noexcept;
 
-  void beaconCallback(const mongo::BSONObj document);
-  void gameTimeCallback(const mongo::BSONObj document);
-  void machineCallback(const mongo::BSONObj document);
-  void orderCallback(const mongo::BSONObj document);
-  void ringColorCallback(const mongo::BSONObj document);
-  void teamColorCallback(const mongo::BSONObj document);
-  void zonesCallback(const mongo::BSONObj document);
+	void beaconCallback(const mongo::BSONObj document);
+	void gameTimeCallback(const mongo::BSONObj document);
+	void machineCallback(const mongo::BSONObj document);
+	void orderCallback(const mongo::BSONObj document);
+	void ringColorCallback(const mongo::BSONObj document);
+	void teamColorCallback(const mongo::BSONObj document);
+	void zonesCallback(const mongo::BSONObj document);
 
 public:
-  AspPlannerThread(void);
-  ~AspPlannerThread(void);
+	AspPlannerThread(void);
+	~AspPlannerThread(void);
 
-  void init(void) override;
-  void loop(void) override;
-  void finalize(void) override;
+	void init(void) override;
+	void loop(void) override;
+	void finalize(void) override;
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  void run() override {
-    Thread::run();
-    return;
-  }
+	void
+	run() override
+	{
+		Thread::run();
+		return;
+	}
 };
 
 #endif

--- a/src/plugins/asp-planner/asp_planner_types.h
+++ b/src/plugins/asp-planner/asp_planner_types.h
@@ -24,9 +24,8 @@
 #ifndef __PLUGINS_ASP_AGENT_TYPES_H_
 #define __PLUGINS_ASP_AGENT_TYPES_H_
 
-#include <clingo.hh>
-
 #include <chrono>
+#include <clingo.hh>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -41,108 +40,108 @@ namespace fawkes {
 class MutexLocker;
 }
 
-using Clock = std::chrono::high_resolution_clock;
+using Clock     = std::chrono::high_resolution_clock;
 using TimePoint = Clock::time_point;
 
-enum class InterruptSolving : short {
-  Not = 0,
-  JustStarted,
-  Normal,
-  High,
-  Critical
+enum class InterruptSolving : short { Not = 0, JustStarted, Normal, High, Critical };
+
+inline constexpr const char *
+interruptString(const InterruptSolving interrupt)
+{
+	switch (interrupt) {
+	case InterruptSolving::Not: return "Not";
+	case InterruptSolving::JustStarted: return "JustStarted";
+	case InterruptSolving::Normal: return "Normal";
+	case InterruptSolving::High: return "High";
+	case InterruptSolving::Critical: return "Critical";
+	} // switch ( interrupt )
+	return "";
+}
+
+struct BasicPlanElement
+{
+	std::string Task;
+	int         Begin = 0;
+	int         End   = 0;
 };
 
-inline constexpr const char *interruptString(const InterruptSolving interrupt) {
-  switch (interrupt) {
-  case InterruptSolving::Not:
-    return "Not";
-  case InterruptSolving::JustStarted:
-    return "JustStarted";
-  case InterruptSolving::Normal:
-    return "Normal";
-  case InterruptSolving::High:
-    return "High";
-  case InterruptSolving::Critical:
-    return "Critical";
-  } // switch ( interrupt )
-  return "";
+inline bool
+operator==(const BasicPlanElement &e1, const BasicPlanElement &e2) noexcept
+{
+	return e1.Begin == e2.Begin && e1.End == e2.End && e1.Task == e2.Task;
 }
 
-struct BasicPlanElement {
-  std::string Task;
-  int Begin = 0;
-  int End = 0;
-};
-
-inline bool operator==(const BasicPlanElement &e1,
-                       const BasicPlanElement &e2) noexcept {
-  return e1.Begin == e2.Begin && e1.End == e2.End && e1.Task == e2.Task;
+inline bool
+operator!=(const BasicPlanElement &e1, const BasicPlanElement &e2) noexcept
+{
+	return !(e1 == e2);
 }
 
-inline bool operator!=(const BasicPlanElement &e1,
-                       const BasicPlanElement &e2) noexcept {
-  return !(e1 == e2);
-}
+struct PlanElement : public BasicPlanElement
+{
+	bool Begun  = false;
+	bool Done   = false;
+	bool Failed = false;
 
-struct PlanElement : public BasicPlanElement {
-  bool Begun = false;
-  bool Done = false;
-  bool Failed = false;
-
-  /** Construct from base class.
+	/** Construct from base class.
    * @param b basic plan element
    */
-  inline PlanElement(const BasicPlanElement &b) noexcept : BasicPlanElement(b) {
-    return;
-  }
+	inline PlanElement(const BasicPlanElement &b) noexcept : BasicPlanElement(b)
+	{
+		return;
+	}
 
-  /** Construct from base class.
+	/** Construct from base class.
    * @param b basic plan element
    */
-  inline PlanElement(BasicPlanElement &&b) noexcept
-      : BasicPlanElement(std::move(b)) {
-    return;
-  }
+	inline PlanElement(BasicPlanElement &&b) noexcept : BasicPlanElement(std::move(b))
+	{
+		return;
+	}
 
-  /** Copy ctor.
+	/** Copy ctor.
    * @param e plan element to copy
    */
-  inline PlanElement(const PlanElement &e) = default;
-  /** Move ctor.
+	inline PlanElement(const PlanElement &e) = default;
+	/** Move ctor.
    * @param e plan element to move
    */
-  inline PlanElement(PlanElement &&e) noexcept = default;
-  /** Copying assignment operator.
+	inline PlanElement(PlanElement &&e) noexcept = default;
+	/** Copying assignment operator.
    * @param e plan element to copy from
    * @return reference to this instance
    */
-  inline PlanElement &operator=(const PlanElement &e) = default;
-  /** Moving assignment operator.
+	inline PlanElement &operator=(const PlanElement &e) = default;
+	/** Moving assignment operator.
    * @param e plan element to move
    * @return reference to this instance
    */
-  inline PlanElement &operator=(PlanElement &&e) noexcept = default;
+	inline PlanElement &operator=(PlanElement &&e) noexcept = default;
 
-  /** Update time to that of the given element.
+	/** Update time to that of the given element.
    * @param e plan element to copy time from
    */
-  inline void updateTime(const BasicPlanElement &e) noexcept {
-    if (e.Begin != 0) {
-      Begin = e.Begin;
-    } // if ( e.Begin != 0 )
-    End = e.End;
-    return;
-  }
+	inline void
+	updateTime(const BasicPlanElement &e) noexcept
+	{
+		if (e.Begin != 0) {
+			Begin = e.Begin;
+		} // if ( e.Begin != 0 )
+		End = e.End;
+		return;
+	}
 
-  /** Update time and task to that of another element.
+	/** Update time and task to that of another element.
    * @param e plan element to copy from
    */
-  inline void updateTimeAndTask(const BasicPlanElement &e) noexcept(
-      noexcept(std::is_nothrow_copy_assignable<decltype(e.Task)>::value)) {
-    updateTime(e);
-    Task = e.Task;
-    return;
-  }
+	inline void
+	updateTimeAndTask(const BasicPlanElement &e) noexcept(
+	  noexcept(std::is_nothrow_copy_assignable<decltype(e.Task)>::value))
+	{
+		updateTime(e);
+		Task = e.Task;
+		return;
+	}
 };
 
 /** Check equality of two plan elements.
@@ -150,10 +149,11 @@ struct PlanElement : public BasicPlanElement {
  * @param e2 second plan element
  * @return true if plan elements are the same, false otherwise
  */
-inline bool operator==(const PlanElement &e1, const PlanElement &e2) noexcept {
-  return static_cast<BasicPlanElement>(e1) ==
-             static_cast<BasicPlanElement>(e2) &&
-         e1.Done == e2.Done && e1.Begun == e2.Begun;
+inline bool
+operator==(const PlanElement &e1, const PlanElement &e2) noexcept
+{
+	return static_cast<BasicPlanElement>(e1) == static_cast<BasicPlanElement>(e2)
+	       && e1.Done == e2.Done && e1.Begun == e2.Begun;
 }
 
 /** Check inequality of two plan elements.
@@ -161,109 +161,131 @@ inline bool operator==(const PlanElement &e1, const PlanElement &e2) noexcept {
  * @param e2 second plan element
  * @return true if plan elements are not the same, false otherwise
  */
-inline bool operator!=(const PlanElement &e1, const PlanElement &e2) noexcept {
-  return !(e1 == e2);
+inline bool
+operator!=(const PlanElement &e1, const PlanElement &e2) noexcept
+{
+	return !(e1 == e2);
 }
 
-struct RobotPlan {
-  std::vector<PlanElement> Tasks;
-  std::size_t FirstNotDone = 0;
-  std::size_t FirstNotDoneOnSolveStart = 0;
-  std::string CurrentTask;
+struct RobotPlan
+{
+	std::vector<PlanElement> Tasks;
+	std::size_t              FirstNotDone             = 0;
+	std::size_t              FirstNotDoneOnSolveStart = 0;
+	std::string              CurrentTask;
 };
 
-struct ProductIdentifier {
-  int ID = -1;
+struct ProductIdentifier
+{
+	int ID = -1;
 
-  /** Check if ID is valid.
+	/** Check if ID is valid.
    * @return true if ID is valid, i.e. it is not -1.
    */
-  inline bool isValid(void) const noexcept { return ID != -1; }
+	inline bool
+	isValid(void) const noexcept
+	{
+		return ID != -1;
+	}
 };
 
-struct Product {
-  std::string Base;
-  // +1 to skip the calculation of +1 and -1 everytime we use this.
-  std::string Rings[4];
-  std::string Cap;
+struct Product
+{
+	std::string Base;
+	// +1 to skip the calculation of +1 and -1 everytime we use this.
+	std::string Rings[4];
+	std::string Cap;
 };
 
-struct TaskDescription {
-  /** Possible types. */
-  enum {
-    None,
-    Deliver,
-    FeedRS,
-    GetBase,
-    GetProduct,
-    Goto,
-    MountCap,
-    MountRing,
-    PrepareCS
-  } Type = None;
+struct TaskDescription
+{
+	/** Possible types. */
+	enum {
+		None,
+		Deliver,
+		FeedRS,
+		GetBase,
+		GetProduct,
+		Goto,
+		MountCap,
+		MountRing,
+		PrepareCS
+	} Type = None;
 
-  Clingo::Symbol TaskSymbol;
-  int EstimatedEnd = -1;
+	Clingo::Symbol TaskSymbol;
+	int            EstimatedEnd = -1;
 
-  /** Check if type is valid.
+	/** Check if type is valid.
    * @return true if type is not None */
-  inline bool isValid(void) const noexcept { return Type != None; }
+	inline bool
+	isValid(void) const noexcept
+	{
+		return Type != None;
+	}
 
-  /** Get location for task.
+	/** Get location for task.
    * @return symbol representing location.
    **/
-  inline Clingo::Symbol location(void) const {
-    assert(isValid());
-    return TaskSymbol.arguments()[0];
-  }
+	inline Clingo::Symbol
+	location(void) const
+	{
+		assert(isValid());
+		return TaskSymbol.arguments()[0];
+	}
 };
 
-struct RobotInformation {
-  TimePoint LastSeen;
-  bool Alive;
-  Clingo::Symbol AliveExternal;
-  float X;
-  float Y;
-  ProductIdentifier Holding;
-  TaskDescription Doing;
+struct RobotInformation
+{
+	TimePoint         LastSeen;
+	bool              Alive;
+	Clingo::Symbol    AliveExternal;
+	float             X;
+	float             Y;
+	ProductIdentifier Holding;
+	TaskDescription   Doing;
 };
 
-struct MachineInformation {
-  int BrokenUntil = 0;
-  int WorkingUntil = 0;
-  ProductIdentifier Storing;
-  int FillState = 0;
-  bool Prepared = false;
-  std::string State = "(not set)";
+struct MachineInformation
+{
+	int               BrokenUntil  = 0;
+	int               WorkingUntil = 0;
+	ProductIdentifier Storing;
+	int               FillState = 0;
+	bool              Prepared  = false;
+	std::string       State     = "(not set)";
 };
 
-struct CapColorInformation {
-  std::string Color;
-  std::string Machine;
+struct CapColorInformation
+{
+	std::string Color;
+	std::string Machine;
 };
 
-struct RingColorInformation {
-  std::string Color;
-  std::string Machine;
-  int Cost;
+struct RingColorInformation
+{
+	std::string Color;
+	std::string Machine;
+	int         Cost;
 };
 
-struct OrderInformation {
-  int Number;
-  int Quantity;
-  std::string Base;
-  std::string Cap;
-  // +1 to skip the calculation of +1 and -1 everytime we use this.
-  std::string Rings[4];
-  int DeliveryBegin;
-  int DeliveryEnd;
+struct OrderInformation
+{
+	int         Number;
+	int         Quantity;
+	std::string Base;
+	std::string Cap;
+	// +1 to skip the calculation of +1 and -1 everytime we use this.
+	std::string Rings[4];
+	int         DeliveryBegin;
+	int         DeliveryEnd;
 };
 
-struct OrderTasks {
-  // +1 to skip the calculation of +1 and -1 everytime we use this.
-  Clingo::Symbol RingTasks[4];
-  Clingo::Symbol CapTask;
-  Clingo::Symbol DeliverTasks[2];
+struct OrderTasks
+{
+	// +1 to skip the calculation of +1 and -1 everytime we use this.
+	Clingo::Symbol RingTasks[4];
+	Clingo::Symbol CapTask;
+	Clingo::Symbol DeliverTasks[2];
 };
 
 namespace std {
@@ -272,17 +294,20 @@ namespace std {
  * @brief Helper class to instantiate a std::unordered_map with a std::pair as
  * key.
  */
-template <typename T1, typename T2> struct hash<pair<T1, T2>> {
-  /** Calculate hash.
+template <typename T1, typename T2>
+struct hash<pair<T1, T2>>
+{
+	/** Calculate hash.
    * @param pair elements to create hash for
    * @return hash value
    */
-  auto operator()(const pair<T1, T2> &pair) const
-      noexcept(noexcept(hash<T1>{}(pair.first) &&
-                        noexcept(hash<T2>{}(pair.second)))) {
-    // Is this a good hash?
-    return hash<T1>{}(pair.first) << 16 ^ hash<T2>{}(pair.second);
-  }
+	auto
+	operator()(const pair<T1, T2> &pair) const
+	  noexcept(noexcept(hash<T1>{}(pair.first) && noexcept(hash<T2>{}(pair.second))))
+	{
+		// Is this a good hash?
+		return hash<T1>{}(pair.first) << 16 ^ hash<T2>{}(pair.second);
+	}
 };
 } // namespace std
 
@@ -292,7 +317,11 @@ namespace Clingo {
  * @param[in] string The C++-String.
  * @return The Clingo::Symbol constructed from the string.
  */
-inline Symbol String(const std::string &str) { return String(str.c_str()); }
+inline Symbol
+String(const std::string &str)
+{
+	return String(str.c_str());
+}
 
 } // namespace Clingo
 

--- a/src/plugins/attic/ampelvar/pipeline_thread.cpp
+++ b/src/plugins/attic/ampelvar/pipeline_thread.cpp
@@ -23,21 +23,18 @@
 
 #include "pipeline_thread.h"
 
-#include <fvutils/color/conversions.h>
-#include <fvutils/draw/drawer.h>
-#include <fvutils/ipc/shm_image.h>
-
+#include <fvcams/camera.h>
 #include <fvmodels/global_position/omni_global.h>
 #include <fvmodels/mirror/bulb.h>
 #include <fvmodels/mirror/mirrormodel.h>
 #include <fvmodels/scanlines/grid.h>
-
-#include <fvcams/camera.h>
-#include <interfaces/Position3DInterface.h>
-#include <interfaces/SwitchInterface.h>
-
+#include <fvutils/color/conversions.h>
+#include <fvutils/draw/drawer.h>
+#include <fvutils/ipc/shm_image.h>
 #include <geometry/hom_point.h>
 #include <geometry/hom_vector.h>
+#include <interfaces/Position3DInterface.h>
+#include <interfaces/SwitchInterface.h>
 #include <utils/math/angle.h> //diff angle
 #include <utils/math/coord.h> //cart2polar2d
 #include <utils/system/hostinfo.h>
@@ -45,7 +42,6 @@
 #include <cmath>
 #include <cstdio>
 #include <stdlib.h>
-
 #include <string>
 
 using namespace std;
@@ -61,201 +57,200 @@ using namespace firevision;
 
 /** Constructor. */
 RobotinoAmpelVarPipelineThread::RobotinoAmpelVarPipelineThread()
-    : Thread("RobotinoAmpelVarThread", Thread::OPMODE_WAITFORWAKEUP),
-      VisionAspect(VisionAspect::CYCLIC) {
-  scanline_ = NULL;
-  mirror_ = NULL;
-  shm_buffer_ = NULL;
-  ampel_red_if_ = NULL;
-  ampel_orange_if_ = NULL;
-  ampel_green_if_ = NULL;
+: Thread("RobotinoAmpelVarThread", Thread::OPMODE_WAITFORWAKEUP), VisionAspect(VisionAspect::CYCLIC)
+{
+	scanline_        = NULL;
+	mirror_          = NULL;
+	shm_buffer_      = NULL;
+	ampel_red_if_    = NULL;
+	ampel_orange_if_ = NULL;
+	ampel_green_if_  = NULL;
 
-  laser_pos_if_ = NULL;
+	laser_pos_if_ = NULL;
 
-  cspace_to_ = YUV422_PLANAR;
+	cspace_to_ = YUV422_PLANAR;
 
-  drawer_ = 0;
+	drawer_ = 0;
 }
 
 /** Destructor. */
-RobotinoAmpelVarPipelineThread::~RobotinoAmpelVarPipelineThread() {}
+RobotinoAmpelVarPipelineThread::~RobotinoAmpelVarPipelineThread()
+{
+}
 
 /** Initialize the pipeline thread.
  * Camera is requested, config parameters are obtained from the config db, and
  * other miscellaneous init stuff is done here.
  */
-void RobotinoAmpelVarPipelineThread::init() {
-  cfg_prefix_ = "/plugins/ampelvar/";
-  cfg_camera_ = config->get_string((cfg_prefix_ + "camera").c_str());
-  cfg_camera_height_ =
-      config->get_float((cfg_prefix_ + "camera_height").c_str());
-  cfg_debug_buffer_ = config->get_bool((cfg_prefix_ + "debug_buffer").c_str());
-  cfg_frame_ = config->get_string((cfg_prefix_ + "frame").c_str());
-  cfg_mirror_file_ = std::string(CONFDIR) + "/" +
-                     config->get_string((cfg_prefix_ + "mirror_file").c_str());
+void
+RobotinoAmpelVarPipelineThread::init()
+{
+	cfg_prefix_        = "/plugins/ampelvar/";
+	cfg_camera_        = config->get_string((cfg_prefix_ + "camera").c_str());
+	cfg_camera_height_ = config->get_float((cfg_prefix_ + "camera_height").c_str());
+	cfg_debug_buffer_  = config->get_bool((cfg_prefix_ + "debug_buffer").c_str());
+	cfg_frame_         = config->get_string((cfg_prefix_ + "frame").c_str());
+	cfg_mirror_file_ =
+	  std::string(CONFDIR) + "/" + config->get_string((cfg_prefix_ + "mirror_file").c_str());
 
-  cfg_red_height_ = config->get_float((cfg_prefix_ + "red_height").c_str());
-  cfg_orange_height_ =
-      config->get_float((cfg_prefix_ + "orange_height").c_str());
-  cfg_green_height_ = config->get_float((cfg_prefix_ + "green_height").c_str());
-  cfg_is_static_ = config->get_bool((cfg_prefix_ + "static").c_str());
+	cfg_red_height_    = config->get_float((cfg_prefix_ + "red_height").c_str());
+	cfg_orange_height_ = config->get_float((cfg_prefix_ + "orange_height").c_str());
+	cfg_green_height_  = config->get_float((cfg_prefix_ + "green_height").c_str());
+	cfg_is_static_     = config->get_bool((cfg_prefix_ + "static").c_str());
 
-  // camera
-  cam_ = vision_master->register_for_camera(cfg_camera_.c_str(), this);
+	// camera
+	cam_ = vision_master->register_for_camera(cfg_camera_.c_str(), this);
 
-  // interfaces
-  try {
-    ampel_red_if_ = blackboard->open_for_writing<SwitchInterface>("ampel_red");
-    ampel_red_if_->write();
-    ampel_orange_if_ =
-        blackboard->open_for_writing<SwitchInterface>("ampel_orange");
-    ampel_orange_if_->write();
-    ampel_green_if_ =
-        blackboard->open_for_writing<SwitchInterface>("ampel_green");
-    ampel_green_if_->write();
+	// interfaces
+	try {
+		ampel_red_if_ = blackboard->open_for_writing<SwitchInterface>("ampel_red");
+		ampel_red_if_->write();
+		ampel_orange_if_ = blackboard->open_for_writing<SwitchInterface>("ampel_orange");
+		ampel_orange_if_->write();
+		ampel_green_if_ = blackboard->open_for_writing<SwitchInterface>("ampel_green");
+		ampel_green_if_->write();
 
-    laser_pos_if_ =
-        blackboard->open_for_reading<Position3DInterface>("Machine_0");
+		laser_pos_if_ = blackboard->open_for_reading<Position3DInterface>("Machine_0");
 
-  } catch (Exception &e) {
-    delete cam_;
-    cam_ = NULL;
-    e.append("Opening ampel interfaces for writing failed");
-    throw;
-  }
+	} catch (Exception &e) {
+		delete cam_;
+		cam_ = NULL;
+		e.append("Opening ampel interfaces for writing failed");
+		throw;
+	}
 
-  try {
-    ampel_switch_if_ =
-        blackboard->open_for_writing<SwitchInterface>("ampelswitch");
-  } catch (Exception &e) {
-    e.append("Opening ampelswitch interface for writing failed");
-    throw;
-  }
+	try {
+		ampel_switch_if_ = blackboard->open_for_writing<SwitchInterface>("ampelswitch");
+	} catch (Exception &e) {
+		e.append("Opening ampelswitch interface for writing failed");
+		throw;
+	}
 
-  // image properties
-  img_width_ = cam_->pixel_width();
-  img_height_ = cam_->pixel_height();
-  cspace_from_ = cam_->colorspace(); // cspace from == cspace to, damit kein
-                                     // convert. sonst exception
+	// image properties
+	img_width_   = cam_->pixel_width();
+	img_height_  = cam_->pixel_height();
+	cspace_from_ = cam_->colorspace(); // cspace from == cspace to, damit kein
+	                                   // convert. sonst exception
 
-  if (!cfg_debug_buffer_) {
-    try {
-      if (cspace_from_ != cspace_to_) {
-        throw Exception("cspace_from_ does not match cspace_to_");
-      }
-    } catch (Exception &e) {
-      throw;
-    }
-  }
+	if (!cfg_debug_buffer_) {
+		try {
+			if (cspace_from_ != cspace_to_) {
+				throw Exception("cspace_from_ does not match cspace_to_");
+			}
+		} catch (Exception &e) {
+			throw;
+		}
+	}
 
-  // other stuff that might throw an exception
-  try {
-    // mirror calibration
-    mirror_ = new Bulb(cfg_mirror_file_.c_str(), "omni-mirror",
-                       true /* destroy on delete */);
+	// other stuff that might throw an exception
+	try {
+		// mirror calibration
+		mirror_ = new Bulb(cfg_mirror_file_.c_str(), "omni-mirror", true /* destroy on delete */);
 
-    // SHM image buffer
-    shm_buffer_ = new SharedMemoryImageBuffer("ampelvar-processed", cspace_to_,
-                                              img_width_, img_height_);
-    if (!shm_buffer_->is_valid()) {
-      throw Exception("Shared memory segment not valid");
-    }
+		// SHM image buffer
+		shm_buffer_ =
+		  new SharedMemoryImageBuffer("ampelvar-processed", cspace_to_, img_width_, img_height_);
+		if (!shm_buffer_->is_valid()) {
+			throw Exception("Shared memory segment not valid");
+		}
 
-    shm_buffer_->set_frame_id(cfg_frame_.c_str());
-    buffer_ = shm_buffer_->buffer();
+		shm_buffer_->set_frame_id(cfg_frame_.c_str());
+		buffer_ = shm_buffer_->buffer();
 
-  } catch (Exception &e) {
-    delete mirror_;
-    mirror_ = NULL;
-    delete shm_buffer_;
-    shm_buffer_ = NULL;
-    blackboard->close(ampel_red_if_);
-    ampel_red_if_ = NULL;
-    blackboard->close(ampel_orange_if_);
-    ampel_orange_if_ = NULL;
-    blackboard->close(ampel_green_if_);
-    ampel_green_if_ = NULL;
+	} catch (Exception &e) {
+		delete mirror_;
+		mirror_ = NULL;
+		delete shm_buffer_;
+		shm_buffer_ = NULL;
+		blackboard->close(ampel_red_if_);
+		ampel_red_if_ = NULL;
+		blackboard->close(ampel_orange_if_);
+		ampel_orange_if_ = NULL;
+		blackboard->close(ampel_green_if_);
+		ampel_green_if_ = NULL;
 
-    blackboard->close(laser_pos_if_);
-    laser_pos_if_ = NULL;
+		blackboard->close(laser_pos_if_);
+		laser_pos_if_ = NULL;
 
-    delete cam_;
-    cam_ = NULL;
-    throw;
-  }
+		delete cam_;
+		cam_ = NULL;
+		throw;
+	}
 
-  // scanline_ model
-  scanline_ = new ScanlineGrid(img_width_, img_height_, 1, 1);
+	// scanline_ model
+	scanline_ = new ScanlineGrid(img_width_, img_height_, 1, 1);
 
-  // drawer
-  if (cfg_debug_buffer_) {
-    drawer_ = new Drawer();
-    drawer_->set_buffer(buffer_, img_width_, img_height_);
-    drawer_->set_color(76, 84, 255);
-  }
+	// drawer
+	if (cfg_debug_buffer_) {
+		drawer_ = new Drawer();
+		drawer_->set_buffer(buffer_, img_width_, img_height_);
+		drawer_->set_color(76, 84, 255);
+	}
 
-  for (unsigned int i = 0; i <= 63; i++) {
-    bucket[i] = 0;
-  }
+	for (unsigned int i = 0; i <= 63; i++) {
+		bucket[i] = 0;
+	}
 
-  center = mirror_->getCenter();
-  /*center.x=158;
+	center = mirror_->getCenter();
+	/*center.x=158;
   center.y=121;*/
 
-  luminance_threshold = 60;
+	luminance_threshold = 60;
 
-  logger->log_debug(name(), "init=> center: x=%i, y=%i", center.x, center.y);
+	logger->log_debug(name(), "init=> center: x=%i, y=%i", center.x, center.y);
 
-  /* static values for non-dynamic-approach */
-  upper_left_red_x_man = 53; // ima3, ima2: each 53
-  upper_left_orange_x_man = 53;
-  upper_left_green_x_man = 53;
+	/* static values for non-dynamic-approach */
+	upper_left_red_x_man    = 53; // ima3, ima2: each 53
+	upper_left_orange_x_man = 53;
+	upper_left_green_x_man  = 53;
 
-  upper_left_red_y_man = 35;    // ima3: 38, ima2: 35
-  upper_left_orange_y_man = 56; // ima3: 57, ima2: 56
-  upper_left_green_y_man = 84;  // ima3: 72, ima2: 84
+	upper_left_red_y_man    = 35; // ima3: 38, ima2: 35
+	upper_left_orange_y_man = 56; // ima3: 57, ima2: 56
+	upper_left_green_y_man  = 84; // ima3: 72, ima2: 84
 
-  red_width_man = 24;
-  orange_width_man = 24;
-  green_width_man = 24;
+	red_width_man    = 24;
+	orange_width_man = 24;
+	green_width_man  = 24;
 
-  red_height_man = 12; // ima3: each 10, ima2: each 12
-  orange_height_man = 12;
-  green_height_man = 12;
+	red_height_man    = 12; // ima3: each 10, ima2: each 12
+	orange_height_man = 12;
+	green_height_man  = 12;
 }
 
 /** Thread finalization. */
-void RobotinoAmpelVarPipelineThread::finalize() {
-  delete drawer_;
-  delete scanline_;
-  delete shm_buffer_;
-  delete mirror_;
+void
+RobotinoAmpelVarPipelineThread::finalize()
+{
+	delete drawer_;
+	delete scanline_;
+	delete shm_buffer_;
+	delete mirror_;
 
-  try {
-    ampel_red_if_->write();
-    blackboard->close(ampel_red_if_);
-    ampel_orange_if_->write();
-    blackboard->close(ampel_orange_if_);
-    ampel_green_if_->write();
-    blackboard->close(ampel_green_if_);
+	try {
+		ampel_red_if_->write();
+		blackboard->close(ampel_red_if_);
+		ampel_orange_if_->write();
+		blackboard->close(ampel_orange_if_);
+		ampel_green_if_->write();
+		blackboard->close(ampel_green_if_);
 
-    ampel_switch_if_->write();
-    blackboard->close(ampel_switch_if_);
+		ampel_switch_if_->write();
+		blackboard->close(ampel_switch_if_);
 
-    blackboard->close(laser_pos_if_);
+		blackboard->close(laser_pos_if_);
 
-    delete ROI_colors[0];
-    delete ROI_colors[1];
-    delete ROI_colors[2];
+		delete ROI_colors[0];
+		delete ROI_colors[1];
+		delete ROI_colors[2];
 
-  } catch (Exception &e) {
-    e.append("Closing ampel interfaces failed");
-    throw;
-  }
+	} catch (Exception &e) {
+		e.append("Closing ampel interfaces failed");
+		throw;
+	}
 
-  logger->log_debug(name(), "Unregistering from vision master");
-  vision_master->unregister_thread(this);
-  delete cam_;
+	logger->log_debug(name(), "Unregistering from vision master");
+	vision_master->unregister_thread(this);
+	delete cam_;
 }
 
 /** Process image to detect objects.
@@ -263,305 +258,319 @@ void RobotinoAmpelVarPipelineThread::finalize() {
  * determine objects according to the colormap. Publish the
  * position of the closest such object as puck position.
  */
-void RobotinoAmpelVarPipelineThread::loop() {
-  // check if there is a msg in the msg-queue
-  while (!ampel_switch_if_->msgq_empty()) {
-    if (SwitchInterface::DisableSwitchMessage *msg =
-            ampel_switch_if_->msgq_first_safe(msg)) {
-      logger->log_debug(name(), "Switch disable message received");
-      ampel_switch_if_->set_enabled(false);
-    } else if (SwitchInterface::EnableSwitchMessage *msg =
-                   ampel_switch_if_->msgq_first_safe(msg)) {
-      logger->log_debug(name(), "Switch enable message received");
-      ampel_switch_if_->set_enabled(true);
-    }
-    ampel_switch_if_->msgq_pop();
-    ampel_switch_if_->write();
-  }
+void
+RobotinoAmpelVarPipelineThread::loop()
+{
+	// check if there is a msg in the msg-queue
+	while (!ampel_switch_if_->msgq_empty()) {
+		if (SwitchInterface::DisableSwitchMessage *msg = ampel_switch_if_->msgq_first_safe(msg)) {
+			logger->log_debug(name(), "Switch disable message received");
+			ampel_switch_if_->set_enabled(false);
+		} else if (SwitchInterface::EnableSwitchMessage *msg = ampel_switch_if_->msgq_first_safe(msg)) {
+			logger->log_debug(name(), "Switch enable message received");
+			ampel_switch_if_->set_enabled(true);
+		}
+		ampel_switch_if_->msgq_pop();
+		ampel_switch_if_->write();
+	}
 
-  if (ampel_switch_if_->is_enabled() == false) {
-    return;
-  } //*/
+	if (ampel_switch_if_->is_enabled() == false) {
+		return;
+	} //*/
 
-  starttime = clock->now();
-  laser_pos_if_->read();
+	starttime = clock->now();
+	laser_pos_if_->read();
 
-  cam_->capture();
+	cam_->capture();
 
-  buffer_ = cam_->buffer(); // dispose buffer dann am ende!
+	buffer_ = cam_->buffer(); // dispose buffer dann am ende!
 
-  if (!cfg_is_static_) {
-    ampel_x = laser_pos_if_->translation(0);
-    ampel_y = laser_pos_if_->translation(1);
+	if (!cfg_is_static_) {
+		ampel_x = laser_pos_if_->translation(0);
+		ampel_y = laser_pos_if_->translation(1);
 
-    cart2polar2d(ampel_x, ampel_y, &theta, &distance_ampel);
+		cart2polar2d(ampel_x, ampel_y, &theta, &distance_ampel);
 
-    if (cfg_is_static_) {
-      distance_ampel = 0.265f;
-      theta = 0.f;
-    }
+		if (cfg_is_static_) {
+			distance_ampel = 0.265f;
+			theta          = 0.f;
+		}
 
-    // Berechnung des projezierten Abstandes der Ampelfarben auf der Nullebene
-    distance_red = cfg_camera_height_ * 100 * distance_ampel /
-                   (cfg_camera_height_ - cfg_red_height_);
-    distance_orange = cfg_camera_height_ * 100 * distance_ampel /
-                      (cfg_camera_height_ - cfg_orange_height_);
-    distance_green = cfg_camera_height_ * 100 * distance_ampel /
-                     (cfg_camera_height_ - cfg_green_height_);
+		// Berechnung des projezierten Abstandes der Ampelfarben auf der Nullebene
+		distance_red =
+		  cfg_camera_height_ * 100 * distance_ampel / (cfg_camera_height_ - cfg_red_height_);
+		distance_orange =
+		  cfg_camera_height_ * 100 * distance_ampel / (cfg_camera_height_ - cfg_orange_height_);
+		distance_green =
+		  cfg_camera_height_ * 100 * distance_ampel / (cfg_camera_height_ - cfg_green_height_);
 
-    // logger->log_debug(name(),"red %f, orange %f, green
-    // %f",distance_red,distance_orange,distance_green);
+		// logger->log_debug(name(),"red %f, orange %f, green
+		// %f",distance_red,distance_orange,distance_green);
 
-    // px position aus bulb! nearest neighbour
-    // aus Laser: distance d und winkel theta
+		// px position aus bulb! nearest neighbour
+		// aus Laser: distance d und winkel theta
 
-    d = distance_red;
-    gefunden = false;
-    map = mirror_->get_lut();
+		d        = distance_red;
+		gefunden = false;
+		map      = mirror_->get_lut();
 
-    for (h = 1; h < img_height_ / 2; ++h) {
-      for (w = 1; w < img_width_ - 1; ++w) {
-        pol_l = map[h * img_width_ + w];
-        pol_r = map[h * img_width_ + w + 1];
-        pol_l.r = pol_l.r * 100;
+		for (h = 1; h < img_height_ / 2; ++h) {
+			for (w = 1; w < img_width_ - 1; ++w) {
+				pol_l   = map[h * img_width_ + w];
+				pol_r   = map[h * img_width_ + w + 1];
+				pol_l.r = pol_l.r * 100;
 
-        if (pol_l.phi < -M_PI) {
-          pol_l.phi = pol_l.phi + 2 * M_PI;
-        }
+				if (pol_l.phi < -M_PI) {
+					pol_l.phi = pol_l.phi + 2 * M_PI;
+				}
 
-        if (pol_l.phi < -M_PI) {
-          pol_r.phi = pol_r.phi + 2 * M_PI;
-        }
+				if (pol_l.phi < -M_PI) {
+					pol_r.phi = pol_r.phi + 2 * M_PI;
+				}
 
-        if (pol_l.phi <= theta && pol_l.r <= d && pol_r.phi >= theta) {
-          gefunden = true;
-        }
-        if (pol_l.phi >= theta && pol_l.r <= d && pol_r.phi <= theta) {
-          gefunden = true;
-        }
-        if (gefunden)
-          break;
-      }
-      if (gefunden)
-        break;
-    }
+				if (pol_l.phi <= theta && pol_l.r <= d && pol_r.phi >= theta) {
+					gefunden = true;
+				}
+				if (pol_l.phi >= theta && pol_l.r <= d && pol_r.phi <= theta) {
+					gefunden = true;
+				}
+				if (gefunden)
+					break;
+			}
+			if (gefunden)
+				break;
+		}
 
-    px_position_red_x = w;
-    px_position_red_y = h;
+		px_position_red_x = w;
+		px_position_red_y = h;
 
-    d = distance_orange;
-    gefunden = false;
-    map = mirror_->get_lut();
+		d        = distance_orange;
+		gefunden = false;
+		map      = mirror_->get_lut();
 
-    for (h = 1; h < img_height_ / 2; ++h) {
-      for (w = 1; w < img_width_ - 1; ++w) {
-        pol_l = map[h * img_width_ + w];
-        pol_r = map[h * img_width_ + w + 1];
-        pol_l.r = pol_l.r * 100;
+		for (h = 1; h < img_height_ / 2; ++h) {
+			for (w = 1; w < img_width_ - 1; ++w) {
+				pol_l   = map[h * img_width_ + w];
+				pol_r   = map[h * img_width_ + w + 1];
+				pol_l.r = pol_l.r * 100;
 
-        if (pol_l.phi < -M_PI) {
-          pol_l.phi = pol_l.phi + 2 * M_PI;
-        }
+				if (pol_l.phi < -M_PI) {
+					pol_l.phi = pol_l.phi + 2 * M_PI;
+				}
 
-        if (pol_l.phi < -M_PI) {
-          pol_r.phi = pol_r.phi + 2 * M_PI;
-        }
+				if (pol_l.phi < -M_PI) {
+					pol_r.phi = pol_r.phi + 2 * M_PI;
+				}
 
-        if (pol_l.phi <= theta && pol_l.r <= d && pol_r.phi >= theta) {
-          gefunden = true;
-        }
-        if (pol_l.phi >= theta && pol_l.r <= d && pol_r.phi <= theta) {
-          gefunden = true;
-        }
-        if (gefunden)
-          break;
-      }
-      if (gefunden)
-        break;
-    }
-    px_position_orange_x = w;
-    px_position_orange_y = h;
+				if (pol_l.phi <= theta && pol_l.r <= d && pol_r.phi >= theta) {
+					gefunden = true;
+				}
+				if (pol_l.phi >= theta && pol_l.r <= d && pol_r.phi <= theta) {
+					gefunden = true;
+				}
+				if (gefunden)
+					break;
+			}
+			if (gefunden)
+				break;
+		}
+		px_position_orange_x = w;
+		px_position_orange_y = h;
 
-    d = distance_green;
-    gefunden = false;
-    map = mirror_->get_lut();
+		d        = distance_green;
+		gefunden = false;
+		map      = mirror_->get_lut();
 
-    for (h = 1; h < img_height_ / 2; ++h) {
-      for (w = 1; w < img_width_ - 1; ++w) {
-        pol_l = map[h * img_width_ + w];
-        pol_r = map[h * img_width_ + w + 1];
-        pol_l.r = pol_l.r * 100;
+		for (h = 1; h < img_height_ / 2; ++h) {
+			for (w = 1; w < img_width_ - 1; ++w) {
+				pol_l   = map[h * img_width_ + w];
+				pol_r   = map[h * img_width_ + w + 1];
+				pol_l.r = pol_l.r * 100;
 
-        if (pol_l.phi < -M_PI) {
-          pol_l.phi = pol_l.phi + 2 * M_PI;
-        }
+				if (pol_l.phi < -M_PI) {
+					pol_l.phi = pol_l.phi + 2 * M_PI;
+				}
 
-        if (pol_l.phi < -M_PI) {
-          pol_r.phi = pol_r.phi + 2 * M_PI;
-        }
+				if (pol_l.phi < -M_PI) {
+					pol_r.phi = pol_r.phi + 2 * M_PI;
+				}
 
-        if (pol_l.phi <= theta && pol_l.r <= d && pol_r.phi >= theta) {
-          gefunden = true;
-        }
-        if (pol_l.phi >= theta && pol_l.r <= d && pol_r.phi <= theta) {
-          gefunden = true;
-        }
-        if (gefunden)
-          break;
-      }
-      if (gefunden)
-        break;
-    }
+				if (pol_l.phi <= theta && pol_l.r <= d && pol_r.phi >= theta) {
+					gefunden = true;
+				}
+				if (pol_l.phi >= theta && pol_l.r <= d && pol_r.phi <= theta) {
+					gefunden = true;
+				}
+				if (gefunden)
+					break;
+			}
+			if (gefunden)
+				break;
+		}
 
-    px_position_green_x = w;
-    px_position_green_y = h;
-  }
+		px_position_green_x = w;
+		px_position_green_y = h;
+	}
 
-  luminance_threshold = 2;
+	luminance_threshold = 2;
 
-  // set ROI parameter for each color
-  if (!cfg_is_static_) {
-    try {
-      ROI_colors[0] = new ROI(px_position_red_x, px_position_red_y, 6, 2,
-                              img_width_, img_height_);
-      ROI_colors[1] = new ROI(px_position_orange_x, px_position_orange_y, 6, 2,
-                              img_width_, img_height_);
-      ROI_colors[2] = new ROI(px_position_green_x, px_position_green_y, 6, 2,
-                              img_width_, img_height_);
-    } catch (Exception &e) {
-      e.append("ROIs out of bound");
-      throw;
-    }
-  }
+	// set ROI parameter for each color
+	if (!cfg_is_static_) {
+		try {
+			ROI_colors[0] = new ROI(px_position_red_x, px_position_red_y, 6, 2, img_width_, img_height_);
+			ROI_colors[1] =
+			  new ROI(px_position_orange_x, px_position_orange_y, 6, 2, img_width_, img_height_);
+			ROI_colors[2] =
+			  new ROI(px_position_green_x, px_position_green_y, 6, 2, img_width_, img_height_);
+		} catch (Exception &e) {
+			e.append("ROIs out of bound");
+			throw;
+		}
+	}
 
-  // static ROIs
-  if (cfg_is_static_) {
-    ROI_colors[0] =
-        new ROI(upper_left_red_x_man, upper_left_red_y_man, red_width_man,
-                red_height_man, img_width_, img_height_);
-    ROI_colors[1] =
-        new ROI(upper_left_orange_x_man, upper_left_orange_y_man,
-                orange_width_man, orange_height_man, img_width_, img_height_);
-    ROI_colors[2] =
-        new ROI(upper_left_green_x_man, upper_left_green_y_man, green_width_man,
-                green_height_man, img_width_, img_height_);
-  }
+	// static ROIs
+	if (cfg_is_static_) {
+		ROI_colors[0] = new ROI(upper_left_red_x_man,
+		                        upper_left_red_y_man,
+		                        red_width_man,
+		                        red_height_man,
+		                        img_width_,
+		                        img_height_);
+		ROI_colors[1] = new ROI(upper_left_orange_x_man,
+		                        upper_left_orange_y_man,
+		                        orange_width_man,
+		                        orange_height_man,
+		                        img_width_,
+		                        img_height_);
+		ROI_colors[2] = new ROI(upper_left_green_x_man,
+		                        upper_left_green_y_man,
+		                        green_width_man,
+		                        green_height_man,
+		                        img_width_,
+		                        img_height_);
+	}
 
-  // detect red
-  scanline_->reset();
-  scanline_->set_roi(ROI_colors[0]);
-  while (!scanline_->finished()) {
-    current_x = (*scanline_)->x;
-    current_y = (*scanline_)->y;
-    luminance = buffer_[current_y * img_width_ + current_x];
-    // logger->log_info(name(),"luminance red=%i",luminance);
-    bucket[(unsigned int)(luminance / 4)]++;
-    ++(*scanline_);
-  }
+	// detect red
+	scanline_->reset();
+	scanline_->set_roi(ROI_colors[0]);
+	while (!scanline_->finished()) {
+		current_x = (*scanline_)->x;
+		current_y = (*scanline_)->y;
+		luminance = buffer_[current_y * img_width_ + current_x];
+		// logger->log_info(name(),"luminance red=%i",luminance);
+		bucket[(unsigned int)(luminance / 4)]++;
+		++(*scanline_);
+	}
 
-  bucket[0] = bucket[54] + bucket[55] + bucket[56] + bucket[57] + bucket[58] +
-              bucket[59] + bucket[60] + bucket[61] + bucket[62] + bucket[63];
+	bucket[0] = bucket[54] + bucket[55] + bucket[56] + bucket[57] + bucket[58] + bucket[59]
+	            + bucket[60] + bucket[61] + bucket[62] + bucket[63];
 
-  // logger->log_debug(name(),"bucket[0] red: %i",bucket[0]);
-  if (bucket[0] >= luminance_threshold) {
-    is_red = true;
-  } else
-    is_red = false;
+	// logger->log_debug(name(),"bucket[0] red: %i",bucket[0]);
+	if (bucket[0] >= luminance_threshold) {
+		is_red = true;
+	} else
+		is_red = false;
 
-  for (unsigned int i = 0; i <= 63; i++) {
-    bucket[i] = 0;
-  }
+	for (unsigned int i = 0; i <= 63; i++) {
+		bucket[i] = 0;
+	}
 
-  // detect orange
-  scanline_->reset();
-  scanline_->set_roi(ROI_colors[1]);
+	// detect orange
+	scanline_->reset();
+	scanline_->set_roi(ROI_colors[1]);
 
-  while (!scanline_->finished()) {
-    current_x = (*scanline_)->x;
-    current_y = (*scanline_)->y;
-    luminance = buffer_[current_y * img_width_ + current_x];
-    // logger->log_info(name(),"luminance orange=%i",luminance);
-    bucket[(unsigned int)(luminance / 4)]++;
-    ++(*scanline_);
-  }
+	while (!scanline_->finished()) {
+		current_x = (*scanline_)->x;
+		current_y = (*scanline_)->y;
+		luminance = buffer_[current_y * img_width_ + current_x];
+		// logger->log_info(name(),"luminance orange=%i",luminance);
+		bucket[(unsigned int)(luminance / 4)]++;
+		++(*scanline_);
+	}
 
-  bucket[0] = bucket[54] + bucket[55] + bucket[56] + bucket[57] + bucket[58] +
-              bucket[59] + bucket[60] + bucket[61] + bucket[62] + bucket[63];
+	bucket[0] = bucket[54] + bucket[55] + bucket[56] + bucket[57] + bucket[58] + bucket[59]
+	            + bucket[60] + bucket[61] + bucket[62] + bucket[63];
 
-  // logger->log_debug(name(),"bucket[0] orange: %i",bucket[0]);
-  if (bucket[0] >= luminance_threshold) {
-    // drawer_->draw_circle(center.x,center.y-px_position_orange,3);
-    is_orange = true;
-  } else
-    is_orange = false;
+	// logger->log_debug(name(),"bucket[0] orange: %i",bucket[0]);
+	if (bucket[0] >= luminance_threshold) {
+		// drawer_->draw_circle(center.x,center.y-px_position_orange,3);
+		is_orange = true;
+	} else
+		is_orange = false;
 
-  for (unsigned int i = 0; i <= 63; i++) {
-    bucket[i] = 0;
-  }
+	for (unsigned int i = 0; i <= 63; i++) {
+		bucket[i] = 0;
+	}
 
-  // detect green
-  scanline_->reset();
-  scanline_->set_roi(ROI_colors[2]);
-  while (!scanline_->finished()) {
-    current_x = (*scanline_)->x;
-    current_y = (*scanline_)->y;
-    luminance = buffer_[current_y * img_width_ + current_x];
-    // logger->log_info(name(),"luminance green=%i",luminance);
-    bucket[(unsigned int)(luminance / 4)]++;
-    ++(*scanline_);
-  }
+	// detect green
+	scanline_->reset();
+	scanline_->set_roi(ROI_colors[2]);
+	while (!scanline_->finished()) {
+		current_x = (*scanline_)->x;
+		current_y = (*scanline_)->y;
+		luminance = buffer_[current_y * img_width_ + current_x];
+		// logger->log_info(name(),"luminance green=%i",luminance);
+		bucket[(unsigned int)(luminance / 4)]++;
+		++(*scanline_);
+	}
 
-  bucket[0] = bucket[54] + bucket[55] + bucket[56] + bucket[57] + bucket[58] +
-              bucket[59] + bucket[60] + bucket[61] + bucket[62] + bucket[63];
+	bucket[0] = bucket[54] + bucket[55] + bucket[56] + bucket[57] + bucket[58] + bucket[59]
+	            + bucket[60] + bucket[61] + bucket[62] + bucket[63];
 
-  // logger->log_debug(name(),"bucket[0] green: %i",bucket[0]);
+	// logger->log_debug(name(),"bucket[0] green: %i",bucket[0]);
 
-  if (bucket[0] >= luminance_threshold) {
-    is_green = true;
-  } else
-    is_green = false;
+	if (bucket[0] >= luminance_threshold) {
+		is_green = true;
+	} else
+		is_green = false;
 
-  if (cfg_debug_buffer_) {
-    // wenn der debug buffer geschrieben werden soll
-    convert(cspace_from_, cspace_to_, cam_->buffer(), shm_buffer_->buffer(),
-            img_width_, img_height_);
-    drawer_->draw_rectangle(upper_left_red_x_man, upper_left_red_y_man,
-                            red_width_man, red_height_man);
-    drawer_->draw_rectangle(upper_left_orange_x_man, upper_left_orange_y_man,
-                            orange_width_man, orange_height_man);
-    drawer_->draw_rectangle(upper_left_green_x_man, upper_left_green_y_man,
-                            green_width_man, green_height_man);
-  }
+	if (cfg_debug_buffer_) {
+		// wenn der debug buffer geschrieben werden soll
+		convert(
+		  cspace_from_, cspace_to_, cam_->buffer(), shm_buffer_->buffer(), img_width_, img_height_);
+		drawer_->draw_rectangle(upper_left_red_x_man,
+		                        upper_left_red_y_man,
+		                        red_width_man,
+		                        red_height_man);
+		drawer_->draw_rectangle(upper_left_orange_x_man,
+		                        upper_left_orange_y_man,
+		                        orange_width_man,
+		                        orange_height_man);
+		drawer_->draw_rectangle(upper_left_green_x_man,
+		                        upper_left_green_y_man,
+		                        green_width_man,
+		                        green_height_man);
+	}
 
-  for (unsigned int i = 0; i <= 63; i++) {
-    bucket[i] = 0;
-  }
+	for (unsigned int i = 0; i <= 63; i++) {
+		bucket[i] = 0;
+	}
 
-  /*
+	/*
     scanline_model->reset();
           while (! scanline_model->finished()) {
 
             x = (*scanline_model)->x;
             y = (*scanline_model)->y; */
 
-  // interface schreiben
-  ampel_red_if_->set_enabled(is_red);
-  ampel_orange_if_->set_enabled(is_orange);
-  ampel_green_if_->set_enabled(is_green);
+	// interface schreiben
+	ampel_red_if_->set_enabled(is_red);
+	ampel_orange_if_->set_enabled(is_orange);
+	ampel_green_if_->set_enabled(is_green);
 
-  ampel_red_if_->write();
-  ampel_orange_if_->write();
-  ampel_green_if_->write();
+	ampel_red_if_->write();
+	ampel_orange_if_->write();
+	ampel_green_if_->write();
 
-  delete ROI_colors[0];
-  delete ROI_colors[1];
-  delete ROI_colors[2];
+	delete ROI_colors[0];
+	delete ROI_colors[1];
+	delete ROI_colors[2];
 
-  // logger->log_debug(name(),"result red: %i, orange: %i, green:
-  // %i",ampel_red_if_->is_enabled(),ampel_orange_if_->is_enabled(),ampel_green_if_->is_enabled());
-  // logger->log_debug(name(),"Zeit: %f",clock->elapsed(&starttime));
+	// logger->log_debug(name(),"result red: %i, orange: %i, green:
+	// %i",ampel_red_if_->is_enabled(),ampel_orange_if_->is_enabled(),ampel_green_if_->is_enabled());
+	// logger->log_debug(name(),"Zeit: %f",clock->elapsed(&starttime));
 
-  cam_->dispose_buffer();
+	cam_->dispose_buffer();
 }
 
 /*  float zwischen1 =

--- a/src/plugins/attic/ampelvar/pipeline_thread.h
+++ b/src/plugins/attic/ampelvar/pipeline_thread.h
@@ -24,19 +24,16 @@
 #ifndef __PLUGINS_ROBOTINO_AMPELVAR_PIPELINE_THREAD_H_
 #define __PLUGINS_ROBOTINO_AMPELVAR_PIPELINE_THREAD_H_
 
-#include <core/threading/thread.h>
-
 #include <aspect/blackboard.h>
+#include <aspect/clock.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <aspect/vision.h>
-
+#include <core/threading/thread.h>
 #include <fvutils/base/roi.h>
 #include <fvutils/base/types.h>
 #include <fvutils/color/colorspaces.h>
 #include <utils/math/types.h>
-
-#include <aspect/clock.h>
 
 #include <string>
 
@@ -57,119 +54,120 @@ class RobotinoAmpelVarPipelineThread : public fawkes::Thread,
                                        public fawkes::VisionAspect,
                                        public fawkes::ConfigurableAspect,
                                        public fawkes::BlackBoardAspect,
-                                       public fawkes::ClockAspect {
+                                       public fawkes::ClockAspect
+{
 public:
-  RobotinoAmpelVarPipelineThread();
-  virtual ~RobotinoAmpelVarPipelineThread();
+	RobotinoAmpelVarPipelineThread();
+	virtual ~RobotinoAmpelVarPipelineThread();
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
 private:
-  firevision::Camera *cam_;
-  firevision::ScanlineModel *scanline_;
-  firevision::Bulb *mirror_;
-  firevision::SharedMemoryImageBuffer *shm_buffer_;
+	firevision::Camera *                 cam_;
+	firevision::ScanlineModel *          scanline_;
+	firevision::Bulb *                   mirror_;
+	firevision::SharedMemoryImageBuffer *shm_buffer_;
 
-  unsigned char *buffer_;
+	unsigned char *buffer_;
 
-  unsigned int img_width_;
-  unsigned int img_height_;
+	unsigned int img_width_;
+	unsigned int img_height_;
 
-  firevision::colorspace_t cspace_from_;
-  firevision::colorspace_t cspace_to_;
+	firevision::colorspace_t cspace_from_;
+	firevision::colorspace_t cspace_to_;
 
-  fawkes::SwitchInterface *ampel_red_if_;
-  fawkes::SwitchInterface *ampel_orange_if_;
-  fawkes::SwitchInterface *ampel_green_if_;
+	fawkes::SwitchInterface *ampel_red_if_;
+	fawkes::SwitchInterface *ampel_orange_if_;
+	fawkes::SwitchInterface *ampel_green_if_;
 
-  fawkes::Position3DInterface *laser_pos_if_;
+	fawkes::Position3DInterface *laser_pos_if_;
 
-  fawkes::SwitchInterface *ampel_switch_if_;
+	fawkes::SwitchInterface *ampel_switch_if_;
 
-  fawkes::polar_coord_2d_t pol_l;
-  fawkes::polar_coord_2d_t pol_r;
-  const fawkes::polar_coord_2d_t *map;
+	fawkes::polar_coord_2d_t        pol_l;
+	fawkes::polar_coord_2d_t        pol_r;
+	const fawkes::polar_coord_2d_t *map;
 
-  std::list<firevision::ROI> *rois_;
+	std::list<firevision::ROI> *rois_;
 
-  std::string cfg_prefix_;
-  std::string cfg_camera_;
-  std::string cfg_mirror_file_;
-  std::string cfg_frame_;
+	std::string cfg_prefix_;
+	std::string cfg_camera_;
+	std::string cfg_mirror_file_;
+	std::string cfg_frame_;
 
-  float cfg_camera_height_;
-  bool cfg_debug_buffer_;
-  bool cfg_is_static_;
+	float cfg_camera_height_;
+	bool  cfg_debug_buffer_;
+	bool  cfg_is_static_;
 
-  float cfg_red_height_;
-  float cfg_orange_height_;
-  float cfg_green_height_;
+	float cfg_red_height_;
+	float cfg_orange_height_;
+	float cfg_green_height_;
 
-  float d;
-  float theta;
+	float d;
+	float theta;
 
-  float distance_ampel;
-  float distance_red;
-  float distance_orange;
-  float distance_green;
+	float distance_ampel;
+	float distance_red;
+	float distance_orange;
+	float distance_green;
 
-  unsigned int px_position_red_x;
-  unsigned int px_position_orange_x;
-  unsigned int px_position_green_x;
+	unsigned int px_position_red_x;
+	unsigned int px_position_orange_x;
+	unsigned int px_position_green_x;
 
-  unsigned int px_position_red_y;
-  unsigned int px_position_orange_y;
-  unsigned int px_position_green_y;
+	unsigned int px_position_red_y;
+	unsigned int px_position_orange_y;
+	unsigned int px_position_green_y;
 
-  unsigned int current_x;
-  unsigned int current_y;
+	unsigned int current_x;
+	unsigned int current_y;
 
-  unsigned int upper_left_red_x_man;
-  unsigned int upper_left_orange_x_man;
-  unsigned int upper_left_green_x_man;
+	unsigned int upper_left_red_x_man;
+	unsigned int upper_left_orange_x_man;
+	unsigned int upper_left_green_x_man;
 
-  unsigned int upper_left_red_y_man;
-  unsigned int upper_left_orange_y_man;
-  unsigned int upper_left_green_y_man;
+	unsigned int upper_left_red_y_man;
+	unsigned int upper_left_orange_y_man;
+	unsigned int upper_left_green_y_man;
 
-  unsigned int red_width_man;
-  unsigned int orange_width_man;
-  unsigned int green_width_man;
+	unsigned int red_width_man;
+	unsigned int orange_width_man;
+	unsigned int green_width_man;
 
-  unsigned int red_height_man;
-  unsigned int orange_height_man;
-  unsigned int green_height_man;
+	unsigned int red_height_man;
+	unsigned int orange_height_man;
+	unsigned int green_height_man;
 
-  double ampel_x;
-  double ampel_y;
+	double ampel_x;
+	double ampel_y;
 
-  unsigned int w;
-  unsigned int h;
+	unsigned int w;
+	unsigned int h;
 
-  bool is_red;
-  bool is_orange;
-  bool is_green;
-  bool gefunden;
-  bool check_ampel;
+	bool is_red;
+	bool is_orange;
+	bool is_green;
+	bool gefunden;
+	bool check_ampel;
 
-  float delta_r;
-  float delta_r_next;
+	float delta_r;
+	float delta_r_next;
 
-  unsigned int bucket[64];
-  unsigned int luminance; // Y in YUV
-  unsigned int luminance_threshold;
+	unsigned int bucket[64];
+	unsigned int luminance; // Y in YUV
+	unsigned int luminance_threshold;
 
-  /*
+	/*
    *  ROI_colors enthaelt die Regionen der Ampelfarben
    */
-  firevision::ROI *ROI_colors[3]; // 0 == red, 1 == orange, 3 == green
+	firevision::ROI *ROI_colors[3]; // 0 == red, 1 == orange, 3 == green
 
-  fawkes::point_t center;
-  fawkes::Time starttime;
+	fawkes::point_t center;
+	fawkes::Time    starttime;
 
-  firevision::Drawer *drawer_;
+	firevision::Drawer *drawer_;
 };
 
 #endif

--- a/src/plugins/attic/ampelvar/robotino_ampelvar_plugin.cpp
+++ b/src/plugins/attic/ampelvar/robotino_ampelvar_plugin.cpp
@@ -32,14 +32,16 @@ using namespace fawkes;
  * ampel.
  * @author Tim Niemueller
  */
-class RobotinoAmpelVarPlugin : public fawkes::Plugin {
+class RobotinoAmpelVarPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  RobotinoAmpelVarPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new RobotinoAmpelVarPipelineThread());
-  }
+	RobotinoAmpelVarPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new RobotinoAmpelVarPipelineThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Robotino ampel-var image processing")

--- a/src/plugins/attic/clusterdetection/laser_cluster_detector_plugin.cpp
+++ b/src/plugins/attic/clusterdetection/laser_cluster_detector_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "laser_cluster_detector_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Template! Makes the robotino move forward for 3 seconds
  * @author Daniel Ewert
  */
-class LaserClusterDetectorPlugin : public fawkes::Plugin {
+class LaserClusterDetectorPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  LaserClusterDetectorPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new LaserClusterDetector());
-  }
+	LaserClusterDetectorPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new LaserClusterDetector());
+	}
 };
 
 PLUGIN_DESCRIPTION("find a cluster of laserpoints")

--- a/src/plugins/attic/clusterdetection/laser_cluster_detector_thread.cpp
+++ b/src/plugins/attic/clusterdetection/laser_cluster_detector_thread.cpp
@@ -42,407 +42,422 @@ using namespace std;
  * @author Daniel Ewert
  */
 
-bool compare_polar_pos(const LaserClusterDetector::PolarPos &a,
-                       const LaserClusterDetector::PolarPos &b) {
-  return a.angle < b.angle;
+bool
+compare_polar_pos(const LaserClusterDetector::PolarPos &a, const LaserClusterDetector::PolarPos &b)
+{
+	return a.angle < b.angle;
 }
 
-int LaserClusterDetector::angle_to_scanrange(int angle) {
-  return (angle + cfg_laser_scanrange_ / 2) % 360;
+int
+LaserClusterDetector::angle_to_scanrange(int angle)
+{
+	return (angle + cfg_laser_scanrange_ / 2) % 360;
 }
 
-int LaserClusterDetector::scanrange_to_angle(int scanrange) {
-  return ((scanrange - cfg_laser_scanrange_ / 2) + 360) % 360;
+int
+LaserClusterDetector::scanrange_to_angle(int scanrange)
+{
+	return ((scanrange - cfg_laser_scanrange_ / 2) + 360) % 360;
 }
 
 /** Constructor. */
 LaserClusterDetector::LaserClusterDetector()
-    : Thread("MachinePositionerThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL) {}
-
-void LaserClusterDetector::init() {
-
-  logger->log_info(name(), "Laser_Cluster_Detector starts up");
-  laser_if_ = blackboard->open_for_reading<Laser360Interface>(
-      config->get_string(CFG_PREFIX "laser_interface").c_str());
-  num_scans_ = laser_if_->maxlenof_distances();
-
-  cfg_laser_min_ = config->get_float(CFG_PREFIX "laser_min_length");
-  cfg_laser_max_ = config->get_float(CFG_PREFIX "laser_max_length");
-  cfg_laser_scanrange_ = config->get_uint(CFG_PREFIX "laser_scanrange");
-  cfg_dist_threshold_ = config->get_float(CFG_PREFIX "dist_threshold");
-  cfg_debug_ = config->get_bool(CFG_PREFIX "show_debug_messages");
-
-  cfg_cluster_valid_size_ = config->get_float(CFG_PREFIX "cluster_size");
-
-  cfg_cluster_allowed_variance_ =
-      config->get_float(CFG_PREFIX "cluster_variance");
-  cfg_cluster_allowed_variance_over_time_ =
-      config->get_float(CFG_PREFIX "cluster_variance_over_time");
-  cfg_publish_laser_vis_ = config->get_bool(CFG_PREFIX "visualize_clusters");
-  cfg_cluster_max_distance_ =
-      config->get_float(CFG_PREFIX "cluster_max_distance");
-  cfg_cluster_coherence_ = config->get_float(CFG_PREFIX "cluster_coherence");
-  cfg_cluster_distance_delta_ =
-      config->get_float(CFG_PREFIX "cluster_distance_delta");
-
-  logger->log_debug(name(), "Configuration values:");
-  logger->log_debug(name(), "laser_min_length: %f", cfg_laser_min_);
-  logger->log_debug(name(), "laser_max_length: %f", cfg_laser_max_);
-  logger->log_debug(name(), "laser_scanrange: %d", cfg_laser_scanrange_);
-  logger->log_debug(name(), "threshold: %f", cfg_dist_threshold_);
-  logger->log_debug(name(), "cluster size: %f", cfg_cluster_valid_size_);
-  logger->log_debug(name(), "cluster_variance: %f",
-                    cfg_cluster_allowed_variance_);
-  logger->log_debug(name(), "cluster_variance_over_time: %f",
-                    cfg_cluster_allowed_variance_over_time_);
-
-  pos3d_nearest_cluster_if_ =
-      blackboard->open_for_writing<Position3DInterface>("Closest_Machine");
-  pos3d_nearest_laser_if_ = blackboard->open_for_writing<Position3DInterface>(
-      "Closest_Laser_Reading");
-
-  if (cfg_publish_laser_vis_) {
-    laser_vis_ = blackboard->open_for_writing<Laser360Interface>("Cluster Vis");
-  }
-
-  loopcnt = 0;
+: Thread("MachinePositionerThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
 }
 
-bool LaserClusterDetector::prepare_finalize_user() { return true; }
+void
+LaserClusterDetector::init()
+{
+	logger->log_info(name(), "Laser_Cluster_Detector starts up");
+	laser_if_ = blackboard->open_for_reading<Laser360Interface>(
+	  config->get_string(CFG_PREFIX "laser_interface").c_str());
+	num_scans_ = laser_if_->maxlenof_distances();
 
-bool compareReadings(const pair<unsigned int, float> &f,
-                     const pair<unsigned int, float> &s) {
-  return f.first < s.first;
+	cfg_laser_min_       = config->get_float(CFG_PREFIX "laser_min_length");
+	cfg_laser_max_       = config->get_float(CFG_PREFIX "laser_max_length");
+	cfg_laser_scanrange_ = config->get_uint(CFG_PREFIX "laser_scanrange");
+	cfg_dist_threshold_  = config->get_float(CFG_PREFIX "dist_threshold");
+	cfg_debug_           = config->get_bool(CFG_PREFIX "show_debug_messages");
+
+	cfg_cluster_valid_size_ = config->get_float(CFG_PREFIX "cluster_size");
+
+	cfg_cluster_allowed_variance_ = config->get_float(CFG_PREFIX "cluster_variance");
+	cfg_cluster_allowed_variance_over_time_ =
+	  config->get_float(CFG_PREFIX "cluster_variance_over_time");
+	cfg_publish_laser_vis_      = config->get_bool(CFG_PREFIX "visualize_clusters");
+	cfg_cluster_max_distance_   = config->get_float(CFG_PREFIX "cluster_max_distance");
+	cfg_cluster_coherence_      = config->get_float(CFG_PREFIX "cluster_coherence");
+	cfg_cluster_distance_delta_ = config->get_float(CFG_PREFIX "cluster_distance_delta");
+
+	logger->log_debug(name(), "Configuration values:");
+	logger->log_debug(name(), "laser_min_length: %f", cfg_laser_min_);
+	logger->log_debug(name(), "laser_max_length: %f", cfg_laser_max_);
+	logger->log_debug(name(), "laser_scanrange: %d", cfg_laser_scanrange_);
+	logger->log_debug(name(), "threshold: %f", cfg_dist_threshold_);
+	logger->log_debug(name(), "cluster size: %f", cfg_cluster_valid_size_);
+	logger->log_debug(name(), "cluster_variance: %f", cfg_cluster_allowed_variance_);
+	logger->log_debug(name(),
+	                  "cluster_variance_over_time: %f",
+	                  cfg_cluster_allowed_variance_over_time_);
+
+	pos3d_nearest_cluster_if_ = blackboard->open_for_writing<Position3DInterface>("Closest_Machine");
+	pos3d_nearest_laser_if_ =
+	  blackboard->open_for_writing<Position3DInterface>("Closest_Laser_Reading");
+
+	if (cfg_publish_laser_vis_) {
+		laser_vis_ = blackboard->open_for_writing<Laser360Interface>("Cluster Vis");
+	}
+
+	loopcnt = 0;
 }
 
-void LaserClusterDetector::finalize() {
-  blackboard->close(laser_if_);
-  blackboard->close(pos3d_nearest_cluster_if_);
-  blackboard->close(pos3d_nearest_laser_if_);
-  if (cfg_publish_laser_vis_) {
-    blackboard->close(laser_vis_);
-  }
+bool
+LaserClusterDetector::prepare_finalize_user()
+{
+	return true;
 }
 
-double LaserClusterDetector::calculate_cluster_size(const PolarPos &last_peak,
-                                                    const PolarPos &current) {
-  // check if angle between current_angle and angle_last_peak
-  // given the measured distances could be an signal light
-  // with c= sqrt(a**2 + b**2 - 2 ab cos(gamma)) law of cosines
-  // c then must be a feasible diameter of the light at the measured height
-  double angle = fawkes::deg2rad(abs(current.angle - last_peak.angle));
-  return sqrt(last_peak.distance * last_peak.distance +
-              current.distance * current.distance -
-              2 * last_peak.distance * current.distance * cos(angle));
+bool
+compareReadings(const pair<unsigned int, float> &f, const pair<unsigned int, float> &s)
+{
+	return f.first < s.first;
 }
 
-void LaserClusterDetector::calc_average_of_distances(
-    list<PolarPos>::iterator last_peak, list<PolarPos>::iterator current,
-    float *average_distance, float *variance) {
-  float sum = 0;
-  float sum_diffs = 0;
-  float last_distance = last_peak->distance;
-  int num = 0;
-  for (list<PolarPos>::iterator it = last_peak; it != current; ++it) {
-    sum += it->distance;
-    num++;
-    sum_diffs += abs(it->distance - last_distance);
-  }
-  *average_distance = sum / num;
-  *variance = sum_diffs / num;
+void
+LaserClusterDetector::finalize()
+{
+	blackboard->close(laser_if_);
+	blackboard->close(pos3d_nearest_cluster_if_);
+	blackboard->close(pos3d_nearest_laser_if_);
+	if (cfg_publish_laser_vis_) {
+		blackboard->close(laser_vis_);
+	}
 }
 
-void LaserClusterDetector::find_lights() {
-
-  lights_.clear();
-
-  list<PolarPos>::iterator last_peak = filtered_scan_.begin();
-  if (filtered_scan_.size() < 5) {
-    logger->log_error(name(), "not enough laser scan points!!");
-    return;
-  }
-
-  // Incredibly ugly, but i need a list, and i need to know predec and succ..
-  laserscan::iterator beforebefore = filtered_scan_.begin();
-  laserscan::iterator before = filtered_scan_.begin();
-  before++;
-
-  laserscan::iterator current = filtered_scan_.begin();
-  std::advance(current, 2);
-
-  laserscan::iterator following = filtered_scan_.begin();
-  std::advance(following, 3);
-  laserscan::iterator followingfollowing = filtered_scan_.begin();
-  std::advance(followingfollowing, 4);
-  if (debug_) {
-    logger->log_debug(name(), "======  Scanning ========== ");
-  }
-  while (followingfollowing != filtered_scan_.end()) {
-    float average_distance;
-    float variance;
-    calc_average_of_distances(last_peak, current, &average_distance, &variance);
-
-    // we can either have a peak (the begin or end of a cluster) iff
-    // - the difference between the current reading and the average so far is
-    // greater than threshold
-    // - we read two invalid readings before or after the current reading
-    if (current->distance != -1 &&
-        current->distance <= cfg_cluster_max_distance_ &&
-        (abs(average_distance - current->distance) > cfg_dist_threshold_ ||
-         (before->distance == -1 && beforebefore->distance == -1) ||
-         (following->distance == -1 && followingfollowing->distance == -1)
-
-             )) {
-      // we have a sufficient peak, can either be the begin or the end
-
-      if (debug_)
-        logger->log_debug(name(), "peak at %d", current->angle);
-
-      // check if we have a valid last_peak.
-      // if not, go on
-      if (last_peak->distance != -1.0) {
-        int angle = abs(current->angle - last_peak->angle);
-        int light_angle = current->angle - (angle / 2.0);
-        float light_distance;
-
-        float diam_light = calculate_cluster_size(*last_peak, *current);
-        if (debug_)
-          logger->log_debug(name(), "cluster size would be: %f", diam_light);
-
-        // determine max and min of the cluster
-        int min_angle = 0;
-        float max_dist = 0;
-        float min_dist = cfg_laser_max_;
-        for (list<PolarPos>::iterator it = last_peak; it != following; ++it) {
-          if (it->distance < min_dist) {
-            min_dist = it->distance;
-            min_angle = it->angle;
-          }
-          if (it->distance > max_dist) {
-            max_dist = it->distance;
-          }
-        }
-
-        if (max_dist > min_dist) {
-          if (max_dist - min_dist <= cfg_cluster_coherence_) {
-            // Cluster is regular everything good
-            if (debug_)
-              logger->log_debug(name(), "regular cluster");
-            light_distance = (last_peak->distance + current->distance) / 2.0;
-          } else {
-            // cluster is too widespread, assume reflection from signal light
-            // and
-            // chose minimal values as correct readings
-
-            light_distance = min_dist + cfg_cluster_distance_delta_;
-            light_angle = min_angle;
-            PolarPos lastpeak_corrected(last_peak->angle, min_dist);
-            PolarPos current_corrected(current->angle, min_dist);
-            diam_light =
-                calculate_cluster_size(lastpeak_corrected, current_corrected);
-            if (debug_)
-              logger->log_debug(name(), "irregular cluster, new size: %f",
-                                diam_light);
-          }
-        }
-
-        if (debug_) {
-          logger->log_debug(name(),
-                            "last peak: %s current peak: %s; cluster size: %f",
-                            last_peak->to_string().c_str(),
-                            current->to_string().c_str(), diam_light);
-        }
-        if (abs(diam_light - cfg_cluster_valid_size_) <=
-            cfg_cluster_allowed_variance_) {
-          if (debug_)
-            logger->log_debug(name(), "Valid light!");
-
-          if (cfg_publish_laser_vis_) {
-            laser_vis_->set_distances(scanrange_to_angle(last_peak->angle),
-                                      last_peak->distance);
-            laser_vis_->set_distances(scanrange_to_angle(current->angle),
-                                      current->distance);
-            laser_vis_->set_distances(scanrange_to_angle(light_angle),
-                                      light_distance);
-          }
-          lights_.push_back(PolarPos(light_angle, light_distance));
-        }
-      }
-      // Peak can be the beginning of a new light
-      last_peak = current;
-    }
-
-    // yeah, it's ugly.
-    ++beforebefore;
-    ++before;
-    ++current;
-    ++following;
-    ++followingfollowing;
-  }
-  if (debug_) {
-    logger->log_debug(name(), "======  SCAN ENDED ========== ");
-  }
+double
+LaserClusterDetector::calculate_cluster_size(const PolarPos &last_peak, const PolarPos &current)
+{
+	// check if angle between current_angle and angle_last_peak
+	// given the measured distances could be an signal light
+	// with c= sqrt(a**2 + b**2 - 2 ab cos(gamma)) law of cosines
+	// c then must be a feasible diameter of the light at the measured height
+	double angle = fawkes::deg2rad(abs(current.angle - last_peak.angle));
+	return sqrt(last_peak.distance * last_peak.distance + current.distance * current.distance
+	            - 2 * last_peak.distance * current.distance * cos(angle));
 }
 
-void LaserClusterDetector::read_laser() {
-
-  // reading at [0] is in driving direction
-  // laser is reading counterclockwise
-  laser_if_->read();
-  filtered_scan_.clear();
-
-  float laser_min = cfg_laser_max_;
-  int laser_min_index = -1;
-
-  for (size_t i = 0; i < num_scans_; i++) {
-    // filter and transform to correct orientation
-    float distance = laser_if_->distances(i);
-
-    if (!(isfinite(distance)               // valid number?
-          && distance > cfg_laser_min_     // big enough?
-          && distance < cfg_laser_max_)) { // small enough?
-      distance = -1;
-    }
-
-    if (distance != -1 && distance < laser_min) {
-      laser_min = distance;
-      laser_min_index = i;
-    }
-
-    // rotate angles so that scan starts at right scan range limit
-    // Only for calculation, needs to be undone before publishing!!!
-    int angle = angle_to_scanrange(i);
-    filtered_scan_.push_back(PolarPos(angle, distance));
-
-    // skip all the readings that are not to be considered:
-    if (i == cfg_laser_scanrange_ / 2)
-      i = (360 - cfg_laser_scanrange_ / 2) - 1;
-  }
-  if (laser_min_index != -1) {
-
-    PolarPos nearest_laser_polar(laser_min_index, laser_min);
-    Point3d nearest_laser_cart = apply_tf(nearest_laser_polar.toPoint3d());
-    if (debug_) {
-      pos3d_nearest_laser_if_->set_translation(0, nearest_laser_cart.getX());
-      pos3d_nearest_laser_if_->set_translation(1, nearest_laser_cart.getY());
-      pos3d_nearest_laser_if_->set_frame("/base_link");
-      pos3d_nearest_laser_if_->write();
-    }
-  }
-
-  filtered_scan_.sort(compare_polar_pos);
+void
+LaserClusterDetector::calc_average_of_distances(list<PolarPos>::iterator last_peak,
+                                                list<PolarPos>::iterator current,
+                                                float *                  average_distance,
+                                                float *                  variance)
+{
+	float sum           = 0;
+	float sum_diffs     = 0;
+	float last_distance = last_peak->distance;
+	int   num           = 0;
+	for (list<PolarPos>::iterator it = last_peak; it != current; ++it) {
+		sum += it->distance;
+		num++;
+		sum_diffs += abs(it->distance - last_distance);
+	}
+	*average_distance = sum / num;
+	*variance         = sum_diffs / num;
 }
 
-LaserClusterDetector::Point3d LaserClusterDetector::apply_tf(Point3d src) {
+void
+LaserClusterDetector::find_lights()
+{
+	lights_.clear();
 
-  const char *target_frame = "/base_link";
-  const char *source_frame = "/base_laser";
+	list<PolarPos>::iterator last_peak = filtered_scan_.begin();
+	if (filtered_scan_.size() < 5) {
+		logger->log_error(name(), "not enough laser scan points!!");
+		return;
+	}
 
-  tf::Stamped<tf::Point> targetPoint;
-  targetPoint.frame_id = target_frame;
+	// Incredibly ugly, but i need a list, and i need to know predec and succ..
+	laserscan::iterator beforebefore = filtered_scan_.begin();
+	laserscan::iterator before       = filtered_scan_.begin();
+	before++;
 
-  bool link_frame_exists = tf_listener->frame_exists(target_frame);
-  bool laser_frame_exists = tf_listener->frame_exists(source_frame);
+	laserscan::iterator current = filtered_scan_.begin();
+	std::advance(current, 2);
 
-  if (!link_frame_exists || !laser_frame_exists) {
-    logger->log_warn(name(), "Frame missing: %s %s   %s %s", source_frame,
-                     link_frame_exists ? "exists" : "missing", target_frame,
-                     laser_frame_exists ? "exists" : "missing");
-  } else {
-    src.frame_id = source_frame;
-    try {
-      tf_listener->transform_point(target_frame, src, targetPoint);
-    } catch (tf::ExtrapolationException &e) {
-      logger->log_debug(name(), "Extrapolation error");
-      return src;
-    } catch (tf::ConnectivityException &e) {
-      logger->log_debug(name(), "Connectivity exception: %s", e.what());
-      return src;
-    }
+	laserscan::iterator following = filtered_scan_.begin();
+	std::advance(following, 3);
+	laserscan::iterator followingfollowing = filtered_scan_.begin();
+	std::advance(followingfollowing, 4);
+	if (debug_) {
+		logger->log_debug(name(), "======  Scanning ========== ");
+	}
+	while (followingfollowing != filtered_scan_.end()) {
+		float average_distance;
+		float variance;
+		calc_average_of_distances(last_peak, current, &average_distance, &variance);
 
-    return targetPoint;
-  }
-  return src;
+		// we can either have a peak (the begin or end of a cluster) iff
+		// - the difference between the current reading and the average so far is
+		// greater than threshold
+		// - we read two invalid readings before or after the current reading
+		if (current->distance != -1 && current->distance <= cfg_cluster_max_distance_
+		    && (abs(average_distance - current->distance) > cfg_dist_threshold_
+		        || (before->distance == -1 && beforebefore->distance == -1)
+		        || (following->distance == -1 && followingfollowing->distance == -1)
+
+		          )) {
+			// we have a sufficient peak, can either be the begin or the end
+
+			if (debug_)
+				logger->log_debug(name(), "peak at %d", current->angle);
+
+			// check if we have a valid last_peak.
+			// if not, go on
+			if (last_peak->distance != -1.0) {
+				int   angle       = abs(current->angle - last_peak->angle);
+				int   light_angle = current->angle - (angle / 2.0);
+				float light_distance;
+
+				float diam_light = calculate_cluster_size(*last_peak, *current);
+				if (debug_)
+					logger->log_debug(name(), "cluster size would be: %f", diam_light);
+
+				// determine max and min of the cluster
+				int   min_angle = 0;
+				float max_dist  = 0;
+				float min_dist  = cfg_laser_max_;
+				for (list<PolarPos>::iterator it = last_peak; it != following; ++it) {
+					if (it->distance < min_dist) {
+						min_dist  = it->distance;
+						min_angle = it->angle;
+					}
+					if (it->distance > max_dist) {
+						max_dist = it->distance;
+					}
+				}
+
+				if (max_dist > min_dist) {
+					if (max_dist - min_dist <= cfg_cluster_coherence_) {
+						// Cluster is regular everything good
+						if (debug_)
+							logger->log_debug(name(), "regular cluster");
+						light_distance = (last_peak->distance + current->distance) / 2.0;
+					} else {
+						// cluster is too widespread, assume reflection from signal light
+						// and
+						// chose minimal values as correct readings
+
+						light_distance = min_dist + cfg_cluster_distance_delta_;
+						light_angle    = min_angle;
+						PolarPos lastpeak_corrected(last_peak->angle, min_dist);
+						PolarPos current_corrected(current->angle, min_dist);
+						diam_light = calculate_cluster_size(lastpeak_corrected, current_corrected);
+						if (debug_)
+							logger->log_debug(name(), "irregular cluster, new size: %f", diam_light);
+					}
+				}
+
+				if (debug_) {
+					logger->log_debug(name(),
+					                  "last peak: %s current peak: %s; cluster size: %f",
+					                  last_peak->to_string().c_str(),
+					                  current->to_string().c_str(),
+					                  diam_light);
+				}
+				if (abs(diam_light - cfg_cluster_valid_size_) <= cfg_cluster_allowed_variance_) {
+					if (debug_)
+						logger->log_debug(name(), "Valid light!");
+
+					if (cfg_publish_laser_vis_) {
+						laser_vis_->set_distances(scanrange_to_angle(last_peak->angle), last_peak->distance);
+						laser_vis_->set_distances(scanrange_to_angle(current->angle), current->distance);
+						laser_vis_->set_distances(scanrange_to_angle(light_angle), light_distance);
+					}
+					lights_.push_back(PolarPos(light_angle, light_distance));
+				}
+			}
+			// Peak can be the beginning of a new light
+			last_peak = current;
+		}
+
+		// yeah, it's ugly.
+		++beforebefore;
+		++before;
+		++current;
+		++following;
+		++followingfollowing;
+	}
+	if (debug_) {
+		logger->log_debug(name(), "======  SCAN ENDED ========== ");
+	}
+}
+
+void
+LaserClusterDetector::read_laser()
+{
+	// reading at [0] is in driving direction
+	// laser is reading counterclockwise
+	laser_if_->read();
+	filtered_scan_.clear();
+
+	float laser_min       = cfg_laser_max_;
+	int   laser_min_index = -1;
+
+	for (size_t i = 0; i < num_scans_; i++) {
+		// filter and transform to correct orientation
+		float distance = laser_if_->distances(i);
+
+		if (!(isfinite(distance)               // valid number?
+		      && distance > cfg_laser_min_     // big enough?
+		      && distance < cfg_laser_max_)) { // small enough?
+			distance = -1;
+		}
+
+		if (distance != -1 && distance < laser_min) {
+			laser_min       = distance;
+			laser_min_index = i;
+		}
+
+		// rotate angles so that scan starts at right scan range limit
+		// Only for calculation, needs to be undone before publishing!!!
+		int angle = angle_to_scanrange(i);
+		filtered_scan_.push_back(PolarPos(angle, distance));
+
+		// skip all the readings that are not to be considered:
+		if (i == cfg_laser_scanrange_ / 2)
+			i = (360 - cfg_laser_scanrange_ / 2) - 1;
+	}
+	if (laser_min_index != -1) {
+		PolarPos nearest_laser_polar(laser_min_index, laser_min);
+		Point3d  nearest_laser_cart = apply_tf(nearest_laser_polar.toPoint3d());
+		if (debug_) {
+			pos3d_nearest_laser_if_->set_translation(0, nearest_laser_cart.getX());
+			pos3d_nearest_laser_if_->set_translation(1, nearest_laser_cart.getY());
+			pos3d_nearest_laser_if_->set_frame("/base_link");
+			pos3d_nearest_laser_if_->write();
+		}
+	}
+
+	filtered_scan_.sort(compare_polar_pos);
+}
+
+LaserClusterDetector::Point3d
+LaserClusterDetector::apply_tf(Point3d src)
+{
+	const char *target_frame = "/base_link";
+	const char *source_frame = "/base_laser";
+
+	tf::Stamped<tf::Point> targetPoint;
+	targetPoint.frame_id = target_frame;
+
+	bool link_frame_exists  = tf_listener->frame_exists(target_frame);
+	bool laser_frame_exists = tf_listener->frame_exists(source_frame);
+
+	if (!link_frame_exists || !laser_frame_exists) {
+		logger->log_warn(name(),
+		                 "Frame missing: %s %s   %s %s",
+		                 source_frame,
+		                 link_frame_exists ? "exists" : "missing",
+		                 target_frame,
+		                 laser_frame_exists ? "exists" : "missing");
+	} else {
+		src.frame_id = source_frame;
+		try {
+			tf_listener->transform_point(target_frame, src, targetPoint);
+		} catch (tf::ExtrapolationException &e) {
+			logger->log_debug(name(), "Extrapolation error");
+			return src;
+		} catch (tf::ConnectivityException &e) {
+			logger->log_debug(name(), "Connectivity exception: %s", e.what());
+			return src;
+		}
+
+		return targetPoint;
+	}
+	return src;
 }
 
 // for analyzing laserdata manually
-void LaserClusterDetector::write_laser_to_file() {
-  fawkes::File file("laserdata.csv", fawkes::File::ADD_SUFFIX);
-  for (laserscan::iterator it = filtered_scan_.begin();
-       it != filtered_scan_.end(); ++it) {
-    fprintf(file.stream(), "%s\n ", it->to_string().c_str());
-  }
+void
+LaserClusterDetector::write_laser_to_file()
+{
+	fawkes::File file("laserdata.csv", fawkes::File::ADD_SUFFIX);
+	for (laserscan::iterator it = filtered_scan_.begin(); it != filtered_scan_.end(); ++it) {
+		fprintf(file.stream(), "%s\n ", it->to_string().c_str());
+	}
 }
 
-void LaserClusterDetector::publish_nearest_light() {
-  Point3d light;
-  if (lights_.size() > 0) {
-    PolarPos &nearest_light = lights_.front();
-    float min_distance = nearest_light.distance;
-    for (std::list<PolarPos>::iterator it = lights_.begin();
-         it != lights_.end(); ++it) {
-      if (it->distance < min_distance) {
-        nearest_light = *it;
-        min_distance = nearest_light.distance;
-      }
-    }
-    PolarPos nearest_light_transformed(scanrange_to_angle(nearest_light.angle),
-                                       nearest_light.distance);
+void
+LaserClusterDetector::publish_nearest_light()
+{
+	Point3d light;
+	if (lights_.size() > 0) {
+		PolarPos &nearest_light = lights_.front();
+		float     min_distance  = nearest_light.distance;
+		for (std::list<PolarPos>::iterator it = lights_.begin(); it != lights_.end(); ++it) {
+			if (it->distance < min_distance) {
+				nearest_light = *it;
+				min_distance  = nearest_light.distance;
+			}
+		}
+		PolarPos nearest_light_transformed(scanrange_to_angle(nearest_light.angle),
+		                                   nearest_light.distance);
 
-    light = apply_tf(nearest_light_transformed.toPoint3d());
+		light = apply_tf(nearest_light_transformed.toPoint3d());
 
-    if (debug_)
-      logger->log_debug(name(), "found cluster at (%f, %f)", light.getX(),
-                        light.getY());
-    pos3d_nearest_cluster_if_->set_translation(0, light.getX());
-    pos3d_nearest_cluster_if_->set_translation(1, light.getY());
-    pos3d_nearest_cluster_if_->set_frame("/base_link");
-  }
-  if (lights_.size() == 0) {
-    // if we have no light, we set visibility history to at least -1
-    pos3d_nearest_cluster_if_->set_visibility_history(
-        min(pos3d_nearest_cluster_if_->visibility_history() - 1, -1));
+		if (debug_)
+			logger->log_debug(name(), "found cluster at (%f, %f)", light.getX(), light.getY());
+		pos3d_nearest_cluster_if_->set_translation(0, light.getX());
+		pos3d_nearest_cluster_if_->set_translation(1, light.getY());
+		pos3d_nearest_cluster_if_->set_frame("/base_link");
+	}
+	if (lights_.size() == 0) {
+		// if we have no light, we set visibility history to at least -1
+		pos3d_nearest_cluster_if_->set_visibility_history(
+		  min(pos3d_nearest_cluster_if_->visibility_history() - 1, -1));
 
-  } else if (pos3d_nearest_cluster_if_->visibility_history() <= 0) {
-    // we see a light for the first time (or again but not the last time)
-    pos3d_nearest_cluster_if_->set_visibility_history(1);
-    last_light_ = light;
-  } else {
-    float distance = fawkes::distance(light.getX(), light.getY(),
-                                      last_light_.getX(), last_light_.getY());
-    if (debug_) {
-      logger->log_debug(name(), "Distance to last cluster: %f", distance);
-    }
-    if (distance < cfg_cluster_allowed_variance_over_time_) {
-      // distance small enough to count up
-      pos3d_nearest_cluster_if_->set_visibility_history(
-          (pos3d_nearest_cluster_if_->visibility_history() + 1));
-      last_light_ = light;
-    } else {
-      // distance to large -> new light
-      pos3d_nearest_cluster_if_->set_visibility_history(1);
-      last_light_ = light;
-    }
-  }
-  pos3d_nearest_cluster_if_->write();
+	} else if (pos3d_nearest_cluster_if_->visibility_history() <= 0) {
+		// we see a light for the first time (or again but not the last time)
+		pos3d_nearest_cluster_if_->set_visibility_history(1);
+		last_light_ = light;
+	} else {
+		float distance =
+		  fawkes::distance(light.getX(), light.getY(), last_light_.getX(), last_light_.getY());
+		if (debug_) {
+			logger->log_debug(name(), "Distance to last cluster: %f", distance);
+		}
+		if (distance < cfg_cluster_allowed_variance_over_time_) {
+			// distance small enough to count up
+			pos3d_nearest_cluster_if_->set_visibility_history(
+			  (pos3d_nearest_cluster_if_->visibility_history() + 1));
+			last_light_ = light;
+		} else {
+			// distance to large -> new light
+			pos3d_nearest_cluster_if_->set_visibility_history(1);
+			last_light_ = light;
+		}
+	}
+	pos3d_nearest_cluster_if_->write();
 }
 
-void LaserClusterDetector::loop() {
-  debug_ =
-      cfg_debug_ && ((loopcnt++ % 10) == 0); // show debug only every nth loop
-  read_laser();
-  float *f = (float *)calloc(laser_vis_->maxlenof_distances(), sizeof(float));
-  laser_vis_->set_distances(f);
-  free(f);
-  // for(laserscan::iterator it = filtered_scan_.begin(); it !=
-  // filtered_scan_.end();++it){
-  //	laser_vis_->set_distances(scanrange_to_angle(it->angle),abs(it->distance));
-  //}
+void
+LaserClusterDetector::loop()
+{
+	debug_ = cfg_debug_ && ((loopcnt++ % 10) == 0); // show debug only every nth loop
+	read_laser();
+	float *f = (float *)calloc(laser_vis_->maxlenof_distances(), sizeof(float));
+	laser_vis_->set_distances(f);
+	free(f);
+	// for(laserscan::iterator it = filtered_scan_.begin(); it !=
+	// filtered_scan_.end();++it){
+	//	laser_vis_->set_distances(scanrange_to_angle(it->angle),abs(it->distance));
+	//}
 
-  // if (debug_)
-  //	write_laser_to_file();
-  find_lights();
-  publish_nearest_light();
-  laser_vis_->write();
+	// if (debug_)
+	//	write_laser_to_file();
+	find_lights();
+	publish_nearest_light();
+	laser_vis_->write();
 }

--- a/src/plugins/attic/clusterdetection/laser_cluster_detector_thread.h
+++ b/src/plugins/attic/clusterdetection/laser_cluster_detector_thread.h
@@ -29,12 +29,12 @@
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <aspect/tf.h>
-#include <cmath>
 #include <core/threading/thread.h>
-#include <list>
-#include <sstream>
 #include <tf/types.h>
 
+#include <cmath>
+#include <list>
+#include <sstream>
 #include <string>
 
 namespace fawkes {
@@ -48,104 +48,120 @@ class LaserClusterDetector : public fawkes::Thread,
                              public fawkes::ConfigurableAspect,
                              public fawkes::BlackBoardAspect,
                              public fawkes::ClockAspect,
-                             public fawkes::TransformAspect {
-
+                             public fawkes::TransformAspect
+{
 public:
-  LaserClusterDetector();
+	LaserClusterDetector();
 
-  virtual void init();
-  virtual void loop();
-  virtual bool prepare_finalize_user();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual bool prepare_finalize_user();
+	virtual void finalize();
 
-  typedef fawkes::tf::Stamped<fawkes::tf::Point> Point3d;
+	typedef fawkes::tf::Stamped<fawkes::tf::Point> Point3d;
 
-  struct PolarPos {
-    int angle;
-    float distance;
+	struct PolarPos
+	{
+		int   angle;
+		float distance;
 
-    PolarPos(int angle, float distance) : angle(angle), distance(distance) {}
+		PolarPos(int angle, float distance) : angle(angle), distance(distance)
+		{
+		}
 
-    PolarPos() {
-      angle = 0;
-      distance = 0;
-    }
+		PolarPos()
+		{
+			angle    = 0;
+			distance = 0;
+		}
 
-    void toCart(float *x, float *y) {
-      *x = distance * cos(angle * M_PI / 180.0);
-      *y = distance * sin(angle * M_PI / 180.0);
-    }
+		void
+		toCart(float *x, float *y)
+		{
+			*x = distance * cos(angle * M_PI / 180.0);
+			*y = distance * sin(angle * M_PI / 180.0);
+		}
 
-    void fromCart(float x, float y) {
-      angle = atan2f(y, x) * 180 / M_PI;
-      distance = sqrtf(x * x + y * y);
-    }
+		void
+		fromCart(float x, float y)
+		{
+			angle    = atan2f(y, x) * 180 / M_PI;
+			distance = sqrtf(x * x + y * y);
+		}
 
-    LaserClusterDetector::Point3d toPoint3d() {
-      Point3d p3d;
-      float x = distance * cos(angle * M_PI / 180.0);
-      float y = distance * sin(angle * M_PI / 180.0);
-      p3d.setX(x);
-      p3d.setY(y);
-      return p3d;
-    }
+		LaserClusterDetector::Point3d
+		toPoint3d()
+		{
+			Point3d p3d;
+			float   x = distance * cos(angle * M_PI / 180.0);
+			float   y = distance * sin(angle * M_PI / 180.0);
+			p3d.setX(x);
+			p3d.setY(y);
+			return p3d;
+		}
 
-    std::string to_string() {
-      std::stringstream str;
-      str << "(angle: " << angle << ", distance: " << distance << ")";
-      return str.str();
-    }
-  };
+		std::string
+		to_string()
+		{
+			std::stringstream str;
+			str << "(angle: " << angle << ", distance: " << distance << ")";
+			return str.str();
+		}
+	};
 
-  typedef std::list<PolarPos> laserscan;
+	typedef std::list<PolarPos> laserscan;
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  void find_lights();
-  void read_laser();
-  void write_laser_to_file();
-  void publish_nearest_light();
-  Point3d apply_tf(Point3d src);
-  int angle_to_scanrange(int angle);
-  int scanrange_to_angle(int scanrange);
-  double calculate_cluster_size(const PolarPos &last_peak,
-                                const PolarPos &current);
-  void calc_average_of_distances(std::list<PolarPos>::iterator last_peak,
-                                 std::list<PolarPos>::iterator current,
-                                 float *average_distance, float *variance);
+	void    find_lights();
+	void    read_laser();
+	void    write_laser_to_file();
+	void    publish_nearest_light();
+	Point3d apply_tf(Point3d src);
+	int     angle_to_scanrange(int angle);
+	int     scanrange_to_angle(int scanrange);
+	double  calculate_cluster_size(const PolarPos &last_peak, const PolarPos &current);
+	void    calc_average_of_distances(std::list<PolarPos>::iterator last_peak,
+	                                  std::list<PolarPos>::iterator current,
+	                                  float *                       average_distance,
+	                                  float *                       variance);
 
-  // TODO
+	// TODO
 
 private:
-  fawkes::Laser360Interface *laser_if_;
-  fawkes::Laser360Interface *laser_vis_;
-  fawkes::Position3DInterface *pos3d_nearest_cluster_if_;
-  fawkes::Position3DInterface *pos3d_nearest_reading_if_;
+	fawkes::Laser360Interface *  laser_if_;
+	fawkes::Laser360Interface *  laser_vis_;
+	fawkes::Position3DInterface *pos3d_nearest_cluster_if_;
+	fawkes::Position3DInterface *pos3d_nearest_reading_if_;
 
-  std::list<PolarPos> lights_;
-  unsigned int num_scans_;
-  laserscan filtered_scan_;
-  Point3d last_light_;
-  float cfg_laser_min_;
-  float cfg_laser_max_;
-  unsigned int cfg_laser_scanrange_;
-  float cfg_cluster_valid_size_;
-  float cfg_cluster_allowed_variance_;
-  float cfg_cluster_allowed_variance_over_time_;
-  float cfg_dist_threshold_;
-  float cfg_cluster_coherence_;
-  bool cfg_publish_laser_vis_;
-  float cfg_cluster_max_distance_;
-  float cfg_cluster_distance_delta_;
+	std::list<PolarPos> lights_;
+	unsigned int        num_scans_;
+	laserscan           filtered_scan_;
+	Point3d             last_light_;
+	float               cfg_laser_min_;
+	float               cfg_laser_max_;
+	unsigned int        cfg_laser_scanrange_;
+	float               cfg_cluster_valid_size_;
+	float               cfg_cluster_allowed_variance_;
+	float               cfg_cluster_allowed_variance_over_time_;
+	float               cfg_dist_threshold_;
+	float               cfg_cluster_coherence_;
+	bool                cfg_publish_laser_vis_;
+	float               cfg_cluster_max_distance_;
+	float               cfg_cluster_distance_delta_;
 
-  int loopcnt;
-  bool cfg_debug_;
-  bool debug_;
+	int  loopcnt;
+	bool cfg_debug_;
+	bool debug_;
 
-  fawkes::Position3DInterface *pos3d_nearest_laser_if_;
+	fawkes::Position3DInterface *pos3d_nearest_laser_if_;
 };
 
 #endif

--- a/src/plugins/attic/conveyor_vision/conveyor_vision_plugin.cpp
+++ b/src/plugins/attic/conveyor_vision/conveyor_vision_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "conveyor_vision_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /**
  * @author Nicolas Limpert & Randolph Maaßen
  */
-class ConveyorVision : public fawkes::Plugin {
+class ConveyorVision : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  ConveyorVision(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new ConveyorVisionThread());
-  }
+	ConveyorVision(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new ConveyorVisionThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Conveyor Vision plugin")

--- a/src/plugins/attic/conveyor_vision/conveyor_vision_thread.cpp
+++ b/src/plugins/attic/conveyor_vision/conveyor_vision_thread.cpp
@@ -40,161 +40,166 @@ using namespace cv;
 
 /** Constructor. */
 ConveyorVisionThread::ConveyorVisionThread()
-    : Thread("ConveyorVisionThread", Thread::OPMODE_WAITFORWAKEUP),
-      VisionAspect(VisionAspect::CYCLIC),
-      ConfigurationChangeHandler(CFG_PREFIX),
-      fawkes::TransformAspect(fawkes::TransformAspect::ONLY_PUBLISHER,
-                              "conveyor") {
-  fv_cam = NULL;
-  shm_buffer = NULL;
-  image_buffer = NULL;
-  ipl = NULL;
-  use_hough_lines_ = false;
-  //    this->markers_ = NULL;
+: Thread("ConveyorVisionThread", Thread::OPMODE_WAITFORWAKEUP),
+  VisionAspect(VisionAspect::CYCLIC),
+  ConfigurationChangeHandler(CFG_PREFIX),
+  fawkes::TransformAspect(fawkes::TransformAspect::ONLY_PUBLISHER, "conveyor")
+{
+	fv_cam           = NULL;
+	shm_buffer       = NULL;
+	image_buffer     = NULL;
+	ipl              = NULL;
+	use_hough_lines_ = false;
+	//    this->markers_ = NULL;
 }
 
-void ConveyorVisionThread::init() {
-  std::string prefix = CFG_PREFIX;
-  std::string mps_cascade_name =
-      (string)config->get_string((prefix + "classifier_file"));
-  if (!mps_cascade.load(std::string(CONFDIR) + "/" + mps_cascade_name)) {
-    printf("--(!)Error loading\n");
-    return;
-  };
+void
+ConveyorVisionThread::init()
+{
+	std::string prefix           = CFG_PREFIX;
+	std::string mps_cascade_name = (string)config->get_string((prefix + "classifier_file"));
+	if (!mps_cascade.load(std::string(CONFDIR) + "/" + mps_cascade_name)) {
+		printf("--(!)Error loading\n");
+		return;
+	};
 
-  //   fawkes::Position3DInterface* puck_if_ = NULL;
-  try {
-    mps_conveyor_if_ =
-        blackboard->open_for_writing<fawkes::Position3DInterface>(
-            "mps_conveyor");
-    //            puck_if_->set_frame(camera_info_.frame.c_str());
-    mps_conveyor_if_->write();
-    //            puck_interfaces_.push_back(puck_if_);
-  } catch (std::exception &e) {
-    finalize();
-    throw;
-  }
+	//   fawkes::Position3DInterface* puck_if_ = NULL;
+	try {
+		mps_conveyor_if_ = blackboard->open_for_writing<fawkes::Position3DInterface>("mps_conveyor");
+		//            puck_if_->set_frame(camera_info_.frame.c_str());
+		mps_conveyor_if_->write();
+		//            puck_interfaces_.push_back(puck_if_);
+	} catch (std::exception &e) {
+		finalize();
+		throw;
+	}
 
-  config->add_change_handler(this);
-  // load config
-  // config prefix in string for concatinating
-  //    std::string prefix = CFG_PREFIX;
-  // log, that we open load the config
-  logger->log_info(name(), "loading config");
-  load_config();
-  // load alvar camera calibration
-  //    if(!alvar_cam.SetCalib(config->get_string((prefix +
-  //    "classifier_file").c_str()).c_str(),0,0,FILE_FORMAT_DEFAULT))
-  //    {
-  //      this->logger->log_warn(this->name(),"Faild to load calibration file");
-  //    }
-  //    // load marker size and apply it
-  //    marker_size = config->get_uint((prefix + "marker_size").c_str());
-  //    detector.SetMarkerSize(marker_size);
+	config->add_change_handler(this);
+	// load config
+	// config prefix in string for concatinating
+	//    std::string prefix = CFG_PREFIX;
+	// log, that we open load the config
+	logger->log_info(name(), "loading config");
+	load_config();
+	// load alvar camera calibration
+	//    if(!alvar_cam.SetCalib(config->get_string((prefix +
+	//    "classifier_file").c_str()).c_str(),0,0,FILE_FORMAT_DEFAULT))
+	//    {
+	//      this->logger->log_warn(this->name(),"Faild to load calibration file");
+	//    }
+	//    // load marker size and apply it
+	//    marker_size = config->get_uint((prefix + "marker_size").c_str());
+	//    detector.SetMarkerSize(marker_size);
 
-  // Image Buffer ID
+	// Image Buffer ID
 
-  // init firevision camera
-  // CAM swapping not working (??)
-  if (fv_cam != NULL) {
-    // free the camera
-    fv_cam->stop();
-    fv_cam->flush();
-    fv_cam->dispose_buffer();
-    fv_cam->close();
-    delete fv_cam;
-    fv_cam = NULL;
-  }
-  if (fv_cam == NULL) {
-    std::string connection =
-        this->config->get_string((prefix + "camera").c_str());
-    fv_cam = vision_master->register_for_camera(connection.c_str(), this);
-    fv_cam->start();
-    fv_cam->open();
-    this->img_width = fv_cam->pixel_width();
-    this->img_height = fv_cam->pixel_height();
-  }
+	// init firevision camera
+	// CAM swapping not working (??)
+	if (fv_cam != NULL) {
+		// free the camera
+		fv_cam->stop();
+		fv_cam->flush();
+		fv_cam->dispose_buffer();
+		fv_cam->close();
+		delete fv_cam;
+		fv_cam = NULL;
+	}
+	if (fv_cam == NULL) {
+		std::string connection = this->config->get_string((prefix + "camera").c_str());
+		fv_cam                 = vision_master->register_for_camera(connection.c_str(), this);
+		fv_cam->start();
+		fv_cam->open();
+		this->img_width  = fv_cam->pixel_width();
+		this->img_height = fv_cam->pixel_height();
+	}
 
-  // set camera resolution
-  //    alvar_cam.SetRes(this->img_width, this->img_height);
+	// set camera resolution
+	//    alvar_cam.SetRes(this->img_width, this->img_height);
 
-  // SHM image buffer
-  if (shm_buffer != NULL) {
-    delete shm_buffer;
-    shm_buffer = NULL;
-    image_buffer = NULL;
-  }
+	// SHM image buffer
+	if (shm_buffer != NULL) {
+		delete shm_buffer;
+		shm_buffer   = NULL;
+		image_buffer = NULL;
+	}
 
-  shm_buffer = new firevision::SharedMemoryImageBuffer(
-      shm_id.c_str(), firevision::YUV422_PLANAR, this->img_width,
-      this->img_height);
-  if (!shm_buffer->is_valid()) {
-    delete shm_buffer;
-    delete fv_cam;
-    shm_buffer = NULL;
-    fv_cam = NULL;
-    throw fawkes::Exception("Shared memory segment not valid");
-  }
-  std::string frame = this->config->get_string((prefix + "frame").c_str());
-  shm_buffer->set_frame_id(frame.c_str());
+	shm_buffer = new firevision::SharedMemoryImageBuffer(shm_id.c_str(),
+	                                                     firevision::YUV422_PLANAR,
+	                                                     this->img_width,
+	                                                     this->img_height);
+	if (!shm_buffer->is_valid()) {
+		delete shm_buffer;
+		delete fv_cam;
+		shm_buffer = NULL;
+		fv_cam     = NULL;
+		throw fawkes::Exception("Shared memory segment not valid");
+	}
+	std::string frame = this->config->get_string((prefix + "frame").c_str());
+	shm_buffer->set_frame_id(frame.c_str());
 
-  image_buffer = shm_buffer->buffer();
-  ipl = cvCreateImage(cvSize(this->img_width, this->img_height), IPL_DEPTH_8U,
-                      IMAGE_CHANNELS);
+	image_buffer = shm_buffer->buffer();
+	ipl = cvCreateImage(cvSize(this->img_width, this->img_height), IPL_DEPTH_8U, IMAGE_CHANNELS);
 
-  // set up marker
-  world_pos_z_average = 0.;
-  max_marker = 16;
-  //    this->markers_ = new std::vector<alvar::MarkerData>();
-  //    this->tag_interfaces = new
-  //    TagPositionList(this->blackboard,this->max_marker,frame,this->name(),this->logger,
-  //    this->clock, this->tf_publisher);
+	// set up marker
+	world_pos_z_average = 0.;
+	max_marker          = 16;
+	//    this->markers_ = new std::vector<alvar::MarkerData>();
+	//    this->tag_interfaces = new
+	//    TagPositionList(this->blackboard,this->max_marker,frame,this->name(),this->logger,
+	//    this->clock, this->tf_publisher);
 }
 
-void ConveyorVisionThread::finalize() {
-  vision_master->unregister_thread(this);
-  config->rem_change_handler(this);
-  // free the markers
-  //  this->markers_->clear();
-  //  delete this->markers_;
-  delete fv_cam;
-  fv_cam = NULL;
-  delete shm_buffer;
-  shm_buffer = NULL;
-  image_buffer = NULL;
-  //  cvReleaseImage(&ipl);
-  ipl = NULL;
-  //  delete this->tag_interfaces;
+void
+ConveyorVisionThread::finalize()
+{
+	vision_master->unregister_thread(this);
+	config->rem_change_handler(this);
+	// free the markers
+	//  this->markers_->clear();
+	//  delete this->markers_;
+	delete fv_cam;
+	fv_cam = NULL;
+	delete shm_buffer;
+	shm_buffer   = NULL;
+	image_buffer = NULL;
+	//  cvReleaseImage(&ipl);
+	ipl = NULL;
+	//  delete this->tag_interfaces;
 }
 
-void ConveyorVisionThread::loop() {
-  if (!cfg_mutex.try_lock()) {
-    // logger->log_info(name(),"Skipping loop");
-    return;
-  }
-  if (fv_cam == NULL || !fv_cam->ready()) {
-    logger->log_info(name(), "Camera not ready");
-    init();
-    return;
-  }
-  // logger->log_info(name(),"entering loop");
-  // get img form fv
-  fv_cam->capture();
-  firevision::convert(fv_cam->colorspace(), firevision::YUV422_PLANAR,
-                      fv_cam->buffer(), image_buffer, this->img_width,
-                      this->img_height);
-  fv_cam->dispose_buffer();
-  // convert img
-  firevision::IplImageAdapter::convert_image_bgr(image_buffer, ipl);
-  frame = cvarrToMat(ipl);
-  detect();
-  mps_conveyor_if_->write();
-  // get marker from img
-  //    get_marker();
+void
+ConveyorVisionThread::loop()
+{
+	if (!cfg_mutex.try_lock()) {
+		// logger->log_info(name(),"Skipping loop");
+		return;
+	}
+	if (fv_cam == NULL || !fv_cam->ready()) {
+		logger->log_info(name(), "Camera not ready");
+		init();
+		return;
+	}
+	// logger->log_info(name(),"entering loop");
+	// get img form fv
+	fv_cam->capture();
+	firevision::convert(fv_cam->colorspace(),
+	                    firevision::YUV422_PLANAR,
+	                    fv_cam->buffer(),
+	                    image_buffer,
+	                    this->img_width,
+	                    this->img_height);
+	fv_cam->dispose_buffer();
+	// convert img
+	firevision::IplImageAdapter::convert_image_bgr(image_buffer, ipl);
+	frame = cvarrToMat(ipl);
+	detect();
+	mps_conveyor_if_->write();
+	// get marker from img
+	//    get_marker();
 
-  //    this->tag_interfaces->update_blackboard(this->markers_);
+	//    this->tag_interfaces->update_blackboard(this->markers_);
 
-  cfg_mutex.unlock();
+	cfg_mutex.unlock();
 }
 
 // void
@@ -223,371 +228,363 @@ void ConveyorVisionThread::loop() {
 // config handling
 void ConveyorVisionThread::config_value_erased(const char *path){};
 void ConveyorVisionThread::config_tag_changed(const char *new_tag){};
-void ConveyorVisionThread::config_comment_changed(
-    const fawkes::Configuration::ValueIterator *v){};
-void ConveyorVisionThread::config_value_changed(
-    const fawkes::Configuration::ValueIterator *v) {
-  load_config();
+void ConveyorVisionThread::config_comment_changed(const fawkes::Configuration::ValueIterator *v){};
+void
+ConveyorVisionThread::config_value_changed(const fawkes::Configuration::ValueIterator *v)
+{
+	load_config();
 }
 
-void ConveyorVisionThread::load_config() {
-  if (cfg_mutex.try_lock()) {
-    try {
-      std::string prefix = CFG_PREFIX;
-      // log, that we open load the config
-      logger->log_info(name(), "loading config");
-      shm_id = config->get_string((prefix + "shm_image_id").c_str());
-      obj_realworld_distance =
-          config->get_float((prefix + "obj_realworld_distance").c_str());
-      obj_realworld_pixels =
-          config->get_float((prefix + "obj_realworld_pixels").c_str());
-      obj_realworld_width =
-          config->get_float((prefix + "obj_realworld_width").c_str());
-      num_frames_for_average =
-          config->get_int((prefix + "num_frames_for_average").c_str());
-      conveyor_distance_threshold =
-          config->get_float((prefix + "conveyor_distance_threshold").c_str());
-      visualization_enabled =
-          config->get_bool((prefix + "visualization_enabled").c_str());
+void
+ConveyorVisionThread::load_config()
+{
+	if (cfg_mutex.try_lock()) {
+		try {
+			std::string prefix = CFG_PREFIX;
+			// log, that we open load the config
+			logger->log_info(name(), "loading config");
+			shm_id                 = config->get_string((prefix + "shm_image_id").c_str());
+			obj_realworld_distance = config->get_float((prefix + "obj_realworld_distance").c_str());
+			obj_realworld_pixels   = config->get_float((prefix + "obj_realworld_pixels").c_str());
+			obj_realworld_width    = config->get_float((prefix + "obj_realworld_width").c_str());
+			num_frames_for_average = config->get_int((prefix + "num_frames_for_average").c_str());
+			conveyor_distance_threshold =
+			  config->get_float((prefix + "conveyor_distance_threshold").c_str());
+			visualization_enabled = config->get_bool((prefix + "visualization_enabled").c_str());
 
-      use_hough_lines_ = config->get_bool(
-          (prefix + "/houghlines/use_hough_line_optimization").c_str());
-      if (use_hough_lines_) {
-        hough_lines_averaging_count_ = config->get_uint(
-            (prefix + "houghlines/hough_lines_averaging_count").c_str());
+			use_hough_lines_ =
+			  config->get_bool((prefix + "/houghlines/use_hough_line_optimization").c_str());
+			if (use_hough_lines_) {
+				hough_lines_averaging_count_ =
+				  config->get_uint((prefix + "houghlines/hough_lines_averaging_count").c_str());
 
-        binary_threshold_min_ = config->get_int(
-            (prefix + "houghlines/binary_threshold_min").c_str());
-        binary_threshold_max_ = config->get_int(
-            (prefix + "houghlines/binary_threshold_max").c_str());
-        binary_threshold_average_min_ = config->get_int(
-            (prefix + "houghlines/binary_threshold_average_min").c_str());
-        binary_threshold_average_max_ = config->get_int(
-            (prefix + "houghlines/binary_threshold_average_max").c_str());
-        max_binary_value_ =
-            config->get_int((prefix + "houghlines/max_binary_value").c_str());
-        threshold_type_ =
-            config->get_int((prefix + "houghlines/threshold_type").c_str());
-        morph_element_ =
-            config->get_int((prefix + "houghlines/morph_element").c_str());
-        morph_size_ =
-            config->get_int((prefix + "houghlines/morph_size").c_str());
-        morph_operator_ =
-            config->get_int((prefix + "houghlines/morph_operator").c_str());
-        canny_threshold_ =
-            config->get_int((prefix + "houghlines/canny_threshold").c_str());
-        line_mean_ =
-            config->get_uint((prefix + "houghlines/line_mean").c_str());
-        conveyor_realworld_distance = config->get_float(
-            (prefix + "houghlines/conveyor_realworld_distance").c_str());
-        conveyor_realworld_pixels = config->get_float(
-            (prefix + "houghlines/conveyor_realworld_pixels").c_str());
-        conveyor_realworld_width = config->get_float(
-            (prefix + "houghlines/conveyor_realworld_width").c_str());
-      }
-      // load alvar camera calibration
-      //      alvar_cam.SetCalib(config->get_string((prefix +
-      //      "alvar_camera_calib_file").c_str()).c_str(),0,0,FILE_FORMAT_DEFAULT);
-      // load marker size and apply it
-      //      marker_size = config->get_uint((prefix + "marker_size").c_str());
-      //      detector.SetMarkerSize(marker_size);
-    } catch (fawkes::Exception &e) {
-      logger->log_error(name(), e);
-    }
-  }
-  // gets called for every changed entry... so init is called once per change.
-  cfg_mutex.unlock();
+				binary_threshold_min_ =
+				  config->get_int((prefix + "houghlines/binary_threshold_min").c_str());
+				binary_threshold_max_ =
+				  config->get_int((prefix + "houghlines/binary_threshold_max").c_str());
+				binary_threshold_average_min_ =
+				  config->get_int((prefix + "houghlines/binary_threshold_average_min").c_str());
+				binary_threshold_average_max_ =
+				  config->get_int((prefix + "houghlines/binary_threshold_average_max").c_str());
+				max_binary_value_ = config->get_int((prefix + "houghlines/max_binary_value").c_str());
+				threshold_type_   = config->get_int((prefix + "houghlines/threshold_type").c_str());
+				morph_element_    = config->get_int((prefix + "houghlines/morph_element").c_str());
+				morph_size_       = config->get_int((prefix + "houghlines/morph_size").c_str());
+				morph_operator_   = config->get_int((prefix + "houghlines/morph_operator").c_str());
+				canny_threshold_  = config->get_int((prefix + "houghlines/canny_threshold").c_str());
+				line_mean_        = config->get_uint((prefix + "houghlines/line_mean").c_str());
+				conveyor_realworld_distance =
+				  config->get_float((prefix + "houghlines/conveyor_realworld_distance").c_str());
+				conveyor_realworld_pixels =
+				  config->get_float((prefix + "houghlines/conveyor_realworld_pixels").c_str());
+				conveyor_realworld_width =
+				  config->get_float((prefix + "houghlines/conveyor_realworld_width").c_str());
+			}
+			// load alvar camera calibration
+			//      alvar_cam.SetCalib(config->get_string((prefix +
+			//      "alvar_camera_calib_file").c_str()).c_str(),0,0,FILE_FORMAT_DEFAULT);
+			// load marker size and apply it
+			//      marker_size = config->get_uint((prefix + "marker_size").c_str());
+			//      detector.SetMarkerSize(marker_size);
+		} catch (fawkes::Exception &e) {
+			logger->log_error(name(), e);
+		}
+	}
+	// gets called for every changed entry... so init is called once per change.
+	cfg_mutex.unlock();
 }
 
 /** @function detectAndDisplay */
-void ConveyorVisionThread::detect() {
-  std::vector<Rect> faces;
-  Mat frame_gray;
+void
+ConveyorVisionThread::detect()
+{
+	std::vector<Rect> faces;
+	Mat               frame_gray;
 
-  cvtColor(frame, frame_gray, CV_BGR2GRAY);
-  equalizeHist(frame_gray, frame_gray);
+	cvtColor(frame, frame_gray, CV_BGR2GRAY);
+	equalizeHist(frame_gray, frame_gray);
 
-  //-- Detect faces
-  mps_cascade.detectMultiScale(frame_gray, faces, 1.1, 2,
-                               0 | CV_HAAR_SCALE_IMAGE, Size(30, 30));
-  int visibility_history = mps_conveyor_if_->visibility_history();
+	//-- Detect faces
+	mps_cascade.detectMultiScale(frame_gray, faces, 1.1, 2, 0 | CV_HAAR_SCALE_IMAGE, Size(30, 30));
+	int visibility_history = mps_conveyor_if_->visibility_history();
 
-  //  logger->log_info(name(), "got %d faces", faces.size());
-  // ignore images that probably contain more than one conveyor
-  if (faces.size() == 1) {
-    // width of object at one meters distance
+	//  logger->log_info(name(), "got %d faces", faces.size());
+	// ignore images that probably contain more than one conveyor
+	if (faces.size() == 1) {
+		// width of object at one meters distance
 
-    float focal_length =
-        (obj_realworld_pixels * obj_realworld_distance) / obj_realworld_width;
-    float d_dash = (focal_length * obj_realworld_width) / faces[0].width;
+		float focal_length = (obj_realworld_pixels * obj_realworld_distance) / obj_realworld_width;
+		float d_dash       = (focal_length * obj_realworld_width) / faces[0].width;
 
-    //    float beta = (asin(W/d_dash) * 180) / M_PI;
-    float beta = asin(obj_realworld_width / d_dash);
+		//    float beta = (asin(W/d_dash) * 180) / M_PI;
+		float beta = asin(obj_realworld_width / d_dash);
 
-    float multiplier = frame.cols / faces[0].width;
-    float overall_open_angle = beta * multiplier;
+		float multiplier         = frame.cols / faces[0].width;
+		float overall_open_angle = beta * multiplier;
 
-    // center position of predRect relative to the middle of the image.
-    float center_x = faces[0].x + faces[0].width / 2 - frame.cols / 2;
-    float pixels_x_per_degree = frame.cols / overall_open_angle;
-    float center_x_angle = center_x / pixels_x_per_degree;
-    float world_pos_x = (sin(center_x_angle) * d_dash) / 100;
+		// center position of predRect relative to the middle of the image.
+		float center_x            = faces[0].x + faces[0].width / 2 - frame.cols / 2;
+		float pixels_x_per_degree = frame.cols / overall_open_angle;
+		float center_x_angle      = center_x / pixels_x_per_degree;
+		float world_pos_x         = (sin(center_x_angle) * d_dash) / 100;
 
-    // center position of predRect relative to the middle of the image.
-    float center_y = faces[0].y + faces[0].height / 2 - frame.rows / 2;
-    float pixels_y_per_degree = frame.rows / overall_open_angle;
-    float center_y_angle = center_y / pixels_y_per_degree;
-    float world_pos_y = -(sin(center_y_angle) * d_dash) / 100;
+		// center position of predRect relative to the middle of the image.
+		float center_y            = faces[0].y + faces[0].height / 2 - frame.rows / 2;
+		float pixels_y_per_degree = frame.rows / overall_open_angle;
+		float center_y_angle      = center_y / pixels_y_per_degree;
+		float world_pos_y         = -(sin(center_y_angle) * d_dash) / 100;
 
-    float world_pos_z = sqrt(d_dash * d_dash + world_pos_x * world_pos_x) / 100;
-    if (world_pos_z > conveyor_distance_threshold)
-      return;
+		float world_pos_z = sqrt(d_dash * d_dash + world_pos_x * world_pos_x) / 100;
+		if (world_pos_z > conveyor_distance_threshold)
+			return;
 
-    world_pos_z_measurements.push_front(world_pos_z);
-    if (world_pos_z_measurements.size() > num_frames_for_average) {
-      world_pos_z_measurements.pop_back();
-    }
-    for (size_t i = 0; i < world_pos_z_measurements.size(); i++) {
-      world_pos_z_average += world_pos_z_measurements[i];
-    }
-    world_pos_z_average /= world_pos_z_measurements.size();
+		world_pos_z_measurements.push_front(world_pos_z);
+		if (world_pos_z_measurements.size() > num_frames_for_average) {
+			world_pos_z_measurements.pop_back();
+		}
+		for (size_t i = 0; i < world_pos_z_measurements.size(); i++) {
+			world_pos_z_average += world_pos_z_measurements[i];
+		}
+		world_pos_z_average /= world_pos_z_measurements.size();
 
-    world_pos_y_measurements.push_front(world_pos_y);
-    if (world_pos_y_measurements.size() > num_frames_for_average) {
-      world_pos_y_measurements.pop_back();
-    }
-    for (size_t i = 0; i < world_pos_y_measurements.size(); i++) {
-      world_pos_y_average += world_pos_y_measurements[i];
-    }
-    world_pos_y_average /= world_pos_y_measurements.size();
+		world_pos_y_measurements.push_front(world_pos_y);
+		if (world_pos_y_measurements.size() > num_frames_for_average) {
+			world_pos_y_measurements.pop_back();
+		}
+		for (size_t i = 0; i < world_pos_y_measurements.size(); i++) {
+			world_pos_y_average += world_pos_y_measurements[i];
+		}
+		world_pos_y_average /= world_pos_y_measurements.size();
 
-    world_pos_x_measurements.push_front(world_pos_y);
-    if (world_pos_x_measurements.size() > num_frames_for_average) {
-      world_pos_x_measurements.pop_back();
-    }
-    for (size_t i = 0; i < world_pos_x_measurements.size(); i++) {
-      world_pos_x_average += world_pos_x_measurements[i];
-    }
-    world_pos_x_average /= world_pos_x_measurements.size();
+		world_pos_x_measurements.push_front(world_pos_y);
+		if (world_pos_x_measurements.size() > num_frames_for_average) {
+			world_pos_x_measurements.pop_back();
+		}
+		for (size_t i = 0; i < world_pos_x_measurements.size(); i++) {
+			world_pos_x_average += world_pos_x_measurements[i];
+		}
+		world_pos_x_average /= world_pos_x_measurements.size();
 
-    //    float focal_length_mm = 50;
-    //    float obj_height_mm = 50;
-    //    float im_height_px = frame.rows;
-    //    float obj_height_px = faces[0].height;
-    //    float sensor_height_mm = 2; // 1/4" in mm
-    //    float height_width_sqrt = sqrt(frame.rows * frame.rows + frame.cols *
-    //    frame.cols); float opening_angle = 0.86325; float pixels_per_rad =
-    //    opening_angle / height_width_sqrt;
-    ////    float norm_width = 0.47 / 78;
-    ////    float norm_height = 0.4 / 85;
-    //    Point center( faces[0].x + faces[0].width*0.5, faces[0].y +
-    //    faces[0].height*0.5 ); float dist_from_center_px = frame.cols / 2 -
-    //    center.x; float obj_deg = -(dist_from_center_px * pixels_per_rad);
-    //    float distance = (focal_length_mm * obj_height_mm * im_height_px) /
-    //    (obj_height_px * sensor_height_mm);
+		//    float focal_length_mm = 50;
+		//    float obj_height_mm = 50;
+		//    float im_height_px = frame.rows;
+		//    float obj_height_px = faces[0].height;
+		//    float sensor_height_mm = 2; // 1/4" in mm
+		//    float height_width_sqrt = sqrt(frame.rows * frame.rows + frame.cols *
+		//    frame.cols); float opening_angle = 0.86325; float pixels_per_rad =
+		//    opening_angle / height_width_sqrt;
+		////    float norm_width = 0.47 / 78;
+		////    float norm_height = 0.4 / 85;
+		//    Point center( faces[0].x + faces[0].width*0.5, faces[0].y +
+		//    faces[0].height*0.5 ); float dist_from_center_px = frame.cols / 2 -
+		//    center.x; float obj_deg = -(dist_from_center_px * pixels_per_rad);
+		//    float distance = (focal_length_mm * obj_height_mm * im_height_px) /
+		//    (obj_height_px * sensor_height_mm);
 
-    //    printf("found face: x: %d, y: %d, width: %d, height: %d distance:%f,
-    //    obj_deg: %f\n", faces[0].x, faces[0].y, faces[0].width,
-    //    faces[0].height, distance, obj_deg); logger->log_info(name(), "Found
-    //    conveyor: x= %f, y= %f, z= %f", world_pos_z_average, world_pos_z,
-    //    world_pos_y);
+		//    printf("found face: x: %d, y: %d, width: %d, height: %d distance:%f,
+		//    obj_deg: %f\n", faces[0].x, faces[0].y, faces[0].width,
+		//    faces[0].height, distance, obj_deg); logger->log_info(name(), "Found
+		//    conveyor: x= %f, y= %f, z= %f", world_pos_z_average, world_pos_z,
+		//    world_pos_y);
 
-    if (use_hough_lines_) {
+		if (use_hough_lines_) {
+			Rect myROI(faces[0].x, faces[0].y, faces[0].width, faces[0].height);
+			Mat  croppedImage = frame(myROI);
+			cvtColor(croppedImage, croppedImage, CV_BGR2GRAY);
 
-      Rect myROI(faces[0].x, faces[0].y, faces[0].width, faces[0].height);
-      Mat croppedImage = frame(myROI);
-      cvtColor(croppedImage, croppedImage, CV_BGR2GRAY);
+			// calculate binarization threshold depending on average gray-value in the
+			// image
+			Scalar the_mean   = mean(croppedImage);
+			float  float_mean = the_mean.val[0];
 
-      // calculate binarization threshold depending on average gray-value in the
-      // image
-      Scalar the_mean = mean(croppedImage);
-      float float_mean = the_mean.val[0];
+			int calculated_threshold = binary_threshold_min_;
+			if (float_mean >= binary_threshold_average_min_
+			    && float_mean <= binary_threshold_average_max_) {
+				calculated_threshold += (float_mean - binary_threshold_average_min_);
+			} else if (float_mean > binary_threshold_average_max_) {
+				calculated_threshold = binary_threshold_max_;
+			}
 
-      int calculated_threshold = binary_threshold_min_;
-      if (float_mean >= binary_threshold_average_min_ &&
-          float_mean <= binary_threshold_average_max_) {
-        calculated_threshold += (float_mean - binary_threshold_average_min_);
-      } else if (float_mean > binary_threshold_average_max_) {
-        calculated_threshold = binary_threshold_max_;
-      }
+			int thresh = 200;
+			/// Detect edges using canny
+			Mat dst, cdst;
+			threshold(croppedImage, dst, calculated_threshold, max_binary_value_, threshold_type_);
+			Canny(dst, dst, thresh, thresh * 2, 7);
 
-      int thresh = 200;
-      /// Detect edges using canny
-      Mat dst, cdst;
-      threshold(croppedImage, dst, calculated_threshold, max_binary_value_,
-                threshold_type_);
-      Canny(dst, dst, thresh, thresh * 2, 7);
+			int operation = morph_operator_ + 2;
 
-      int operation = morph_operator_ + 2;
+			Mat element = getStructuringElement(morph_element_,
+			                                    Size(2 * morph_size_ + 1, 2 * morph_size_ + 1),
+			                                    Point(morph_size_, morph_size_));
 
-      Mat element = getStructuringElement(
-          morph_element_, Size(2 * morph_size_ + 1, 2 * morph_size_ + 1),
-          Point(morph_size_, morph_size_));
+			// Apply the specified morphology operation
+			morphologyEx(dst, dst, operation, element);
+			int roi_width_limiter  = dst.cols / 4.2; // 10 percent of width of image
+			int roi_height_limiter = dst.rows / 4.8; // 10 percent of width of image
 
-      // Apply the specified morphology operation
-      morphologyEx(dst, dst, operation, element);
-      int roi_width_limiter = dst.cols / 4.2;  // 10 percent of width of image
-      int roi_height_limiter = dst.rows / 4.8; // 10 percent of width of image
+			// fill left side
+			rectangle(dst, Point(0, 0), Point(roi_width_limiter, dst.rows), Scalar(0, 0, 0), CV_FILLED);
+			// fill right side
+			rectangle(dst,
+			          Point(dst.cols - roi_width_limiter, 0),
+			          Point(dst.cols, dst.rows),
+			          Scalar(0, 0, 0),
+			          CV_FILLED);
+			// fill top
+			rectangle(dst, Point(0, 0), Point(dst.cols, roi_height_limiter), Scalar(0, 0, 0), CV_FILLED);
+			// fill middle
+			rectangle(dst,
+			          Point(dst.cols / 2 - 1.5 * (dst.cols / 8), 0),
+			          Point(dst.cols / 2 + 1.5 * (dst.cols / 8), dst.rows),
+			          Scalar(0, 0, 0),
+			          CV_FILLED);
 
-      // fill left side
-      rectangle(dst, Point(0, 0), Point(roi_width_limiter, dst.rows),
-                Scalar(0, 0, 0), CV_FILLED);
-      // fill right side
-      rectangle(dst, Point(dst.cols - roi_width_limiter, 0),
-                Point(dst.cols, dst.rows), Scalar(0, 0, 0), CV_FILLED);
-      // fill top
-      rectangle(dst, Point(0, 0), Point(dst.cols, roi_height_limiter),
-                Scalar(0, 0, 0), CV_FILLED);
-      // fill middle
-      rectangle(dst, Point(dst.cols / 2 - 1.5 * (dst.cols / 8), 0),
-                Point(dst.cols / 2 + 1.5 * (dst.cols / 8), dst.rows),
-                Scalar(0, 0, 0), CV_FILLED);
+			vector<Vec4i> lines;
+			cvtColor(dst, cdst, CV_GRAY2BGR);
 
-      vector<Vec4i> lines;
-      cvtColor(dst, cdst, CV_GRAY2BGR);
+			double rho             = 1;
+			double theta           = CV_PI / 180;
+			double minLineLength   = 10;
+			double maxLineGap      = 25;
+			int    hough_threshold = 20;
 
-      double rho = 1;
-      double theta = CV_PI / 180;
-      double minLineLength = 10;
-      double maxLineGap = 25;
-      int hough_threshold = 20;
+			HoughLinesP(dst, lines, rho, theta, hough_threshold, minLineLength, maxLineGap);
 
-      HoughLinesP(dst, lines, rho, theta, hough_threshold, minLineLength,
-                  maxLineGap);
+			int nearest_line_left_offset  = 0;
+			int nearest_line_right_offset = dst.cols;
+			int nearest_line_left_index   = 0;
+			int nearest_line_right_index  = 0;
 
-      int nearest_line_left_offset = 0;
-      int nearest_line_right_offset = dst.cols;
-      int nearest_line_left_index = 0;
-      int nearest_line_right_index = 0;
+			vector<Vec4i> vertical_lines;
 
-      vector<Vec4i> vertical_lines;
+			for (size_t j = 0; j < lines.size(); j++) {
+				Vec4i l = lines[j];
 
-      for (size_t j = 0; j < lines.size(); j++) {
-        Vec4i l = lines[j];
+				// is vertically oriented line?
+				if (abs(l[1] - l[3]) > 20) {
+					if (l[0] > l[2]) {
+						int diff = (l[0] - l[2]) / 2;
+						l[0] -= diff;
+						l[2] += diff;
+					} else {
+						int diff = (l[2] - l[0]) / 2;
+						l[0] += diff;
+						l[2] -= diff;
+					}
+					vertical_lines.push_back(l);
+				}
+			}
+			for (size_t iV = 0; iV < vertical_lines.size(); iV++) {
+				Vec4i l = vertical_lines[iV];
+				if (l[0] > nearest_line_left_offset && !(l[0] > dst.cols / 2)) {
+					nearest_line_left_offset = l[0];
+					nearest_line_left_index  = iV;
+				}
+				if (l[0] < nearest_line_right_offset && !(l[0] < dst.cols / 2)) {
+					nearest_line_right_offset = l[0];
+					nearest_line_right_index  = iV;
+				}
+			}
 
-        // is vertically oriented line?
-        if (abs(l[1] - l[3]) > 20) {
-          if (l[0] > l[2]) {
-            int diff = (l[0] - l[2]) / 2;
-            l[0] -= diff;
-            l[2] += diff;
-          } else {
-            int diff = (l[2] - l[0]) / 2;
-            l[0] += diff;
-            l[2] -= diff;
-          }
-          vertical_lines.push_back(l);
-        }
-      }
-      for (size_t iV = 0; iV < vertical_lines.size(); iV++) {
-        Vec4i l = vertical_lines[iV];
-        if (l[0] > nearest_line_left_offset && !(l[0] > dst.cols / 2)) {
-          nearest_line_left_offset = l[0];
-          nearest_line_left_index = iV;
-        }
-        if (l[0] < nearest_line_right_offset && !(l[0] < dst.cols / 2)) {
-          nearest_line_right_offset = l[0];
-          nearest_line_right_index = iV;
-        }
-      }
+			// fail if no vertical lines detected or if horizontal distance between
+			// lines is too low
+			if (vertical_lines.size() > 0
+			    && abs(vertical_lines[nearest_line_left_index][0]
+			           - vertical_lines[nearest_line_right_index][0])
+			         > 20) {
+				int horizontal_diff  = abs(vertical_lines[nearest_line_left_index][0]
+                                  - vertical_lines[nearest_line_right_index][0]);
+				int horizontal_start = vertical_lines[nearest_line_left_index][0];
+				int vertical_start   = abs(vertical_lines[nearest_line_left_index][1]
+                                 - vertical_lines[nearest_line_left_index][3]);
+				conveyor_average_horizontal_diff.push_front(horizontal_diff);
+				conveyor_average_horizontal_start.push_front(horizontal_start);
+				conveyor_average_vertical_start.push_front(vertical_start);
+			}
+			if (conveyor_average_horizontal_diff.size() > line_mean_) {
+				conveyor_average_horizontal_diff.pop_back();
+			}
+			if (conveyor_average_horizontal_start.size() > line_mean_) {
+				conveyor_average_horizontal_start.pop_back();
+			}
+			if (conveyor_average_vertical_start.size() > line_mean_) {
+				conveyor_average_vertical_start.pop_back();
+			}
 
-      // fail if no vertical lines detected or if horizontal distance between
-      // lines is too low
-      if (vertical_lines.size() > 0 &&
-          abs(vertical_lines[nearest_line_left_index][0] -
-              vertical_lines[nearest_line_right_index][0]) > 20) {
-        int horizontal_diff = abs(vertical_lines[nearest_line_left_index][0] -
-                                  vertical_lines[nearest_line_right_index][0]);
-        int horizontal_start = vertical_lines[nearest_line_left_index][0];
-        int vertical_start = abs(vertical_lines[nearest_line_left_index][1] -
-                                 vertical_lines[nearest_line_left_index][3]);
-        conveyor_average_horizontal_diff.push_front(horizontal_diff);
-        conveyor_average_horizontal_start.push_front(horizontal_start);
-        conveyor_average_vertical_start.push_front(vertical_start);
-      }
-      if (conveyor_average_horizontal_diff.size() > line_mean_) {
-        conveyor_average_horizontal_diff.pop_back();
-      }
-      if (conveyor_average_horizontal_start.size() > line_mean_) {
-        conveyor_average_horizontal_start.pop_back();
-      }
-      if (conveyor_average_vertical_start.size() > line_mean_) {
-        conveyor_average_vertical_start.pop_back();
-      }
+			int vert_start = 0;
+			int hor_start  = 0;
+			int hor_diff   = 0;
 
-      int vert_start = 0;
-      int hor_start = 0;
-      int hor_diff = 0;
+			for (size_t i = 0; i < conveyor_average_horizontal_diff.size(); i++) {
+				vert_start += conveyor_average_vertical_start[i];
+				hor_start += conveyor_average_horizontal_start[i];
+				hor_diff += conveyor_average_horizontal_diff[i];
+			}
 
-      for (size_t i = 0; i < conveyor_average_horizontal_diff.size(); i++) {
-        vert_start += conveyor_average_vertical_start[i];
-        hor_start += conveyor_average_horizontal_start[i];
-        hor_diff += conveyor_average_horizontal_diff[i];
-      }
+			if (conveyor_average_vertical_start.size() > 0) {
+				vert_start = vert_start / conveyor_average_vertical_start.size();
+				hor_start  = hor_start / conveyor_average_horizontal_start.size();
+				hor_diff   = hor_diff / conveyor_average_horizontal_diff.size();
 
-      if (conveyor_average_vertical_start.size() > 0) {
-        vert_start = vert_start / conveyor_average_vertical_start.size();
-        hor_start = hor_start / conveyor_average_horizontal_start.size();
-        hor_diff = hor_diff / conveyor_average_horizontal_diff.size();
+				line(frame,
+				     Point(faces[0].x + hor_start, faces[0].y + vert_start),
+				     Point(faces[0].x + hor_start + hor_diff, faces[0].y + vert_start),
+				     Scalar(255, 255, 0),
+				     3,
+				     CV_AA);
+			}
 
-        line(frame, Point(faces[0].x + hor_start, faces[0].y + vert_start),
-             Point(faces[0].x + hor_start + hor_diff, faces[0].y + vert_start),
-             Scalar(255, 255, 0), 3, CV_AA);
-      }
+			float focal_length =
+			  (conveyor_realworld_pixels * conveyor_realworld_distance) / conveyor_realworld_width;
+			float d_dash = (focal_length * conveyor_realworld_width) / hor_diff;
 
-      float focal_length =
-          (conveyor_realworld_pixels * conveyor_realworld_distance) /
-          conveyor_realworld_width;
-      float d_dash = (focal_length * conveyor_realworld_width) / hor_diff;
+			float beta = asin(conveyor_realworld_width / d_dash);
 
-      float beta = asin(conveyor_realworld_width / d_dash);
+			float multiplier         = frame.cols / faces[0].width;
+			float overall_open_angle = beta * multiplier;
+			// center position of predRect relative to the middle of the image.
+			float center_x            = faces[0].x + hor_start + hor_diff / 2;
+			float pixels_x_per_degree = frame.cols / overall_open_angle;
+			float center_x_angle      = center_x / pixels_x_per_degree;
+			world_pos_x               = sin(center_x_angle) * d_dash;
 
-      float multiplier = frame.cols / faces[0].width;
-      float overall_open_angle = beta * multiplier;
-      // center position of predRect relative to the middle of the image.
-      float center_x = faces[0].x + hor_start + hor_diff / 2;
-      float pixels_x_per_degree = frame.cols / overall_open_angle;
-      float center_x_angle = center_x / pixels_x_per_degree;
-      world_pos_x = sin(center_x_angle) * d_dash;
-
-      world_pos_z_average =
-          sqrt(d_dash * d_dash + world_pos_x * world_pos_x) / 100.;
-      world_pos_x /= 100.;
-    }
-    mps_conveyor_if_->set_translation(0, world_pos_z_average);
-    mps_conveyor_if_->set_translation(1, -world_pos_x);
-    mps_conveyor_if_->set_translation(2, world_pos_y_average);
-    mps_conveyor_if_->set_rotation(0, 0);
-    mps_conveyor_if_->set_rotation(1, 0);
-    // interface->set_timestamp(&p->cart.stamp);
-    mps_conveyor_if_->set_frame("base_conveyor");
-    mps_conveyor_if_->set_visibility_history(visibility_history);
-    if (visibility_history >= 0) {
-      mps_conveyor_if_->set_visibility_history(visibility_history + 1);
-    } else {
-      mps_conveyor_if_->set_visibility_history(1);
-    }
-    if (visualization_enabled) {
-      cv::rectangle(
-          frame, Point(faces[0].x, faces[0].y),
-          Point(faces[0].x + faces[0].width, faces[0].y + faces[0].height),
-          Scalar(255, 0, 0), 1);
-      cvReleaseImage(&ipl);
-      ipl = cvCreateImage(cvSize(frame.cols, frame.rows), 8, 3);
-      Mat newC = cvarrToMat(ipl);
-      *ipl = newC;
-      firevision::IplImageAdapter::convert_image_yuv422_planar(ipl,
-                                                               image_buffer);
-    }
-  } else {
-    // conveyor not visible
-    if (visibility_history <= 0) {
-      mps_conveyor_if_->set_visibility_history(visibility_history - 1);
-    } else {
-      mps_conveyor_if_->set_visibility_history(-1);
-      world_pos_z_measurements.clear();
-      world_pos_x_measurements.clear();
-      world_pos_y_measurements.clear();
-    }
-  }
+			world_pos_z_average = sqrt(d_dash * d_dash + world_pos_x * world_pos_x) / 100.;
+			world_pos_x /= 100.;
+		}
+		mps_conveyor_if_->set_translation(0, world_pos_z_average);
+		mps_conveyor_if_->set_translation(1, -world_pos_x);
+		mps_conveyor_if_->set_translation(2, world_pos_y_average);
+		mps_conveyor_if_->set_rotation(0, 0);
+		mps_conveyor_if_->set_rotation(1, 0);
+		// interface->set_timestamp(&p->cart.stamp);
+		mps_conveyor_if_->set_frame("base_conveyor");
+		mps_conveyor_if_->set_visibility_history(visibility_history);
+		if (visibility_history >= 0) {
+			mps_conveyor_if_->set_visibility_history(visibility_history + 1);
+		} else {
+			mps_conveyor_if_->set_visibility_history(1);
+		}
+		if (visualization_enabled) {
+			cv::rectangle(frame,
+			              Point(faces[0].x, faces[0].y),
+			              Point(faces[0].x + faces[0].width, faces[0].y + faces[0].height),
+			              Scalar(255, 0, 0),
+			              1);
+			cvReleaseImage(&ipl);
+			ipl      = cvCreateImage(cvSize(frame.cols, frame.rows), 8, 3);
+			Mat newC = cvarrToMat(ipl);
+			*ipl     = newC;
+			firevision::IplImageAdapter::convert_image_yuv422_planar(ipl, image_buffer);
+		}
+	} else {
+		// conveyor not visible
+		if (visibility_history <= 0) {
+			mps_conveyor_if_->set_visibility_history(visibility_history - 1);
+		} else {
+			mps_conveyor_if_->set_visibility_history(-1);
+			world_pos_z_measurements.clear();
+			world_pos_x_measurements.clear();
+			world_pos_y_measurements.clear();
+		}
+	}
 }

--- a/src/plugins/attic/conveyor_vision/conveyor_vision_thread.h
+++ b/src/plugins/attic/conveyor_vision/conveyor_vision_thread.h
@@ -42,16 +42,17 @@
 // firevision camera
 #include <fvcams/camera.h>
 #include <fvclassifiers/simple.h>
+#include <fvutils/adapters/iplimage.h>
 #include <fvutils/base/roi.h>
 #include <fvutils/color/conversions.h>
 #include <fvutils/ipc/shm_image.h>
 
-#include <fvutils/adapters/iplimage.h>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/objdetect/objdetect.hpp>
 
 // interface
 #include <interfaces/TagVisionInterface.h>
+
 #include <iostream>
 #include <stdio.h>
 
@@ -73,91 +74,90 @@ class ConveyorVisionThread : public fawkes::Thread,
                              public fawkes::VisionAspect,
                              public fawkes::ConfigurationChangeHandler,
                              public fawkes::ClockAspect,
-                             public fawkes::TransformAspect {
+                             public fawkes::TransformAspect
+{
 public:
-  ConveyorVisionThread();
-  // marker size accasors
-  // thread functions
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	ConveyorVisionThread();
+	// marker size accasors
+	// thread functions
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  /// load config from file
-  void load_config();
-  /// function to get the markers from an image
-  void get_marker();
-  /// store the alvar markers, containing the poses
-  //  std::vector<alvar::MarkerData> *markers_;
-  /// maximum markers to detect, size for the markers array
-  size_t max_marker;
+	/// load config from file
+	void load_config();
+	/// function to get the markers from an image
+	void get_marker();
+	/// store the alvar markers, containing the poses
+	//  std::vector<alvar::MarkerData> *markers_;
+	/// maximum markers to detect, size for the markers array
+	size_t max_marker;
 
-  /// mutex for config access
-  fawkes::Mutex cfg_mutex;
-  //  String mps_cascade_name = "data/cascade.xml";
-  cv::Mat frame;
-  cv::CascadeClassifier mps_cascade;
+	/// mutex for config access
+	fawkes::Mutex cfg_mutex;
+	//  String mps_cascade_name = "data/cascade.xml";
+	cv::Mat               frame;
+	cv::CascadeClassifier mps_cascade;
 
-  fawkes::Position3DInterface *mps_conveyor_if_;
+	fawkes::Position3DInterface *mps_conveyor_if_;
 
-  /// firevision camera
-  firevision::Camera *fv_cam;
-  /// firevision image buffer
-  firevision::SharedMemoryImageBuffer *shm_buffer;
-  unsigned char *image_buffer;
-  std::deque<float> world_pos_z_measurements;
-  std::deque<float> world_pos_y_measurements;
-  std::deque<float> world_pos_x_measurements;
-  std::deque<int> conveyor_average_horizontal_diff;
-  std::deque<int> conveyor_average_horizontal_start;
-  std::deque<int> conveyor_average_vertical_start;
-  float world_pos_z_average;
-  float world_pos_y_average;
-  float world_pos_x_average;
-  /// Image Buffer Id
-  std::string shm_id;
-  float obj_realworld_distance;
-  float obj_realworld_width;
-  float obj_realworld_pixels;
-  unsigned int num_frames_for_average;
-  float conveyor_distance_threshold;
-  bool visualization_enabled;
-  bool use_hough_lines_;
-  int hough_lines_averaging_count_;
-  int binary_threshold_min_;
-  int binary_threshold_max_;
-  int binary_threshold_average_min_;
-  int binary_threshold_average_max_;
-  int max_binary_value_;
-  int threshold_type_;
-  int morph_element_;
-  int morph_size_;
-  int morph_operator_;
-  int canny_threshold_;
-  unsigned int line_mean_;
-  float conveyor_realworld_distance;
-  float conveyor_realworld_pixels;
-  float conveyor_realworld_width;
+	/// firevision camera
+	firevision::Camera *fv_cam;
+	/// firevision image buffer
+	firevision::SharedMemoryImageBuffer *shm_buffer;
+	unsigned char *                      image_buffer;
+	std::deque<float>                    world_pos_z_measurements;
+	std::deque<float>                    world_pos_y_measurements;
+	std::deque<float>                    world_pos_x_measurements;
+	std::deque<int>                      conveyor_average_horizontal_diff;
+	std::deque<int>                      conveyor_average_horizontal_start;
+	std::deque<int>                      conveyor_average_vertical_start;
+	float                                world_pos_z_average;
+	float                                world_pos_y_average;
+	float                                world_pos_x_average;
+	/// Image Buffer Id
+	std::string  shm_id;
+	float        obj_realworld_distance;
+	float        obj_realworld_width;
+	float        obj_realworld_pixels;
+	unsigned int num_frames_for_average;
+	float        conveyor_distance_threshold;
+	bool         visualization_enabled;
+	bool         use_hough_lines_;
+	int          hough_lines_averaging_count_;
+	int          binary_threshold_min_;
+	int          binary_threshold_max_;
+	int          binary_threshold_average_min_;
+	int          binary_threshold_average_max_;
+	int          max_binary_value_;
+	int          threshold_type_;
+	int          morph_element_;
+	int          morph_size_;
+	int          morph_operator_;
+	int          canny_threshold_;
+	unsigned int line_mean_;
+	float        conveyor_realworld_distance;
+	float        conveyor_realworld_pixels;
+	float        conveyor_realworld_width;
 
-  // config handling
-  virtual void config_value_erased(const char *path);
-  virtual void config_tag_changed(const char *new_tag);
-  virtual void
-  config_comment_changed(const fawkes::Configuration::ValueIterator *v);
-  virtual void
-  config_value_changed(const fawkes::Configuration::ValueIterator *v);
+	// config handling
+	virtual void config_value_erased(const char *path);
+	virtual void config_tag_changed(const char *new_tag);
+	virtual void config_comment_changed(const fawkes::Configuration::ValueIterator *v);
+	virtual void config_value_changed(const fawkes::Configuration::ValueIterator *v);
 
-  void detect();
-  /// cv image
-  IplImage *ipl;
+	void detect();
+	/// cv image
+	IplImage *ipl;
 
-  /// blackboard communication
-  //  TagPositionList *tag_interfaces;
+	/// blackboard communication
+	//  TagPositionList *tag_interfaces;
 
-  /// Width of the image
-  unsigned int img_width;
-  /// Height of the image
-  unsigned int img_height;
+	/// Width of the image
+	unsigned int img_width;
+	/// Height of the image
+	unsigned int img_height;
 };
 
 #endif

--- a/src/plugins/attic/gazebo/gazsim-light-front/gazsim_light_front_plugin.cpp
+++ b/src/plugins/attic/gazebo/gazsim-light-front/gazsim_light_front_plugin.cpp
@@ -19,9 +19,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "gazsim_light_front_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -30,14 +30,16 @@ using namespace fawkes;
  *
  * @author Frederik Zwilling
  */
-class GazsimLightFrontPlugin : public fawkes::Plugin {
+class GazsimLightFrontPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimLightFrontPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new LightFrontSimThread());
-  }
+	GazsimLightFrontPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new LightFrontSimThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Simulation of the LightFront Plugin results")

--- a/src/plugins/attic/gazebo/gazsim-light-front/gazsim_light_front_thread.cpp
+++ b/src/plugins/attic/gazebo/gazsim-light-front/gazsim_light_front_thread.cpp
@@ -21,21 +21,20 @@
 
 #include "gazsim_light_front_thread.h"
 
-#include <math.h>
-#include <stdio.h>
-#include <tf/types.h>
-#include <utils/math/angle.h>
-
+#include <aspect/logging.h>
 #include <interfaces/Position3DInterface.h>
 #include <interfaces/RobotinoLightInterface.h>
 #include <llsf_msgs/LightSignals.pb.h>
 #include <llsf_msgs/MachineInfo.pb.h>
 #include <llsf_msgs/Pose2D.pb.h>
+#include <tf/types.h>
+#include <utils/math/angle.h>
 
-#include <aspect/logging.h>
 #include <gazebo/msgs/msgs.hh>
 #include <gazebo/transport/Node.hh>
 #include <gazebo/transport/transport.hh>
+#include <math.h>
+#include <stdio.h>
 
 using namespace fawkes;
 using namespace gazebo;
@@ -51,345 +50,327 @@ using namespace gazebo;
 
 /** Constructor. */
 LightFrontSimThread::LightFrontSimThread()
-    : Thread("LightFrontSimThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS) {}
-
-void LightFrontSimThread::init() {
-  logger->log_debug(name(),
-                    "Initializing Simulation of the Light Front Plugin");
-
-  // read config values
-  max_distance_ = config->get_float("/gazsim/light-front/max-distance");
-  success_visibility_history_ =
-      config->get_int("/gazsim/light-front/success-visibility-history");
-  fail_visibility_history_ =
-      config->get_int("/gazsim/light-front/fail-visibility-history");
-  visibility_history_increase_per_update_ = config->get_int(
-      "/gazsim/light-front/visibility-history-increase-per-update");
-  light_state_if_name_ =
-      config->get_string("/gazsim/light-front/interface-id-single");
-  light_pos_if_name_ =
-      config->get_string("/plugins/light_front/light_position_if");
-  switch_if_name_ =
-      config->get_string("/gazsim/light-front/interface-id-switch");
-  delivery_switch_if_name_ =
-      config->get_string("/gazsim/light-front/interface-id-delivery-switch");
-  see_all_delivery_gates_ =
-      config->get_bool("/gazsim/light-front/see-all-delivery-gates");
-  interface_id_multiple_ =
-      config->get_string("/gazsim/light-front/interface-id-multiple");
-  deliver_x_min_ = config->get_float("/gazsim/light-front/deliver-pos-x-min");
-  deliver_y_min_ = config->get_float("/gazsim/light-front/deliver-pos-y-min");
-  deliver_y_max_ = config->get_float("/gazsim/light-front/deliver-pos-y-max");
-  deliver_ori_max_diff_ =
-      config->get_float("/gazsim/light-front/deliver-ori-max-diff");
-  delivery_pose_if_name_ =
-      config->get_string("/gazsim/light-front/interface-id-delivery-pose");
-
-  // open interfaces
-  light_if_ = blackboard->open_for_writing<RobotinoLightInterface>(
-      light_state_if_name_.c_str());
-  pose_if_ = blackboard->open_for_reading<fawkes::Position3DInterface>(
-      light_pos_if_name_.c_str());
-  switch_if_ = blackboard->open_for_writing<fawkes::SwitchInterface>(
-      switch_if_name_.c_str());
-  if (see_all_delivery_gates_) {
-    light_if_0_ = blackboard->open_for_writing<RobotinoLightInterface>(
-        (interface_id_multiple_ + "0").c_str());
-    light_if_1_ = blackboard->open_for_writing<RobotinoLightInterface>(
-        (interface_id_multiple_ + "1").c_str());
-    light_if_2_ = blackboard->open_for_writing<RobotinoLightInterface>(
-        (interface_id_multiple_ + "2").c_str());
-    deliver_mode_if_ = blackboard->open_for_writing<fawkes::SwitchInterface>(
-        delivery_switch_if_name_.c_str());
-    deliver_pose_if_ = blackboard->open_for_writing<Position3DInterface>(
-        delivery_pose_if_name_.c_str());
-  }
-
-  // enable plugin by default
-  switch_if_->set_enabled(true);
-  switch_if_->write();
-
-  // subscribing to gazebo publisher
-  light_signals_sub_ =
-      gazebonode->Subscribe(config->get_string("/gazsim/topics/machine-lights"),
-                            &LightFrontSimThread::on_light_signals_msg, this);
-  localization_sub_ =
-      gazebonode->Subscribe(config->get_string("/gazsim/topics/gps"),
-                            &LightFrontSimThread::on_localization_msg, this);
-
-  new_data_ = false;
-  current_vis_history_ = 0;
+: Thread("LightFrontSimThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS)
+{
 }
 
-void LightFrontSimThread::finalize() {
-  blackboard->close(light_if_);
-  blackboard->close(pose_if_);
-  blackboard->close(switch_if_);
-  if (see_all_delivery_gates_) {
-    blackboard->close(light_if_0_);
-    blackboard->close(light_if_1_);
-    blackboard->close(light_if_2_);
-    blackboard->close(deliver_mode_if_);
-    blackboard->close(deliver_pose_if_);
-  }
+void
+LightFrontSimThread::init()
+{
+	logger->log_debug(name(), "Initializing Simulation of the Light Front Plugin");
+
+	// read config values
+	max_distance_               = config->get_float("/gazsim/light-front/max-distance");
+	success_visibility_history_ = config->get_int("/gazsim/light-front/success-visibility-history");
+	fail_visibility_history_    = config->get_int("/gazsim/light-front/fail-visibility-history");
+	visibility_history_increase_per_update_ =
+	  config->get_int("/gazsim/light-front/visibility-history-increase-per-update");
+	light_state_if_name_     = config->get_string("/gazsim/light-front/interface-id-single");
+	light_pos_if_name_       = config->get_string("/plugins/light_front/light_position_if");
+	switch_if_name_          = config->get_string("/gazsim/light-front/interface-id-switch");
+	delivery_switch_if_name_ = config->get_string("/gazsim/light-front/interface-id-delivery-switch");
+	see_all_delivery_gates_  = config->get_bool("/gazsim/light-front/see-all-delivery-gates");
+	interface_id_multiple_   = config->get_string("/gazsim/light-front/interface-id-multiple");
+	deliver_x_min_           = config->get_float("/gazsim/light-front/deliver-pos-x-min");
+	deliver_y_min_           = config->get_float("/gazsim/light-front/deliver-pos-y-min");
+	deliver_y_max_           = config->get_float("/gazsim/light-front/deliver-pos-y-max");
+	deliver_ori_max_diff_    = config->get_float("/gazsim/light-front/deliver-ori-max-diff");
+	delivery_pose_if_name_   = config->get_string("/gazsim/light-front/interface-id-delivery-pose");
+
+	// open interfaces
+	light_if_ = blackboard->open_for_writing<RobotinoLightInterface>(light_state_if_name_.c_str());
+	pose_if_  = blackboard->open_for_reading<fawkes::Position3DInterface>(light_pos_if_name_.c_str());
+	switch_if_ = blackboard->open_for_writing<fawkes::SwitchInterface>(switch_if_name_.c_str());
+	if (see_all_delivery_gates_) {
+		light_if_0_ =
+		  blackboard->open_for_writing<RobotinoLightInterface>((interface_id_multiple_ + "0").c_str());
+		light_if_1_ =
+		  blackboard->open_for_writing<RobotinoLightInterface>((interface_id_multiple_ + "1").c_str());
+		light_if_2_ =
+		  blackboard->open_for_writing<RobotinoLightInterface>((interface_id_multiple_ + "2").c_str());
+		deliver_mode_if_ =
+		  blackboard->open_for_writing<fawkes::SwitchInterface>(delivery_switch_if_name_.c_str());
+		deliver_pose_if_ =
+		  blackboard->open_for_writing<Position3DInterface>(delivery_pose_if_name_.c_str());
+	}
+
+	// enable plugin by default
+	switch_if_->set_enabled(true);
+	switch_if_->write();
+
+	// subscribing to gazebo publisher
+	light_signals_sub_ = gazebonode->Subscribe(config->get_string("/gazsim/topics/machine-lights"),
+	                                           &LightFrontSimThread::on_light_signals_msg,
+	                                           this);
+	localization_sub_  = gazebonode->Subscribe(config->get_string("/gazsim/topics/gps"),
+                                            &LightFrontSimThread::on_localization_msg,
+                                            this);
+
+	new_data_            = false;
+	current_vis_history_ = 0;
 }
 
-void LightFrontSimThread::loop() {
-  // the acual work takes place in on_light_signals_msg
-
-  // check messages of the switch interface
-  while (!switch_if_->msgq_empty()) {
-    if (SwitchInterface::DisableSwitchMessage *msg =
-            switch_if_->msgq_first_safe(msg)) {
-      switch_if_->set_enabled(false);
-    } else if (SwitchInterface::EnableSwitchMessage *msg =
-                   switch_if_->msgq_first_safe(msg)) {
-      switch_if_->set_enabled(true);
-    }
-    switch_if_->msgq_pop();
-    switch_if_->write();
-  }
-
-  // write light interface
-  if (new_data_) {
-    new_data_ = false;
-
-    // stop if the switch is dibabled
-    if (!switch_if_->is_enabled()) {
-      return;
-    }
-
-    // set light interface of the machine the robot is looking at
-    set_interface_of_nearest();
-
-    // if we stand in front of the delivery we have to set the three interfaces
-    // to the signals of the deliverygates
-    if (see_all_delivery_gates_ && standing_in_front_of_deliver()) {
-      set_interfaces_of_gates();
-    } else {
-      set_interface_unready(light_if_0_);
-      set_interface_unready(light_if_1_);
-      set_interface_unready(light_if_2_);
-      deliver_pose_if_->set_visibility_history(fail_visibility_history_);
-      deliver_pose_if_->write();
-    }
-  }
+void
+LightFrontSimThread::finalize()
+{
+	blackboard->close(light_if_);
+	blackboard->close(pose_if_);
+	blackboard->close(switch_if_);
+	if (see_all_delivery_gates_) {
+		blackboard->close(light_if_0_);
+		blackboard->close(light_if_1_);
+		blackboard->close(light_if_2_);
+		blackboard->close(deliver_mode_if_);
+		blackboard->close(deliver_pose_if_);
+	}
 }
 
-void LightFrontSimThread::on_light_signals_msg(ConstAllMachineSignalsPtr &msg) {
-  // logger->log_info(name(), "Got new Machine Light signals.\n");
-  last_msg_.CopyFrom(*msg);
-  new_data_ = true;
+void
+LightFrontSimThread::loop()
+{
+	// the acual work takes place in on_light_signals_msg
+
+	// check messages of the switch interface
+	while (!switch_if_->msgq_empty()) {
+		if (SwitchInterface::DisableSwitchMessage *msg = switch_if_->msgq_first_safe(msg)) {
+			switch_if_->set_enabled(false);
+		} else if (SwitchInterface::EnableSwitchMessage *msg = switch_if_->msgq_first_safe(msg)) {
+			switch_if_->set_enabled(true);
+		}
+		switch_if_->msgq_pop();
+		switch_if_->write();
+	}
+
+	// write light interface
+	if (new_data_) {
+		new_data_ = false;
+
+		// stop if the switch is dibabled
+		if (!switch_if_->is_enabled()) {
+			return;
+		}
+
+		// set light interface of the machine the robot is looking at
+		set_interface_of_nearest();
+
+		// if we stand in front of the delivery we have to set the three interfaces
+		// to the signals of the deliverygates
+		if (see_all_delivery_gates_ && standing_in_front_of_deliver()) {
+			set_interfaces_of_gates();
+		} else {
+			set_interface_unready(light_if_0_);
+			set_interface_unready(light_if_1_);
+			set_interface_unready(light_if_2_);
+			deliver_pose_if_->set_visibility_history(fail_visibility_history_);
+			deliver_pose_if_->write();
+		}
+	}
 }
 
-void LightFrontSimThread::on_localization_msg(ConstPosePtr &msg) {
-  // logger->log_info(name(), "Got new Localization data.\n");
-
-  // read data from message
-  robot_x_ = msg->position().x();
-  robot_y_ = msg->position().y();
-  // calculate ori from quaternion
-  robot_ori_ = tf::get_yaw(
-      tf::Quaternion(msg->orientation().x(), msg->orientation().y(),
-                     msg->orientation().z(), msg->orientation().w()));
+void
+LightFrontSimThread::on_light_signals_msg(ConstAllMachineSignalsPtr &msg)
+{
+	// logger->log_info(name(), "Got new Machine Light signals.\n");
+	last_msg_.CopyFrom(*msg);
+	new_data_ = true;
 }
 
-void LightFrontSimThread::set_interface_of_nearest() {
-  // read cluster position to determine
-  // on which machine the robotino is looking at
-  //(the cluster returns the position relative to the robots pos and ori)
-  pose_if_->read();
-  double rel_x = pose_if_->translation(0);
-  double rel_y = pose_if_->translation(1);
-  // if both is 0 light-front looks direct in front (e.g. when under the rfid)
-  if (rel_x == 0 && rel_y == 0) {
-    rel_x = 0.28; // distance between laser and light signal when standing under
-                  // the rfid
-  }
-  double look_pos_x =
-      robot_x_ + cos(robot_ori_) * rel_x - sin(robot_ori_) * rel_y;
-  double look_pos_y =
-      robot_y_ + sin(robot_ori_) * rel_x + cos(robot_ori_) * rel_y;
-  // find machine nearest to the look_pos
-  double min_distance = 1000.0;
-  int index_min = 0;
-  for (int i = 0; i < last_msg_.machines_size(); i++) {
-    llsf_msgs::MachineSignal machine = last_msg_.machines(i);
-    llsf_msgs::Pose2D pose = machine.pose();
-    double x = pose.x();
-    double y = pose.y();
-    double distance = sqrt((look_pos_x - x) * (look_pos_x - x) +
-                           (look_pos_y - y) * (look_pos_y - y));
-    if (distance < min_distance) {
-      min_distance = distance;
-      index_min = i;
-    }
-  }
+void
+LightFrontSimThread::on_localization_msg(ConstPosePtr &msg)
+{
+	// logger->log_info(name(), "Got new Localization data.\n");
 
-  // if the distance is greater than a threashold, no light is determined
-  if (min_distance > max_distance_) {
-    // logger->log_info(name(), "Distance between light pos and machine (%f) is
-    // too big.\n", min_distance); set ready and visibility history
-    set_interface_unready(light_if_);
-    // reset visibility history
-    current_vis_history_ = 0;
-  } else {
-    // reset visibility history if we look at another machine
-    if (index_min != current_machine_) {
-      current_vis_history_ = 0;
-      current_machine_ = index_min;
-    }
-    // reset visibility history if the signal changed
-    fawkes::RobotinoLightInterface::LightState red =
-        RobotinoLightInterface::OFF;
-    fawkes::RobotinoLightInterface::LightState yellow =
-        RobotinoLightInterface::OFF;
-    fawkes::RobotinoLightInterface::LightState green =
-        RobotinoLightInterface::OFF;
-    get_signals_from_msg(last_msg_.machines(index_min), &red, &yellow, &green);
-    if (red != current_signal_red_ || yellow != current_signal_yellow_ ||
-        green != current_signal_green_) {
-      current_vis_history_ = 0;
-      current_signal_red_ = red;
-      current_signal_yellow_ = yellow;
-      current_signal_green_ = green;
-    }
-    // printf("looking at machine :%s\n",
-    // last_msg_.machines(index_min).name().c_str());
-    set_interface_to_signal(light_if_, last_msg_.machines(index_min));
-    // increase visibility history for next iteration
-    current_vis_history_ += visibility_history_increase_per_update_;
-  }
+	// read data from message
+	robot_x_ = msg->position().x();
+	robot_y_ = msg->position().y();
+	// calculate ori from quaternion
+	robot_ori_ = tf::get_yaw(tf::Quaternion(msg->orientation().x(),
+	                                        msg->orientation().y(),
+	                                        msg->orientation().z(),
+	                                        msg->orientation().w()));
 }
 
-void LightFrontSimThread::set_interfaces_of_gates() {
-  std::string green_machine_name;
-  if (robot_x_ > 0) {
-    // standing in front of the cyan gates
-    set_interface_to_signal(light_if_0_, get_machine("D3"));
-    set_interface_to_signal(light_if_1_, get_machine("D2"));
-    set_interface_to_signal(light_if_2_, get_machine("D1"));
-    if (light_if_0_->green() == RobotinoLightInterface::ON)
-      green_machine_name = "D3";
-    else if (light_if_1_->green() == RobotinoLightInterface::ON)
-      green_machine_name = "D2";
-    else
-      green_machine_name = "D1";
-  } else {
-    // standing in front of the magenta gates
-    set_interface_to_signal(light_if_0_, get_machine("D4"));
-    set_interface_to_signal(light_if_1_, get_machine("D5"));
-    set_interface_to_signal(light_if_2_, get_machine("D6"));
-    if (light_if_0_->green() == RobotinoLightInterface::ON)
-      green_machine_name = "D4";
-    else if (light_if_1_->green() == RobotinoLightInterface::ON)
-      green_machine_name = "D5";
-    else
-      green_machine_name = "D6";
-  }
-  // set green light position when looking at a green delivery gate
-  llsf_msgs::MachineSignal green_machine =
-      get_machine(green_machine_name.c_str());
-  deliver_pose_if_->set_frame("/base_laser");
-  deliver_pose_if_->set_visibility_history(success_visibility_history_);
-  double rel_x = green_machine.pose().x() - robot_x_;
-  double rel_y = green_machine.pose().y() - robot_y_;
-  deliver_pose_if_->set_translation(0, cos(-robot_ori_) * rel_x -
-                                           sin(-robot_ori_) * rel_y);
-  deliver_pose_if_->set_translation(1, sin(-robot_ori_) * rel_x +
-                                           cos(-robot_ori_) * rel_y);
-  deliver_pose_if_->set_translation(2, 0.15);
-  deliver_pose_if_->write();
+void
+LightFrontSimThread::set_interface_of_nearest()
+{
+	// read cluster position to determine
+	// on which machine the robotino is looking at
+	//(the cluster returns the position relative to the robots pos and ori)
+	pose_if_->read();
+	double rel_x = pose_if_->translation(0);
+	double rel_y = pose_if_->translation(1);
+	// if both is 0 light-front looks direct in front (e.g. when under the rfid)
+	if (rel_x == 0 && rel_y == 0) {
+		rel_x = 0.28; // distance between laser and light signal when standing under
+		              // the rfid
+	}
+	double look_pos_x = robot_x_ + cos(robot_ori_) * rel_x - sin(robot_ori_) * rel_y;
+	double look_pos_y = robot_y_ + sin(robot_ori_) * rel_x + cos(robot_ori_) * rel_y;
+	// find machine nearest to the look_pos
+	double min_distance = 1000.0;
+	int    index_min    = 0;
+	for (int i = 0; i < last_msg_.machines_size(); i++) {
+		llsf_msgs::MachineSignal machine = last_msg_.machines(i);
+		llsf_msgs::Pose2D        pose    = machine.pose();
+		double                   x       = pose.x();
+		double                   y       = pose.y();
+		double                   distance =
+		  sqrt((look_pos_x - x) * (look_pos_x - x) + (look_pos_y - y) * (look_pos_y - y));
+		if (distance < min_distance) {
+			min_distance = distance;
+			index_min    = i;
+		}
+	}
+
+	// if the distance is greater than a threashold, no light is determined
+	if (min_distance > max_distance_) {
+		// logger->log_info(name(), "Distance between light pos and machine (%f) is
+		// too big.\n", min_distance); set ready and visibility history
+		set_interface_unready(light_if_);
+		// reset visibility history
+		current_vis_history_ = 0;
+	} else {
+		// reset visibility history if we look at another machine
+		if (index_min != current_machine_) {
+			current_vis_history_ = 0;
+			current_machine_     = index_min;
+		}
+		// reset visibility history if the signal changed
+		fawkes::RobotinoLightInterface::LightState red    = RobotinoLightInterface::OFF;
+		fawkes::RobotinoLightInterface::LightState yellow = RobotinoLightInterface::OFF;
+		fawkes::RobotinoLightInterface::LightState green  = RobotinoLightInterface::OFF;
+		get_signals_from_msg(last_msg_.machines(index_min), &red, &yellow, &green);
+		if (red != current_signal_red_ || yellow != current_signal_yellow_
+		    || green != current_signal_green_) {
+			current_vis_history_   = 0;
+			current_signal_red_    = red;
+			current_signal_yellow_ = yellow;
+			current_signal_green_  = green;
+		}
+		// printf("looking at machine :%s\n",
+		// last_msg_.machines(index_min).name().c_str());
+		set_interface_to_signal(light_if_, last_msg_.machines(index_min));
+		// increase visibility history for next iteration
+		current_vis_history_ += visibility_history_increase_per_update_;
+	}
 }
 
-bool LightFrontSimThread::standing_in_front_of_deliver() {
-  // we have to stand in the area in front of the deliver
-  // with respect to both sides
-  if (fabs(robot_x_) < deliver_x_min_ || robot_y_ < deliver_y_min_ ||
-      robot_y_ > deliver_y_max_) {
-    return false;
-  }
-  // and look in the right direction
-  if (robot_x_ > 0) {
-    return fabs(robot_ori_) < deliver_ori_max_diff_;
-  } else {
-    return fabs(robot_ori_) > (M_PI - deliver_ori_max_diff_);
-  }
+void
+LightFrontSimThread::set_interfaces_of_gates()
+{
+	std::string green_machine_name;
+	if (robot_x_ > 0) {
+		// standing in front of the cyan gates
+		set_interface_to_signal(light_if_0_, get_machine("D3"));
+		set_interface_to_signal(light_if_1_, get_machine("D2"));
+		set_interface_to_signal(light_if_2_, get_machine("D1"));
+		if (light_if_0_->green() == RobotinoLightInterface::ON)
+			green_machine_name = "D3";
+		else if (light_if_1_->green() == RobotinoLightInterface::ON)
+			green_machine_name = "D2";
+		else
+			green_machine_name = "D1";
+	} else {
+		// standing in front of the magenta gates
+		set_interface_to_signal(light_if_0_, get_machine("D4"));
+		set_interface_to_signal(light_if_1_, get_machine("D5"));
+		set_interface_to_signal(light_if_2_, get_machine("D6"));
+		if (light_if_0_->green() == RobotinoLightInterface::ON)
+			green_machine_name = "D4";
+		else if (light_if_1_->green() == RobotinoLightInterface::ON)
+			green_machine_name = "D5";
+		else
+			green_machine_name = "D6";
+	}
+	// set green light position when looking at a green delivery gate
+	llsf_msgs::MachineSignal green_machine = get_machine(green_machine_name.c_str());
+	deliver_pose_if_->set_frame("/base_laser");
+	deliver_pose_if_->set_visibility_history(success_visibility_history_);
+	double rel_x = green_machine.pose().x() - robot_x_;
+	double rel_y = green_machine.pose().y() - robot_y_;
+	deliver_pose_if_->set_translation(0, cos(-robot_ori_) * rel_x - sin(-robot_ori_) * rel_y);
+	deliver_pose_if_->set_translation(1, sin(-robot_ori_) * rel_x + cos(-robot_ori_) * rel_y);
+	deliver_pose_if_->set_translation(2, 0.15);
+	deliver_pose_if_->write();
+}
+
+bool
+LightFrontSimThread::standing_in_front_of_deliver()
+{
+	// we have to stand in the area in front of the deliver
+	// with respect to both sides
+	if (fabs(robot_x_) < deliver_x_min_ || robot_y_ < deliver_y_min_ || robot_y_ > deliver_y_max_) {
+		return false;
+	}
+	// and look in the right direction
+	if (robot_x_ > 0) {
+		return fabs(robot_ori_) < deliver_ori_max_diff_;
+	} else {
+		return fabs(robot_ori_) > (M_PI - deliver_ori_max_diff_);
+	}
 }
 
 llsf_msgs::MachineSignal
-LightFrontSimThread::get_machine(std::string machine_name) {
-  std::string search_string =
-      machine_name + "::"; // because in name stands the name of the link
-  for (int i = 0; i < last_msg_.machines_size(); i++) {
-    llsf_msgs::MachineSignal machine = last_msg_.machines(i);
-    if (machine.name().find(search_string) != std::string::npos) {
-      return machine;
-    }
-  }
-  logger->log_error(name(), "Could not find Machine %s in msg.",
-                    machine_name.c_str());
-  return last_msg_.machines(0);
+LightFrontSimThread::get_machine(std::string machine_name)
+{
+	std::string search_string = machine_name + "::"; // because in name stands the name of the link
+	for (int i = 0; i < last_msg_.machines_size(); i++) {
+		llsf_msgs::MachineSignal machine = last_msg_.machines(i);
+		if (machine.name().find(search_string) != std::string::npos) {
+			return machine;
+		}
+	}
+	logger->log_error(name(), "Could not find Machine %s in msg.", machine_name.c_str());
+	return last_msg_.machines(0);
 }
 
-void LightFrontSimThread::set_interface_to_signal(
-    fawkes::RobotinoLightInterface *interface,
-    llsf_msgs::MachineSignal signal) {
-  // read out lights
-  fawkes::RobotinoLightInterface::LightState red = RobotinoLightInterface::OFF;
-  fawkes::RobotinoLightInterface::LightState yellow =
-      RobotinoLightInterface::OFF;
-  fawkes::RobotinoLightInterface::LightState green =
-      RobotinoLightInterface::OFF;
-  get_signals_from_msg(signal, &red, &yellow, &green);
+void
+LightFrontSimThread::set_interface_to_signal(fawkes::RobotinoLightInterface *interface,
+                                             llsf_msgs::MachineSignal        signal)
+{
+	// read out lights
+	fawkes::RobotinoLightInterface::LightState red    = RobotinoLightInterface::OFF;
+	fawkes::RobotinoLightInterface::LightState yellow = RobotinoLightInterface::OFF;
+	fawkes::RobotinoLightInterface::LightState green  = RobotinoLightInterface::OFF;
+	get_signals_from_msg(signal, &red, &yellow, &green);
 
-  // write interface
-  interface->set_red(red);
-  interface->set_yellow(yellow);
-  interface->set_green(green);
-  interface->set_ready(true);
-  interface->set_visibility_history(current_vis_history_);
-  interface->write();
+	// write interface
+	interface->set_red(red);
+	interface->set_yellow(yellow);
+	interface->set_green(green);
+	interface->set_ready(true);
+	interface->set_visibility_history(current_vis_history_);
+	interface->write();
 }
 
-void LightFrontSimThread::set_interface_unready(
-    fawkes::RobotinoLightInterface *interface) {
-  interface->set_ready(false);
-  interface->set_visibility_history(fail_visibility_history_);
-  interface->write();
+void
+LightFrontSimThread::set_interface_unready(fawkes::RobotinoLightInterface *interface)
+{
+	interface->set_ready(false);
+	interface->set_visibility_history(fail_visibility_history_);
+	interface->write();
 }
 
-void LightFrontSimThread::get_signals_from_msg(
-    llsf_msgs::MachineSignal signal_msg,
-    fawkes::RobotinoLightInterface::LightState *red,
-    fawkes::RobotinoLightInterface::LightState *yellow,
-    fawkes::RobotinoLightInterface::LightState *green) {
-  // read out lights
-  for (int i = 0; i < signal_msg.lights_size(); i++) {
-    llsf_msgs::LightSpec light_spec = signal_msg.lights(i);
-    RobotinoLightInterface::LightState state = RobotinoLightInterface::OFF;
-    switch (light_spec.state()) {
-    case llsf_msgs::OFF:
-      state = RobotinoLightInterface::OFF;
-      break;
-    case llsf_msgs::ON:
-      state = RobotinoLightInterface::ON;
-      break;
-    case llsf_msgs::BLINK:
-      state = RobotinoLightInterface::BLINKING;
-      break;
-    }
-    switch (light_spec.color()) {
-    case llsf_msgs::RED:
-      *red = state;
-      break;
-    case llsf_msgs::YELLOW:
-      *yellow = state;
-      break;
-    case llsf_msgs::GREEN:
-      *green = state;
-      break;
-    }
-  }
+void
+LightFrontSimThread::get_signals_from_msg(llsf_msgs::MachineSignal                    signal_msg,
+                                          fawkes::RobotinoLightInterface::LightState *red,
+                                          fawkes::RobotinoLightInterface::LightState *yellow,
+                                          fawkes::RobotinoLightInterface::LightState *green)
+{
+	// read out lights
+	for (int i = 0; i < signal_msg.lights_size(); i++) {
+		llsf_msgs::LightSpec               light_spec = signal_msg.lights(i);
+		RobotinoLightInterface::LightState state      = RobotinoLightInterface::OFF;
+		switch (light_spec.state()) {
+		case llsf_msgs::OFF: state = RobotinoLightInterface::OFF; break;
+		case llsf_msgs::ON: state = RobotinoLightInterface::ON; break;
+		case llsf_msgs::BLINK: state = RobotinoLightInterface::BLINKING; break;
+		}
+		switch (light_spec.color()) {
+		case llsf_msgs::RED: *red = state; break;
+		case llsf_msgs::YELLOW: *yellow = state; break;
+		case llsf_msgs::GREEN: *green = state; break;
+		}
+	}
 }

--- a/src/plugins/attic/gazebo/gazsim-light-front/gazsim_light_front_thread.h
+++ b/src/plugins/attic/gazebo/gazsim-light-front/gazsim_light_front_thread.h
@@ -33,6 +33,7 @@
 #include <interfaces/SwitchInterface.h>
 #include <llsf_msgs/LightSignals.pb.h>
 #include <plugins/gazebo/aspect/gazebo.h>
+
 #include <string.h>
 
 // from Gazebo
@@ -40,8 +41,7 @@
 #include <gazebo/transport/TransportTypes.hh>
 #include <gazebo/transport/transport.hh>
 
-typedef const boost::shared_ptr<llsf_msgs::AllMachineSignals const>
-    ConstAllMachineSignalsPtr;
+typedef const boost::shared_ptr<llsf_msgs::AllMachineSignals const> ConstAllMachineSignalsPtr;
 
 namespace fawkes {
 class RobotinoLightInterface;
@@ -53,107 +53,108 @@ class LightFrontSimThread : public fawkes::Thread,
                             public fawkes::ConfigurableAspect,
                             public fawkes::BlackBoardAspect,
                             public fawkes::BlockedTimingAspect,
-                            public fawkes::GazeboAspect {
+                            public fawkes::GazeboAspect
+{
 public:
-  LightFrontSimThread();
+	LightFrontSimThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  // Subscriber to receive light signal data from gazebo
-  gazebo::transport::SubscriberPtr light_signals_sub_;
-  // Subscriber to receive localization data from gazebo
-  //(light front works relative, and the light signal msgs are absolute)
-  gazebo::transport::SubscriberPtr localization_sub_;
+	// Subscriber to receive light signal data from gazebo
+	gazebo::transport::SubscriberPtr light_signals_sub_;
+	// Subscriber to receive localization data from gazebo
+	//(light front works relative, and the light signal msgs are absolute)
+	gazebo::transport::SubscriberPtr localization_sub_;
 
-  // interface needed to determine position of the light
-  fawkes::Position3DInterface *pose_if_;
+	// interface needed to determine position of the light
+	fawkes::Position3DInterface *pose_if_;
 
-  // provided interfaces
-  fawkes::RobotinoLightInterface *light_if_;
-  fawkes::RobotinoLightInterface *light_if_0_;
-  fawkes::RobotinoLightInterface *light_if_1_;
-  fawkes::RobotinoLightInterface *light_if_2_;
-  fawkes::SwitchInterface *switch_if_;
-  fawkes::SwitchInterface *deliver_mode_if_;
-  fawkes::Position3DInterface *deliver_pose_if_;
+	// provided interfaces
+	fawkes::RobotinoLightInterface *light_if_;
+	fawkes::RobotinoLightInterface *light_if_0_;
+	fawkes::RobotinoLightInterface *light_if_1_;
+	fawkes::RobotinoLightInterface *light_if_2_;
+	fawkes::SwitchInterface *       switch_if_;
+	fawkes::SwitchInterface *       deliver_mode_if_;
+	fawkes::Position3DInterface *   deliver_pose_if_;
 
-  // handler function for incoming messages about the machine light signals
-  void on_light_signals_msg(ConstAllMachineSignalsPtr &msg);
+	// handler function for incoming messages about the machine light signals
+	void on_light_signals_msg(ConstAllMachineSignalsPtr &msg);
 
-  // copy of last msg to write the interface in the next loop
-  llsf_msgs::AllMachineSignals last_msg_;
+	// copy of last msg to write the interface in the next loop
+	llsf_msgs::AllMachineSignals last_msg_;
 
-  // handler function for incoming localization data messages
-  void on_localization_msg(ConstPosePtr &msg);
+	// handler function for incoming localization data messages
+	void on_localization_msg(ConstPosePtr &msg);
 
-  /// set the light interface to the signal state nearest to the cluster
-  /// position
-  void set_interface_of_nearest();
+	/// set the light interface to the signal state nearest to the cluster
+	/// position
+	void set_interface_of_nearest();
 
-  /// set the light interfaces of the three delivery gates
-  void set_interfaces_of_gates();
+	/// set the light interfaces of the three delivery gates
+	void set_interfaces_of_gates();
 
-  // config value for maximal distance before the plugin says
-  // it can not detect any light
-  double max_distance_;
+	// config value for maximal distance before the plugin says
+	// it can not detect any light
+	double max_distance_;
 
-  /// does the robot stand in front of the delivery gate?
-  bool standing_in_front_of_deliver();
+	/// does the robot stand in front of the delivery gate?
+	bool standing_in_front_of_deliver();
 
-  /// get machine signal of specific machine
-  llsf_msgs::MachineSignal get_machine(std::string name);
+	/// get machine signal of specific machine
+	llsf_msgs::MachineSignal get_machine(std::string name);
 
-  /// set interface according to signal
-  void set_interface_to_signal(fawkes::RobotinoLightInterface *interface,
-                               llsf_msgs::MachineSignal signal);
+	/// set interface according to signal
+	void set_interface_to_signal(fawkes::RobotinoLightInterface *interface,
+	                             llsf_msgs::MachineSignal        signal);
 
-  /// set interface unready and with low visibility history
-  void set_interface_unready(fawkes::RobotinoLightInterface *interface);
+	/// set interface unready and with low visibility history
+	void set_interface_unready(fawkes::RobotinoLightInterface *interface);
 
-  /// get light signals of a machine from msg (returns values by reference)
-  void get_signals_from_msg(llsf_msgs::MachineSignal signal_msg,
-                            fawkes::RobotinoLightInterface::LightState *red,
-                            fawkes::RobotinoLightInterface::LightState *yellow,
-                            fawkes::RobotinoLightInterface::LightState *green);
+	/// get light signals of a machine from msg (returns values by reference)
+	void get_signals_from_msg(llsf_msgs::MachineSignal                    signal_msg,
+	                          fawkes::RobotinoLightInterface::LightState *red,
+	                          fawkes::RobotinoLightInterface::LightState *yellow,
+	                          fawkes::RobotinoLightInterface::LightState *green);
 
-  // config value for perception at the delivery-gates
-  bool see_all_delivery_gates_;
-  std::string interface_id_multiple_;
-  // area and ori where we assume the robot looks at the delivery gates (also
-  // mirrored for other half)
-  float deliver_x_min_;
-  float deliver_y_min_;
-  float deliver_y_max_;
-  float deliver_ori_max_diff_;
+	// config value for perception at the delivery-gates
+	bool        see_all_delivery_gates_;
+	std::string interface_id_multiple_;
+	// area and ori where we assume the robot looks at the delivery gates (also
+	// mirrored for other half)
+	float deliver_x_min_;
+	float deliver_y_min_;
+	float deliver_y_max_;
+	float deliver_ori_max_diff_;
 
-  int success_visibility_history_;
-  int current_vis_history_;
-  int fail_visibility_history_;
+	int success_visibility_history_;
+	int current_vis_history_;
+	int fail_visibility_history_;
 
-  int visibility_history_increase_per_update_;
+	int visibility_history_increase_per_update_;
 
-  // variables needed to reset visibility history
-  int current_machine_;
-  fawkes::RobotinoLightInterface::LightState current_signal_red_;
-  fawkes::RobotinoLightInterface::LightState current_signal_yellow_;
-  fawkes::RobotinoLightInterface::LightState current_signal_green_;
+	// variables needed to reset visibility history
+	int                                        current_machine_;
+	fawkes::RobotinoLightInterface::LightState current_signal_red_;
+	fawkes::RobotinoLightInterface::LightState current_signal_yellow_;
+	fawkes::RobotinoLightInterface::LightState current_signal_green_;
 
-  std::string light_pos_if_name_;
-  std::string light_state_if_name_;
-  std::string switch_if_name_;
-  std::string delivery_switch_if_name_;
-  std::string delivery_pose_if_name_;
+	std::string light_pos_if_name_;
+	std::string light_state_if_name_;
+	std::string switch_if_name_;
+	std::string delivery_switch_if_name_;
+	std::string delivery_pose_if_name_;
 
-  // the robots position in the simulation
-  double robot_x_;
-  double robot_y_;
-  double robot_ori_;
+	// the robots position in the simulation
+	double robot_x_;
+	double robot_y_;
+	double robot_ori_;
 
-  // interface values to write in the next loop
-  bool new_data_;
+	// interface values to write in the next loop
+	bool new_data_;
 };
 
 #endif

--- a/src/plugins/attic/gazebo/gazsim-llsf-statistics/gazsim_llsf_statistics_plugin.cpp
+++ b/src/plugins/attic/gazebo/gazsim-llsf-statistics/gazsim_llsf_statistics_plugin.cpp
@@ -19,9 +19,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "gazsim_llsf_statistics_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -30,14 +30,16 @@ using namespace fawkes;
  *
  * @author Frederik Zwilling
  */
-class GazsimLlsfStatisticsPlugin : public fawkes::Plugin {
+class GazsimLlsfStatisticsPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimLlsfStatisticsPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new LlsfStatisticsSimThread());
-  }
+	GazsimLlsfStatisticsPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new LlsfStatisticsSimThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Makes statistics of a llsf game in gazebo")

--- a/src/plugins/attic/gazebo/gazsim-llsf-statistics/gazsim_llsf_statistics_thread.cpp
+++ b/src/plugins/attic/gazebo/gazsim-llsf-statistics/gazsim_llsf_statistics_thread.cpp
@@ -21,24 +21,21 @@
 
 #include "gazsim_llsf_statistics_thread.h"
 
+#include <aspect/logging.h>
+#include <interfaces/Position3DInterface.h>
+#include <mongo/client/dbclient.h>
+#include <mongo/client/gridfs.h>
+#include <tf/types.h>
+#include <utils/misc/string_conversions.h>
+
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/transport/Node.hh>
+#include <gazebo/transport/transport.hh>
 #include <math.h>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <tf/types.h>
-
-#include <interfaces/Position3DInterface.h>
-
-#include <aspect/logging.h>
-#include <gazebo/msgs/msgs.hh>
-#include <gazebo/transport/Node.hh>
-#include <gazebo/transport/transport.hh>
-
-#include <mongo/client/dbclient.h>
-#include <mongo/client/gridfs.h>
-
-#include <utils/misc/string_conversions.h>
 
 using namespace fawkes;
 using namespace gazebo;
@@ -52,92 +49,104 @@ using namespace mongo;
 
 /** Constructor. */
 LlsfStatisticsSimThread::LlsfStatisticsSimThread()
-    : Thread("LlsfStatisticsSimThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE) {}
-
-void LlsfStatisticsSimThread::init() {
-  logger->log_debug(name(), "Initializing LLSF-Statistics Plugin");
-
-  // create subscriber
-  game_state_sub_ = gazebo_world_node->Subscribe(
-      config->get_string("/gazsim/topics/game-state"),
-      &LlsfStatisticsSimThread::on_game_state_msg, this);
-
-  // read config values
-  db_name_ = config->get_string("/gazsim/llsf-statistics/db-name");
-  collection_ = config->get_string("/gazsim/llsf-statistics/collection");
-  namespace_ = db_name_ + "." + collection_;
-  configuration_ =
-      config->get_string("/gazsim/llsf-statistics/configuration-name");
-  replay_ = config->get_string("/gazsim/llsf-statistics/log");
-  run_ = config->get_uint("/gazsim/llsf-statistics/run");
-
-  // init statistics
-  exp_points_cyan_ = 0;
-  prod_points_cyan_ = 0;
-  exp_points_magenta_ = 0;
-  prod_points_magenta_ = 0;
-  written_ = false;
-
-  mongodb_ = mongodb_client;
+: Thread("LlsfStatisticsSimThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE)
+{
 }
 
-void LlsfStatisticsSimThread::finalize() { write_statistics(); }
+void
+LlsfStatisticsSimThread::init()
+{
+	logger->log_debug(name(), "Initializing LLSF-Statistics Plugin");
 
-void LlsfStatisticsSimThread::loop() {}
+	// create subscriber
+	game_state_sub_ = gazebo_world_node->Subscribe(config->get_string("/gazsim/topics/game-state"),
+	                                               &LlsfStatisticsSimThread::on_game_state_msg,
+	                                               this);
 
-void LlsfStatisticsSimThread::on_game_state_msg(ConstGameStatePtr &msg) {
-  // logger->log_info(name(), "Got GameState message");
-  if (msg->phase() == llsf_msgs::GameState::EXPLORATION) {
-    exp_points_magenta_ = msg->points_magenta();
-    exp_points_cyan_ = msg->points_cyan();
-  } else if (msg->phase() == llsf_msgs::GameState::PRODUCTION) {
-    prod_points_magenta_ = msg->points_magenta() - exp_points_magenta_;
-    prod_points_cyan_ = msg->points_cyan() - exp_points_cyan_;
-  } else if (msg->phase() == llsf_msgs::GameState::POST_GAME) {
-    write_statistics();
-  }
+	// read config values
+	db_name_       = config->get_string("/gazsim/llsf-statistics/db-name");
+	collection_    = config->get_string("/gazsim/llsf-statistics/collection");
+	namespace_     = db_name_ + "." + collection_;
+	configuration_ = config->get_string("/gazsim/llsf-statistics/configuration-name");
+	replay_        = config->get_string("/gazsim/llsf-statistics/log");
+	run_           = config->get_uint("/gazsim/llsf-statistics/run");
+
+	// init statistics
+	exp_points_cyan_     = 0;
+	prod_points_cyan_    = 0;
+	exp_points_magenta_  = 0;
+	prod_points_magenta_ = 0;
+	written_             = false;
+
+	mongodb_ = mongodb_client;
 }
 
-void LlsfStatisticsSimThread::write_statistics() {
-  if (!written_) {
-    written_ = true;
+void
+LlsfStatisticsSimThread::finalize()
+{
+	write_statistics();
+}
 
-    // get refbox game summery from ninja bash script
-    std::string refbox_log_file = replay_ + "/refbox.log";
-    std::string command =
-        StringConversions::resolve_path(config->get_string(
-            "/gazsim/llsf-statistics/get-refbox-summary-script")) +
-        " " + refbox_log_file;
-    logger->log_info(name(), "command %s\n", command.c_str());
-    FILE *bash_output = popen(command.c_str(), "r");
-    std::string refbox_score_log = "";
-    if (bash_output) {
-      logger->log_info(name(), "shuffeling");
-      char buffer[100];
-      while (!feof(bash_output)) {
-        if (fgets(buffer, 100, bash_output) == NULL) {
-          break;
-        }
-        refbox_score_log += buffer;
-      }
-      fclose(bash_output);
-    }
-    logger->log_info(name(), "summery %s\n", refbox_score_log.c_str());
+void
+LlsfStatisticsSimThread::loop()
+{
+}
 
-    BSONObjBuilder builder;
-    builder.append("configuration", configuration_.c_str());
-    builder.append("run", run_);
-    builder.append("exp-points-cyan", exp_points_cyan_);
-    builder.append("prod-points-cyan", prod_points_cyan_);
-    builder.append("total-points-cyan", exp_points_cyan_ + prod_points_cyan_);
-    builder.append("exp-points-magenta", exp_points_magenta_);
-    builder.append("prod-points-magenta", prod_points_magenta_);
-    builder.append("total-points-magenta",
-                   exp_points_magenta_ + prod_points_magenta_);
-    builder.append("logs_and_replay", replay_.c_str());
-    builder.append("refbox_game_summery", refbox_score_log.c_str());
-    BSONObj entry = builder.obj();
-    mongodb_->insert(namespace_.c_str(), entry);
-  }
+void
+LlsfStatisticsSimThread::on_game_state_msg(ConstGameStatePtr &msg)
+{
+	// logger->log_info(name(), "Got GameState message");
+	if (msg->phase() == llsf_msgs::GameState::EXPLORATION) {
+		exp_points_magenta_ = msg->points_magenta();
+		exp_points_cyan_    = msg->points_cyan();
+	} else if (msg->phase() == llsf_msgs::GameState::PRODUCTION) {
+		prod_points_magenta_ = msg->points_magenta() - exp_points_magenta_;
+		prod_points_cyan_    = msg->points_cyan() - exp_points_cyan_;
+	} else if (msg->phase() == llsf_msgs::GameState::POST_GAME) {
+		write_statistics();
+	}
+}
+
+void
+LlsfStatisticsSimThread::write_statistics()
+{
+	if (!written_) {
+		written_ = true;
+
+		// get refbox game summery from ninja bash script
+		std::string refbox_log_file = replay_ + "/refbox.log";
+		std::string command         = StringConversions::resolve_path(
+                            config->get_string("/gazsim/llsf-statistics/get-refbox-summary-script"))
+		                      + " " + refbox_log_file;
+		logger->log_info(name(), "command %s\n", command.c_str());
+		FILE *      bash_output      = popen(command.c_str(), "r");
+		std::string refbox_score_log = "";
+		if (bash_output) {
+			logger->log_info(name(), "shuffeling");
+			char buffer[100];
+			while (!feof(bash_output)) {
+				if (fgets(buffer, 100, bash_output) == NULL) {
+					break;
+				}
+				refbox_score_log += buffer;
+			}
+			fclose(bash_output);
+		}
+		logger->log_info(name(), "summery %s\n", refbox_score_log.c_str());
+
+		BSONObjBuilder builder;
+		builder.append("configuration", configuration_.c_str());
+		builder.append("run", run_);
+		builder.append("exp-points-cyan", exp_points_cyan_);
+		builder.append("prod-points-cyan", prod_points_cyan_);
+		builder.append("total-points-cyan", exp_points_cyan_ + prod_points_cyan_);
+		builder.append("exp-points-magenta", exp_points_magenta_);
+		builder.append("prod-points-magenta", prod_points_magenta_);
+		builder.append("total-points-magenta", exp_points_magenta_ + prod_points_magenta_);
+		builder.append("logs_and_replay", replay_.c_str());
+		builder.append("refbox_game_summery", refbox_score_log.c_str());
+		BSONObj entry = builder.obj();
+		mongodb_->insert(namespace_.c_str(), entry);
+	}
 }

--- a/src/plugins/attic/gazebo/gazsim-llsf-statistics/gazsim_llsf_statistics_thread.h
+++ b/src/plugins/attic/gazebo/gazsim-llsf-statistics/gazsim_llsf_statistics_thread.h
@@ -32,11 +32,11 @@
 #include <llsf_msgs/GameState.pb.h>
 #include <plugins/gazebo/aspect/gazebo.h>
 #include <plugins/mongodb/aspect/mongodb.h>
-#include <string.h>
 
 #include <gazebo/msgs/MessageTypes.hh>
 #include <gazebo/transport/TransportTypes.hh>
 #include <gazebo/transport/transport.hh>
+#include <string.h>
 
 namespace fawkes {
 class Position3DInterface;
@@ -56,34 +56,35 @@ class LlsfStatisticsSimThread : public fawkes::Thread,
                                 public fawkes::BlackBoardAspect,
                                 public fawkes::BlockedTimingAspect,
                                 public fawkes::GazeboAspect,
-                                public fawkes::MongoDBAspect {
+                                public fawkes::MongoDBAspect
+{
 public:
-  LlsfStatisticsSimThread();
+	LlsfStatisticsSimThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  // suscribers for gazebo nodes (refbox messages forwarded by
-  // gazsim-llsfrbcomm)
-  gazebo::transport::SubscriberPtr game_state_sub_;
+	// suscribers for gazebo nodes (refbox messages forwarded by
+	// gazsim-llsfrbcomm)
+	gazebo::transport::SubscriberPtr game_state_sub_;
 
-  // Mongo stuff
-  mongo::DBClientBase *mongodb_;
-  std::map<std::string, mongo::GridFS *> mongogrids_;
+	// Mongo stuff
+	mongo::DBClientBase *                  mongodb_;
+	std::map<std::string, mongo::GridFS *> mongogrids_;
 
-  // handler functions
-  void on_game_state_msg(ConstGameStatePtr &msg);
+	// handler functions
+	void on_game_state_msg(ConstGameStatePtr &msg);
 
-  // statistics
-  std::string configuration_, replay_, namespace_, db_name_, collection_;
-  int run_;
-  int exp_points_cyan_, prod_points_cyan_;
-  int exp_points_magenta_, prod_points_magenta_;
-  bool written_;
+	// statistics
+	std::string configuration_, replay_, namespace_, db_name_, collection_;
+	int         run_;
+	int         exp_points_cyan_, prod_points_cyan_;
+	int         exp_points_magenta_, prod_points_magenta_;
+	bool        written_;
 
-  void write_statistics();
+	void write_statistics();
 };
 
 #endif

--- a/src/plugins/attic/gazebo/gazsim-machine-signal/gazsim_machine_signal_plugin.cpp
+++ b/src/plugins/attic/gazebo/gazsim-machine-signal/gazsim_machine_signal_plugin.cpp
@@ -19,9 +19,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "gazsim_machine_signal_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -30,14 +30,16 @@ using namespace fawkes;
  *
  * @author Frederik Zwilling
  */
-class GazsimMachineSignalPlugin : public fawkes::Plugin {
+class GazsimMachineSignalPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimMachineSignalPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new MachineSignalSimThread());
-  }
+	GazsimMachineSignalPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new MachineSignalSimThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Simulation of the MachineSignal Plugin results")

--- a/src/plugins/attic/gazebo/gazsim-machine-signal/gazsim_machine_signal_thread.cpp
+++ b/src/plugins/attic/gazebo/gazsim-machine-signal/gazsim_machine_signal_thread.cpp
@@ -21,17 +21,16 @@
 
 #include "gazsim_machine_signal_thread.h"
 
-#include <math.h>
-#include <stdio.h>
+#include <aspect/logging.h>
+#include <interfaces/RobotinoLightInterface.h>
 #include <tf/types.h>
 #include <utils/math/angle.h>
 
-#include <interfaces/RobotinoLightInterface.h>
-
-#include <aspect/logging.h>
 #include <gazebo/msgs/msgs.hh>
 #include <gazebo/transport/Node.hh>
 #include <gazebo/transport/transport.hh>
+#include <math.h>
+#include <stdio.h>
 
 using namespace fawkes;
 using namespace gazebo;
@@ -47,145 +46,134 @@ using namespace gazebo;
 
 /** Constructor. */
 MachineSignalSimThread::MachineSignalSimThread()
-    : Thread("MachineSignalSimThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS) {}
-
-void MachineSignalSimThread::init() {
-  logger->log_debug(name(),
-                    "Initializing Simulation of the Machine Signal Plugin");
-
-  // read config values
-  light_state_if_name_ =
-      config->get_string("/gazsim/light-front/interface-id-single");
-  switch_if_name_ =
-      config->get_string("/gazsim/light-front/interface-id-switch");
-  hint_if_name_ = config->get_string("/gazsim/light-front/interface-id-hint");
-  delivery_mode_if_name_ =
-      config->get_string("/gazsim/light-front/interface-id-delivery-switch");
-
-  // open interfaces
-  light_if_ = blackboard->open_for_writing<RobotinoLightInterface>(
-      light_state_if_name_.c_str());
-  switch_if_ = blackboard->open_for_writing<fawkes::SwitchInterface>(
-      switch_if_name_.c_str());
-  hint_if_ =
-      blackboard->open_for_writing<SignalHintInterface>(hint_if_name_.c_str());
-  delivery_if_ = blackboard->open_for_writing<fawkes::SwitchInterface>(
-      delivery_mode_if_name_.c_str());
-
-  // enable plugin by default
-  switch_if_->set_enabled(true);
-  switch_if_->write();
-
-  // subscribing to gazebo publisher
-  light_signals_sub_ = gazebonode->Subscribe(
-      config->get_string("/gazsim/topics/mps-machine-signal"),
-      &MachineSignalSimThread::on_light_signals_msg, this);
-
-  new_data_ = false;
+: Thread("MachineSignalSimThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS)
+{
 }
 
-void MachineSignalSimThread::finalize() {
-  blackboard->close(light_if_);
-  blackboard->close(switch_if_);
+void
+MachineSignalSimThread::init()
+{
+	logger->log_debug(name(), "Initializing Simulation of the Machine Signal Plugin");
+
+	// read config values
+	light_state_if_name_   = config->get_string("/gazsim/light-front/interface-id-single");
+	switch_if_name_        = config->get_string("/gazsim/light-front/interface-id-switch");
+	hint_if_name_          = config->get_string("/gazsim/light-front/interface-id-hint");
+	delivery_mode_if_name_ = config->get_string("/gazsim/light-front/interface-id-delivery-switch");
+
+	// open interfaces
+	light_if_  = blackboard->open_for_writing<RobotinoLightInterface>(light_state_if_name_.c_str());
+	switch_if_ = blackboard->open_for_writing<fawkes::SwitchInterface>(switch_if_name_.c_str());
+	hint_if_   = blackboard->open_for_writing<SignalHintInterface>(hint_if_name_.c_str());
+	delivery_if_ =
+	  blackboard->open_for_writing<fawkes::SwitchInterface>(delivery_mode_if_name_.c_str());
+
+	// enable plugin by default
+	switch_if_->set_enabled(true);
+	switch_if_->write();
+
+	// subscribing to gazebo publisher
+	light_signals_sub_ =
+	  gazebonode->Subscribe(config->get_string("/gazsim/topics/mps-machine-signal"),
+	                        &MachineSignalSimThread::on_light_signals_msg,
+	                        this);
+
+	new_data_ = false;
 }
 
-void MachineSignalSimThread::loop() {
-  // check messages of the switch interface
-  while (!switch_if_->msgq_empty()) {
-    if (SwitchInterface::DisableSwitchMessage *msg =
-            switch_if_->msgq_first_safe(msg)) {
-      switch_if_->set_enabled(false);
-    } else if (SwitchInterface::EnableSwitchMessage *msg =
-                   switch_if_->msgq_first_safe(msg)) {
-      switch_if_->set_enabled(true);
-    }
-    switch_if_->msgq_pop();
-    switch_if_->write();
-  }
-
-  // consume messages to the hint interface (they are not used in the
-  // simulation)
-  while (!hint_if_->msgq_empty()) {
-    hint_if_->msgq_pop();
-    hint_if_->write();
-  }
-  // consume messages to the delivery-mode interface (they are not used in the
-  // simulation)
-  while (!delivery_if_->msgq_empty()) {
-    delivery_if_->msgq_pop();
-    delivery_if_->write();
-  }
-
-  // write light interface
-  if (new_data_) {
-    new_data_ = false;
-
-    // stop if the switch is dibabled
-    if (!switch_if_->is_enabled()) {
-      return;
-    }
-
-    // set light interface according to the last message
-    set_interface();
-  }
+void
+MachineSignalSimThread::finalize()
+{
+	blackboard->close(light_if_);
+	blackboard->close(switch_if_);
 }
 
-void MachineSignalSimThread::on_light_signals_msg(
-    ConstLightSignalDetectionPtr &msg) {
-  // logger->log_info(name(), "Got new Machine Light signals.\n");
-  last_msg_.CopyFrom(*msg);
-  new_data_ = true;
+void
+MachineSignalSimThread::loop()
+{
+	// check messages of the switch interface
+	while (!switch_if_->msgq_empty()) {
+		if (SwitchInterface::DisableSwitchMessage *msg = switch_if_->msgq_first_safe(msg)) {
+			switch_if_->set_enabled(false);
+		} else if (SwitchInterface::EnableSwitchMessage *msg = switch_if_->msgq_first_safe(msg)) {
+			switch_if_->set_enabled(true);
+		}
+		switch_if_->msgq_pop();
+		switch_if_->write();
+	}
+
+	// consume messages to the hint interface (they are not used in the
+	// simulation)
+	while (!hint_if_->msgq_empty()) {
+		hint_if_->msgq_pop();
+		hint_if_->write();
+	}
+	// consume messages to the delivery-mode interface (they are not used in the
+	// simulation)
+	while (!delivery_if_->msgq_empty()) {
+		delivery_if_->msgq_pop();
+		delivery_if_->write();
+	}
+
+	// write light interface
+	if (new_data_) {
+		new_data_ = false;
+
+		// stop if the switch is dibabled
+		if (!switch_if_->is_enabled()) {
+			return;
+		}
+
+		// set light interface according to the last message
+		set_interface();
+	}
 }
 
-void MachineSignalSimThread::set_interface() {
-  // read out lights
-  fawkes::RobotinoLightInterface::LightState red = RobotinoLightInterface::OFF;
-  fawkes::RobotinoLightInterface::LightState yellow =
-      RobotinoLightInterface::OFF;
-  fawkes::RobotinoLightInterface::LightState green =
-      RobotinoLightInterface::OFF;
-  get_signals_from_msg(&red, &yellow, &green);
-
-  // write interface
-  light_if_->set_red(red);
-  light_if_->set_yellow(yellow);
-  light_if_->set_green(green);
-  light_if_->set_ready(last_msg_.visible());
-  light_if_->set_visibility_history(last_msg_.visibility_history());
-  light_if_->write();
+void
+MachineSignalSimThread::on_light_signals_msg(ConstLightSignalDetectionPtr &msg)
+{
+	// logger->log_info(name(), "Got new Machine Light signals.\n");
+	last_msg_.CopyFrom(*msg);
+	new_data_ = true;
 }
 
-void MachineSignalSimThread::get_signals_from_msg(
-    fawkes::RobotinoLightInterface::LightState *red,
-    fawkes::RobotinoLightInterface::LightState *yellow,
-    fawkes::RobotinoLightInterface::LightState *green) {
-  // read out lights
-  for (int i = 0; i < last_msg_.lights_size(); i++) {
-    gazsim_msgs::LightSignalDetection::LightSpec light_spec =
-        last_msg_.lights(i);
-    RobotinoLightInterface::LightState state = RobotinoLightInterface::OFF;
-    switch (light_spec.state()) {
-    case gazsim_msgs::LightSignalDetection::OFF:
-      state = RobotinoLightInterface::OFF;
-      break;
-    case gazsim_msgs::LightSignalDetection::ON:
-      state = RobotinoLightInterface::ON;
-      break;
-    case gazsim_msgs::LightSignalDetection::BLINK:
-      state = RobotinoLightInterface::BLINKING;
-      break;
-    }
-    switch (light_spec.color()) {
-    case gazsim_msgs::LightSignalDetection::RED:
-      *red = state;
-      break;
-    case gazsim_msgs::LightSignalDetection::YELLOW:
-      *yellow = state;
-      break;
-    case gazsim_msgs::LightSignalDetection::GREEN:
-      *green = state;
-      break;
-    }
-  }
+void
+MachineSignalSimThread::set_interface()
+{
+	// read out lights
+	fawkes::RobotinoLightInterface::LightState red    = RobotinoLightInterface::OFF;
+	fawkes::RobotinoLightInterface::LightState yellow = RobotinoLightInterface::OFF;
+	fawkes::RobotinoLightInterface::LightState green  = RobotinoLightInterface::OFF;
+	get_signals_from_msg(&red, &yellow, &green);
+
+	// write interface
+	light_if_->set_red(red);
+	light_if_->set_yellow(yellow);
+	light_if_->set_green(green);
+	light_if_->set_ready(last_msg_.visible());
+	light_if_->set_visibility_history(last_msg_.visibility_history());
+	light_if_->write();
+}
+
+void
+MachineSignalSimThread::get_signals_from_msg(fawkes::RobotinoLightInterface::LightState *red,
+                                             fawkes::RobotinoLightInterface::LightState *yellow,
+                                             fawkes::RobotinoLightInterface::LightState *green)
+{
+	// read out lights
+	for (int i = 0; i < last_msg_.lights_size(); i++) {
+		gazsim_msgs::LightSignalDetection::LightSpec light_spec = last_msg_.lights(i);
+		RobotinoLightInterface::LightState           state      = RobotinoLightInterface::OFF;
+		switch (light_spec.state()) {
+		case gazsim_msgs::LightSignalDetection::OFF: state = RobotinoLightInterface::OFF; break;
+		case gazsim_msgs::LightSignalDetection::ON: state = RobotinoLightInterface::ON; break;
+		case gazsim_msgs::LightSignalDetection::BLINK: state = RobotinoLightInterface::BLINKING; break;
+		}
+		switch (light_spec.color()) {
+		case gazsim_msgs::LightSignalDetection::RED: *red = state; break;
+		case gazsim_msgs::LightSignalDetection::YELLOW: *yellow = state; break;
+		case gazsim_msgs::LightSignalDetection::GREEN: *green = state; break;
+		}
+	}
 }

--- a/src/plugins/attic/gazebo/gazsim-machine-signal/gazsim_machine_signal_thread.h
+++ b/src/plugins/attic/gazebo/gazsim-machine-signal/gazsim_machine_signal_thread.h
@@ -22,6 +22,8 @@
 #ifndef __PLUGINS_GAZSIM_MACHINE_SIGNAL_THREAD_H_
 #define __PLUGINS_GAZSIM_MACHINE_SIGNAL_THREAD_H_
 
+#include "../msgs/LightSignalDetection.pb.h"
+
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/clock.h>
@@ -33,9 +35,8 @@
 #include <interfaces/SignalHintInterface.h>
 #include <interfaces/SwitchInterface.h>
 #include <plugins/gazebo/aspect/gazebo.h>
-#include <string.h>
 
-#include "../msgs/LightSignalDetection.pb.h"
+#include <string.h>
 
 // from Gazebo
 #include <gazebo/msgs/MessageTypes.hh>
@@ -43,7 +44,7 @@
 #include <gazebo/transport/transport.hh>
 
 typedef const boost::shared_ptr<gazsim_msgs::LightSignalDetection const>
-    ConstLightSignalDetectionPtr;
+  ConstLightSignalDetectionPtr;
 
 namespace fawkes {
 class RobotinoLightInterface;
@@ -55,46 +56,47 @@ class MachineSignalSimThread : public fawkes::Thread,
                                public fawkes::ConfigurableAspect,
                                public fawkes::BlackBoardAspect,
                                public fawkes::BlockedTimingAspect,
-                               public fawkes::GazeboAspect {
+                               public fawkes::GazeboAspect
+{
 public:
-  MachineSignalSimThread();
+	MachineSignalSimThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  // Subscriber to receive light signal data from gazebo
-  gazebo::transport::SubscriberPtr light_signals_sub_;
+	// Subscriber to receive light signal data from gazebo
+	gazebo::transport::SubscriberPtr light_signals_sub_;
 
-  // provided interfaces
-  fawkes::RobotinoLightInterface *light_if_;
-  fawkes::SwitchInterface *switch_if_;
-  fawkes::SignalHintInterface *hint_if_;
-  fawkes::SwitchInterface *delivery_if_;
+	// provided interfaces
+	fawkes::RobotinoLightInterface *light_if_;
+	fawkes::SwitchInterface *       switch_if_;
+	fawkes::SignalHintInterface *   hint_if_;
+	fawkes::SwitchInterface *       delivery_if_;
 
-  // handler function for incoming messages about the machine light signals
-  void on_light_signals_msg(ConstLightSignalDetectionPtr &msg);
+	// handler function for incoming messages about the machine light signals
+	void on_light_signals_msg(ConstLightSignalDetectionPtr &msg);
 
-  // copy of last msg to write the interface in the next loop
-  gazsim_msgs::LightSignalDetection last_msg_;
+	// copy of last msg to write the interface in the next loop
+	gazsim_msgs::LightSignalDetection last_msg_;
 
-  /// set the light interface to the signal state nearest to the cluster
-  /// position
-  void set_interface();
+	/// set the light interface to the signal state nearest to the cluster
+	/// position
+	void set_interface();
 
-  /// get light signals of a machine from msg (returns values by reference)
-  void get_signals_from_msg(fawkes::RobotinoLightInterface::LightState *red,
-                            fawkes::RobotinoLightInterface::LightState *yellow,
-                            fawkes::RobotinoLightInterface::LightState *green);
+	/// get light signals of a machine from msg (returns values by reference)
+	void get_signals_from_msg(fawkes::RobotinoLightInterface::LightState *red,
+	                          fawkes::RobotinoLightInterface::LightState *yellow,
+	                          fawkes::RobotinoLightInterface::LightState *green);
 
-  std::string light_state_if_name_;
-  std::string switch_if_name_;
-  std::string hint_if_name_;
-  std::string delivery_mode_if_name_;
+	std::string light_state_if_name_;
+	std::string switch_if_name_;
+	std::string hint_if_name_;
+	std::string delivery_mode_if_name_;
 
-  // interface values to write in the next loop
-  bool new_data_;
+	// interface values to write in the next loop
+	bool new_data_;
 };
 
 #endif

--- a/src/plugins/attic/gazebo/gazsim-puck-detection/gazsim_puck_detection_plugin.cpp
+++ b/src/plugins/attic/gazebo/gazsim-puck-detection/gazsim_puck_detection_plugin.cpp
@@ -19,9 +19,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "gazsim_puck_detection_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -30,14 +30,16 @@ using namespace fawkes;
  *
  * @author Frederik Zwilling
  */
-class GazsimPuckDetectionPlugin : public fawkes::Plugin {
+class GazsimPuckDetectionPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimPuckDetectionPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new PuckDetectionSimThread());
-  }
+	GazsimPuckDetectionPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new PuckDetectionSimThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Simulation of the Omnivision Puck Detection Results")

--- a/src/plugins/attic/gazebo/gazsim-puck-detection/gazsim_puck_detection_thread.cpp
+++ b/src/plugins/attic/gazebo/gazsim-puck-detection/gazsim_puck_detection_thread.cpp
@@ -21,20 +21,19 @@
 
 #include "gazsim_puck_detection_thread.h"
 
+#include <aspect/logging.h>
+#include <interfaces/Position3DInterface.h>
+#include <interfaces/SwitchInterface.h>
+#include <llsf_msgs/Pose2D.pb.h>
+#include <tf/types.h>
+
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/transport/Node.hh>
+#include <gazebo/transport/transport.hh>
 #include <math.h>
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
-#include <tf/types.h>
-
-#include <interfaces/Position3DInterface.h>
-#include <interfaces/SwitchInterface.h>
-#include <llsf_msgs/Pose2D.pb.h>
-
-#include <aspect/logging.h>
-#include <gazebo/msgs/msgs.hh>
-#include <gazebo/transport/Node.hh>
-#include <gazebo/transport/transport.hh>
 
 using namespace fawkes;
 using namespace gazebo;
@@ -47,123 +46,121 @@ using namespace gazebo;
 
 /** Constructor. */
 PuckDetectionSimThread::PuckDetectionSimThread()
-    : Thread("PuckDetectionSimThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS) {}
-
-void PuckDetectionSimThread::init() {
-  logger->log_debug(name(),
-                    "Initializing Simulation of the Puck Detection Plugin");
-
-  // read config values
-  max_distance_ = config->get_float("/gazsim/puck-detection/max-distance");
-  success_visibility_history_ =
-      config->get_int("/gazsim/puck-detection/success-visibility-history");
-  fail_visibility_history_ =
-      config->get_int("/gazsim/puck-detection/fail-visibility-history");
-  number_pucks_ = config->get_float("/gazsim/puck-detection/number-pucks");
-  use_switch_interface_ =
-      config->get_bool("/gazsim/puck-detection/use-switch-interface");
-  is_omni_directional_ =
-      config->get_bool("/gazsim/puck-detection/is-omni-directional");
-  max_fov_angle_ = config->get_float("/gazsim/puck-detection/max-fov-angle");
-  number_interfaces_ =
-      config->get_int("/gazsim/puck-detection/number-interfaces");
-
-  // open interfaces (puck enumeration starts with 1)
-  for (int i = 0; i < number_interfaces_; i++) {
-    printf("Opening interface puck_%d\n", i);
-    std::ostringstream ss;
-    ss << "puck_" << i;
-    map_pos_if_[i] = blackboard->open_for_writing<fawkes::Position3DInterface>(
-        ss.str().c_str());
-  }
-  switch_if_ =
-      blackboard->open_for_writing<fawkes::SwitchInterface>("omnivisionSwitch");
-
-  // subscribing to gazebo publisher
-  puck_positions_sub_ = gazebonode->Subscribe(
-      config->get_string("/gazsim/topics/puck-detection"),
-      &PuckDetectionSimThread::on_puck_positions_msg, this);
-
-  new_data_ = false;
+: Thread("PuckDetectionSimThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS)
+{
 }
 
-void PuckDetectionSimThread::finalize() {
-  for (std::map<int, Position3DInterface *>::iterator it = map_pos_if_.begin();
-       it != map_pos_if_.end(); it++) {
-    blackboard->close(it->second);
-  }
-  blackboard->close(switch_if_);
+void
+PuckDetectionSimThread::init()
+{
+	logger->log_debug(name(), "Initializing Simulation of the Puck Detection Plugin");
+
+	// read config values
+	max_distance_ = config->get_float("/gazsim/puck-detection/max-distance");
+	success_visibility_history_ =
+	  config->get_int("/gazsim/puck-detection/success-visibility-history");
+	fail_visibility_history_ = config->get_int("/gazsim/puck-detection/fail-visibility-history");
+	number_pucks_            = config->get_float("/gazsim/puck-detection/number-pucks");
+	use_switch_interface_    = config->get_bool("/gazsim/puck-detection/use-switch-interface");
+	is_omni_directional_     = config->get_bool("/gazsim/puck-detection/is-omni-directional");
+	max_fov_angle_           = config->get_float("/gazsim/puck-detection/max-fov-angle");
+	number_interfaces_       = config->get_int("/gazsim/puck-detection/number-interfaces");
+
+	// open interfaces (puck enumeration starts with 1)
+	for (int i = 0; i < number_interfaces_; i++) {
+		printf("Opening interface puck_%d\n", i);
+		std::ostringstream ss;
+		ss << "puck_" << i;
+		map_pos_if_[i] = blackboard->open_for_writing<fawkes::Position3DInterface>(ss.str().c_str());
+	}
+	switch_if_ = blackboard->open_for_writing<fawkes::SwitchInterface>("omnivisionSwitch");
+
+	// subscribing to gazebo publisher
+	puck_positions_sub_ = gazebonode->Subscribe(config->get_string("/gazsim/topics/puck-detection"),
+	                                            &PuckDetectionSimThread::on_puck_positions_msg,
+	                                            this);
+
+	new_data_ = false;
 }
 
-void PuckDetectionSimThread::loop() {
-  // check messages of the switch interface
-  while (!switch_if_->msgq_empty()) {
-    if (SwitchInterface::DisableSwitchMessage *msg =
-            switch_if_->msgq_first_safe(msg)) {
-      switch_if_->set_enabled(false);
-    } else if (SwitchInterface::EnableSwitchMessage *msg =
-                   switch_if_->msgq_first_safe(msg)) {
-      switch_if_->set_enabled(true);
-    }
-    switch_if_->msgq_pop();
-    switch_if_->write();
-  }
-
-  if (new_data_) {
-    new_data_ = false;
-    // Only write the interface if the switch is enabled
-    if (!switch_if_->is_enabled() && use_switch_interface_) {
-      std::list<fawkes::Position3DInterface *>::iterator puck;
-      for (std::map<int, Position3DInterface *>::iterator it =
-               map_pos_if_.begin();
-           it != map_pos_if_.end(); it++) {
-        it->second->set_visibility_history(0);
-        it->second->write();
-      }
-      return;
-    }
-    int num_interface = 0;
-    // find all pucks in perception range
-    for (int i = 0;
-         i < last_msg_.positions_size() && num_interface < number_interfaces_;
-         i++) {
-      llsf_msgs::Pose2D pose = last_msg_.positions(i);
-      // check if the puck is in detection range
-      if (is_in_perception_area(pose.x(), pose.y())) {
-        map_pos_if_[num_interface]->set_translation(0, pose.x());
-        map_pos_if_[num_interface]->set_translation(1, pose.y());
-        map_pos_if_[num_interface]->set_translation(2, 0);
-        map_pos_if_[num_interface]->set_visibility_history(
-            success_visibility_history_);
-        map_pos_if_[num_interface]->set_frame("/base_link");
-        map_pos_if_[num_interface]->write();
-        num_interface++;
-      }
-    }
-    // clear remaining interfaces
-    for (; num_interface < number_interfaces_; num_interface++) {
-      map_pos_if_[num_interface]->set_visibility_history(
-          fail_visibility_history_);
-      map_pos_if_[num_interface]->set_frame("/base_link");
-      map_pos_if_[num_interface]->write();
-    }
-  }
+void
+PuckDetectionSimThread::finalize()
+{
+	for (std::map<int, Position3DInterface *>::iterator it = map_pos_if_.begin();
+	     it != map_pos_if_.end();
+	     it++) {
+		blackboard->close(it->second);
+	}
+	blackboard->close(switch_if_);
 }
 
-void PuckDetectionSimThread::on_puck_positions_msg(
-    ConstPuckDetectionResultPtr &msg) {
-  // logger->log_info(name(), "Got new Puck Positions.\n");
-  last_msg_.CopyFrom(*msg);
-  new_data_ = true;
+void
+PuckDetectionSimThread::loop()
+{
+	// check messages of the switch interface
+	while (!switch_if_->msgq_empty()) {
+		if (SwitchInterface::DisableSwitchMessage *msg = switch_if_->msgq_first_safe(msg)) {
+			switch_if_->set_enabled(false);
+		} else if (SwitchInterface::EnableSwitchMessage *msg = switch_if_->msgq_first_safe(msg)) {
+			switch_if_->set_enabled(true);
+		}
+		switch_if_->msgq_pop();
+		switch_if_->write();
+	}
+
+	if (new_data_) {
+		new_data_ = false;
+		// Only write the interface if the switch is enabled
+		if (!switch_if_->is_enabled() && use_switch_interface_) {
+			std::list<fawkes::Position3DInterface *>::iterator puck;
+			for (std::map<int, Position3DInterface *>::iterator it = map_pos_if_.begin();
+			     it != map_pos_if_.end();
+			     it++) {
+				it->second->set_visibility_history(0);
+				it->second->write();
+			}
+			return;
+		}
+		int num_interface = 0;
+		// find all pucks in perception range
+		for (int i = 0; i < last_msg_.positions_size() && num_interface < number_interfaces_; i++) {
+			llsf_msgs::Pose2D pose = last_msg_.positions(i);
+			// check if the puck is in detection range
+			if (is_in_perception_area(pose.x(), pose.y())) {
+				map_pos_if_[num_interface]->set_translation(0, pose.x());
+				map_pos_if_[num_interface]->set_translation(1, pose.y());
+				map_pos_if_[num_interface]->set_translation(2, 0);
+				map_pos_if_[num_interface]->set_visibility_history(success_visibility_history_);
+				map_pos_if_[num_interface]->set_frame("/base_link");
+				map_pos_if_[num_interface]->write();
+				num_interface++;
+			}
+		}
+		// clear remaining interfaces
+		for (; num_interface < number_interfaces_; num_interface++) {
+			map_pos_if_[num_interface]->set_visibility_history(fail_visibility_history_);
+			map_pos_if_[num_interface]->set_frame("/base_link");
+			map_pos_if_[num_interface]->write();
+		}
+	}
 }
 
-bool PuckDetectionSimThread::is_in_perception_area(float x, float y) {
-  double distance = sqrt(x * x + y * y);
-  if (is_omni_directional_) {
-    return distance < max_distance_;
-  } else {
-    return distance < max_distance_ && x > 0 &&
-           fabs(atan(y / x)) < max_fov_angle_;
-  }
+void
+PuckDetectionSimThread::on_puck_positions_msg(ConstPuckDetectionResultPtr &msg)
+{
+	// logger->log_info(name(), "Got new Puck Positions.\n");
+	last_msg_.CopyFrom(*msg);
+	new_data_ = true;
+}
+
+bool
+PuckDetectionSimThread::is_in_perception_area(float x, float y)
+{
+	double distance = sqrt(x * x + y * y);
+	if (is_omni_directional_) {
+		return distance < max_distance_;
+	} else {
+		return distance < max_distance_ && x > 0 && fabs(atan(y / x)) < max_fov_angle_;
+	}
 }

--- a/src/plugins/attic/gazebo/gazsim-puck-detection/gazsim_puck_detection_thread.h
+++ b/src/plugins/attic/gazebo/gazsim-puck-detection/gazsim_puck_detection_thread.h
@@ -20,27 +20,27 @@
  */
 
 #ifndef __PLUGINS_GAZSIM_PUCK_DETECTION_THREAD_H_
-#define __PLUGINS_GAZSIM_LIGHT_FRONT_THREAD_H_
+#	define __PLUGINS_GAZSIM_LIGHT_FRONT_THREAD_H_
 
-#include <aspect/blackboard.h>
-#include <aspect/blocked_timing.h>
-#include <aspect/clock.h>
-#include <aspect/configurable.h>
-#include <aspect/logging.h>
-#include <core/threading/thread.h>
-#include <interfaces/Position3DInterface.h>
-#include <interfaces/SwitchInterface.h>
-#include <llsf_msgs/PuckDetectionResult.pb.h>
-#include <map>
-#include <plugins/gazebo/aspect/gazebo.h>
+#	include <aspect/blackboard.h>
+#	include <aspect/blocked_timing.h>
+#	include <aspect/clock.h>
+#	include <aspect/configurable.h>
+#	include <aspect/logging.h>
+#	include <core/threading/thread.h>
+#	include <interfaces/Position3DInterface.h>
+#	include <interfaces/SwitchInterface.h>
+#	include <llsf_msgs/PuckDetectionResult.pb.h>
+#	include <plugins/gazebo/aspect/gazebo.h>
+
+#	include <map>
 
 // from Gazebo
-#include <gazebo/msgs/MessageTypes.hh>
-#include <gazebo/transport/TransportTypes.hh>
-#include <gazebo/transport/transport.hh>
+#	include <gazebo/msgs/MessageTypes.hh>
+#	include <gazebo/transport/TransportTypes.hh>
+#	include <gazebo/transport/transport.hh>
 
-typedef const boost::shared_ptr<llsf_msgs::PuckDetectionResult const>
-    ConstPuckDetectionResultPtr;
+typedef const boost::shared_ptr<llsf_msgs::PuckDetectionResult const> ConstPuckDetectionResultPtr;
 
 namespace fawkes {
 class Position3DInterface;
@@ -52,43 +52,44 @@ class PuckDetectionSimThread : public fawkes::Thread,
                                public fawkes::ConfigurableAspect,
                                public fawkes::BlackBoardAspect,
                                public fawkes::BlockedTimingAspect,
-                               public fawkes::GazeboAspect {
+                               public fawkes::GazeboAspect
+{
 public:
-  PuckDetectionSimThread();
+	PuckDetectionSimThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  // Subscriber to receive puck positions from gazebo
-  gazebo::transport::SubscriberPtr puck_positions_sub_;
+	// Subscriber to receive puck positions from gazebo
+	gazebo::transport::SubscriberPtr puck_positions_sub_;
 
-  // interfaces to publish the positions
-  std::map<int, fawkes::Position3DInterface *> map_pos_if_;
-  // switch interface for enableing/disableing
-  fawkes::SwitchInterface *switch_if_;
+	// interfaces to publish the positions
+	std::map<int, fawkes::Position3DInterface *> map_pos_if_;
+	// switch interface for enableing/disableing
+	fawkes::SwitchInterface *switch_if_;
 
-  // handler function for incoming messages about the machine light signals
-  void on_puck_positions_msg(ConstPuckDetectionResultPtr &msg);
+	// handler function for incoming messages about the machine light signals
+	void on_puck_positions_msg(ConstPuckDetectionResultPtr &msg);
 
-  // can the position of the puck be recognized by the sensor?
-  bool is_in_perception_area(float x, float y);
+	// can the position of the puck be recognized by the sensor?
+	bool is_in_perception_area(float x, float y);
 
-  // config values:
-  // maximal distance before the plugin says it can not detect the puck
-  double max_distance_;
-  int success_visibility_history_;
-  int fail_visibility_history_;
-  int number_pucks_;
-  int number_interfaces_;
-  bool use_switch_interface_;
-  bool is_omni_directional_;
-  float max_fov_angle_;
+	// config values:
+	// maximal distance before the plugin says it can not detect the puck
+	double max_distance_;
+	int    success_visibility_history_;
+	int    fail_visibility_history_;
+	int    number_pucks_;
+	int    number_interfaces_;
+	bool   use_switch_interface_;
+	bool   is_omni_directional_;
+	float  max_fov_angle_;
 
-  // copy of last msg to write the interface in the next loop
-  llsf_msgs::PuckDetectionResult last_msg_;
-  bool new_data_;
+	// copy of last msg to write the interface in the next loop
+	llsf_msgs::PuckDetectionResult last_msg_;
+	bool                           new_data_;
 };
 
 #endif

--- a/src/plugins/attic/laser_sim/laser_sim_plugin.cpp
+++ b/src/plugins/attic/laser_sim/laser_sim_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "laser_sim_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Template! Makes the robotino move forward for 3 seconds
  * @author Daniel Ewert
  */
-class LaserSimPlugin : public fawkes::Plugin {
+class LaserSimPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  LaserSimPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new LaserSim());
-  }
+	LaserSimPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new LaserSim());
+	}
 };
 
 PLUGIN_DESCRIPTION("simple laser simulation")

--- a/src/plugins/attic/laser_sim/laser_sim_thread.cpp
+++ b/src/plugins/attic/laser_sim/laser_sim_thread.cpp
@@ -25,11 +25,10 @@
 #include <interfaces/Position3DInterface.h>
 
 #include <algorithm>
-#include <utility>
-#include <vector>
-
 #include <cfloat>
 #include <cmath>
+#include <utility>
+#include <vector>
 
 #define CFG_PREFIX "/plugins/LaserSim/"
 #define NOISE 0.01f
@@ -48,54 +47,66 @@ using namespace std;
 
 /** Constructor. */
 LaserSim::LaserSim()
-    : Thread("MachinePositionerThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL) {}
-
-void LaserSim::init() {
-  logger->log_info(name(), "Laser_Sim starts up");
-  laser_if_ = blackboard->open_for_writing<Laser360Interface>("Laser sim");
+: Thread("MachinePositionerThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
 }
 
-bool LaserSim::prepare_finalize_user() { return true; }
-
-void LaserSim::finalize() { blackboard->close(laser_if_); }
-
-void LaserSim::add_cluster_at(unsigned int angle_of_center, unsigned int size,
-                              float distance) {
-  // adding some noise
-  switch (rand() % 50) {
-  case 0:
-    angle_of_center++;
-    break;
-  case 1:
-    angle_of_center--;
-    break;
-  default:
-    break;
-  }
-
-  for (unsigned int i = 0; i < size; ++i) {
-    int angle = (i + angle_of_center) - size / 2;
-
-    if (angle >= 360)
-      angle -= 360;
-    else if (angle < 0)
-      angle += 360;
-    laser_if_->set_distances(angle, add_noise(distance));
-  }
+void
+LaserSim::init()
+{
+	logger->log_info(name(), "Laser_Sim starts up");
+	laser_if_ = blackboard->open_for_writing<Laser360Interface>("Laser sim");
 }
 
-void LaserSim::loop() {
-  for (unsigned int i = 0; i < 360; ++i) {
-    laser_if_->set_distances(i, add_noise(BASE_DIST));
-  }
-  add_cluster_at(CLUSTER_LOC, CLUSTER_SIZE, CLUSTER_DIST);
-  // INTERESTING: Lasergui doesn't show the 0 value, and allows [0-360]
-  // entries..
-  laser_if_->write();
+bool
+LaserSim::prepare_finalize_user()
+{
+	return true;
 }
 
-float LaserSim::add_noise(float base) {
-  double noise = (drand48() * NOISE * 2) - NOISE;
-  return (float)noise + base;
+void
+LaserSim::finalize()
+{
+	blackboard->close(laser_if_);
+}
+
+void
+LaserSim::add_cluster_at(unsigned int angle_of_center, unsigned int size, float distance)
+{
+	// adding some noise
+	switch (rand() % 50) {
+	case 0: angle_of_center++; break;
+	case 1: angle_of_center--; break;
+	default: break;
+	}
+
+	for (unsigned int i = 0; i < size; ++i) {
+		int angle = (i + angle_of_center) - size / 2;
+
+		if (angle >= 360)
+			angle -= 360;
+		else if (angle < 0)
+			angle += 360;
+		laser_if_->set_distances(angle, add_noise(distance));
+	}
+}
+
+void
+LaserSim::loop()
+{
+	for (unsigned int i = 0; i < 360; ++i) {
+		laser_if_->set_distances(i, add_noise(BASE_DIST));
+	}
+	add_cluster_at(CLUSTER_LOC, CLUSTER_SIZE, CLUSTER_DIST);
+	// INTERESTING: Lasergui doesn't show the 0 value, and allows [0-360]
+	// entries..
+	laser_if_->write();
+}
+
+float
+LaserSim::add_noise(float base)
+{
+	double noise = (drand48() * NOISE * 2) - NOISE;
+	return (float)noise + base;
 }

--- a/src/plugins/attic/laser_sim/laser_sim_thread.h
+++ b/src/plugins/attic/laser_sim/laser_sim_thread.h
@@ -41,29 +41,33 @@ class LaserSim : public fawkes::Thread,
                  public fawkes::BlockedTimingAspect,
                  public fawkes::LoggingAspect,
                  public fawkes::ConfigurableAspect,
-                 public fawkes::BlackBoardAspect {
-
+                 public fawkes::BlackBoardAspect
+{
 public:
-  LaserSim();
+	LaserSim();
 
-  virtual void init();
-  virtual void loop();
-  virtual bool prepare_finalize_user();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual bool prepare_finalize_user();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  void add_cluster_at(unsigned int angle, unsigned int size, float distance);
-  float add_noise(float base);
+	void  add_cluster_at(unsigned int angle, unsigned int size, float distance);
+	float add_noise(float base);
 
 private:
-  fawkes::Laser360Interface *laser_if_;
+	fawkes::Laser360Interface *laser_if_;
 
-  float laser_scan_[360];
-  unsigned int num_scans_;
+	float        laser_scan_[360];
+	unsigned int num_scans_;
 };
 
 #endif

--- a/src/plugins/attic/light_compass/ColorModelRange.cpp
+++ b/src/plugins/attic/light_compass/ColorModelRange.cpp
@@ -22,9 +22,9 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#include <iostream>
-
 #include "ColorModelRange.h"
+
+#include <iostream>
 
 using namespace std;
 
@@ -38,38 +38,48 @@ namespace firevision {
  * just for initial development of color models.
  */
 
-ColorModelRange::ColorModelRange(unsigned int y_min, unsigned int y_max,
-                                 unsigned int u_min, unsigned int u_max,
-                                 unsigned int v_min, unsigned int v_max) {
-  threshold_y_low_ = y_min;
-  threshold_y_high_ = y_max;
-  threshold_u_low_ = u_min;
-  threshold_v_low_ = u_max;
-  threshold_u_high_ = v_min;
-  threshold_v_high_ = v_max;
+ColorModelRange::ColorModelRange(unsigned int y_min,
+                                 unsigned int y_max,
+                                 unsigned int u_min,
+                                 unsigned int u_max,
+                                 unsigned int v_min,
+                                 unsigned int v_max)
+{
+	threshold_y_low_  = y_min;
+	threshold_y_high_ = y_max;
+	threshold_u_low_  = u_min;
+	threshold_v_low_  = u_max;
+	threshold_u_high_ = v_min;
+	threshold_v_high_ = v_max;
 }
 
-color_t ColorModelRange::determine(unsigned int y, unsigned int u,
-                                   unsigned int v) const {
-  if (y >= threshold_y_low_ && y <= threshold_y_high_ &&
-      u >= threshold_u_low_ && u <= threshold_u_high_ &&
-      v >= threshold_v_low_ && v <= threshold_v_high_) {
-    return C_WHITE;
-  } else {
-    return C_OTHER;
-  }
+color_t
+ColorModelRange::determine(unsigned int y, unsigned int u, unsigned int v) const
+{
+	if (y >= threshold_y_low_ && y <= threshold_y_high_ && u >= threshold_u_low_
+	    && u <= threshold_u_high_ && v >= threshold_v_low_ && v <= threshold_v_high_) {
+		return C_WHITE;
+	} else {
+		return C_OTHER;
+	}
 }
 
-const char *ColorModelRange::get_name() { return "ColorModelRange"; }
+const char *
+ColorModelRange::get_name()
+{
+	return "ColorModelRange";
+}
 
 /** Print the thresholds to stdout.
  */
-void ColorModelRange::print_thresholds() {
-  cout << get_name() << endl
-       << "==========================================================" << endl
-       << "y: " << threshold_y_low_ << " - " << threshold_y_high_
-       << "u: " << threshold_y_low_ << " - " << threshold_y_high_
-       << "v: " << threshold_y_low_ << " - " << threshold_y_high_ << endl;
+void
+ColorModelRange::print_thresholds()
+{
+	cout << get_name() << endl
+	     << "==========================================================" << endl
+	     << "y: " << threshold_y_low_ << " - " << threshold_y_high_ << "u: " << threshold_y_low_
+	     << " - " << threshold_y_high_ << "v: " << threshold_y_low_ << " - " << threshold_y_high_
+	     << endl;
 }
 
 } // end namespace firevision

--- a/src/plugins/attic/light_compass/ColorModelRange.h
+++ b/src/plugins/attic/light_compass/ColorModelRange.h
@@ -37,23 +37,28 @@ namespace firevision {
    It is assumed that the Y-, U- and V-components range from 0 to 255 each,
    and that (0, 0) is at the lower left corner. */
 
-class ColorModelRange : public ColorModel {
+class ColorModelRange : public ColorModel
+{
 public:
-  ColorModelRange(unsigned int y_min, unsigned int y_max, unsigned int u_min,
-                  unsigned int u_max, unsigned int v_min, unsigned int v_max);
+	ColorModelRange(unsigned int y_min,
+	                unsigned int y_max,
+	                unsigned int u_min,
+	                unsigned int u_max,
+	                unsigned int v_min,
+	                unsigned int v_max);
 
-  color_t determine(unsigned int y, unsigned int u, unsigned int v) const;
+	color_t determine(unsigned int y, unsigned int u, unsigned int v) const;
 
-  const char *get_name();
-  void print_thresholds();
+	const char *get_name();
+	void        print_thresholds();
 
 private:
-  unsigned int threshold_y_low_;
-  unsigned int threshold_u_low_;
-  unsigned int threshold_v_low_;
-  unsigned int threshold_y_high_;
-  unsigned int threshold_u_high_;
-  unsigned int threshold_v_high_;
+	unsigned int threshold_y_low_;
+	unsigned int threshold_u_low_;
+	unsigned int threshold_v_low_;
+	unsigned int threshold_y_high_;
+	unsigned int threshold_u_high_;
+	unsigned int threshold_v_high_;
 };
 
 } // end namespace firevision

--- a/src/plugins/attic/light_compass/light_compass.cpp
+++ b/src/plugins/attic/light_compass/light_compass.cpp
@@ -20,9 +20,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "light_compass_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -30,14 +30,16 @@ using namespace fawkes;
  * the nearest light
  * @author Florian Nolden & Tobias Neumann
  */
-class LightCompassPlugin : public fawkes::Plugin {
+class LightCompassPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  LightCompassPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new LightCompassThread());
-  }
+	LightCompassPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new LightCompassThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Gives the distance and direction of the nearest light ")

--- a/src/plugins/attic/light_compass/light_compass_thread.cpp
+++ b/src/plugins/attic/light_compass/light_compass_thread.cpp
@@ -33,457 +33,446 @@ using namespace fawkes;
 
 /** Constructor. */
 LightCompassThread::LightCompassThread()
-    : Thread("LightCompassThread", Thread::OPMODE_WAITFORWAKEUP),
-      VisionAspect(VisionAspect::CYCLIC) {
+: Thread("LightCompassThread", Thread::OPMODE_WAITFORWAKEUP), VisionAspect(VisionAspect::CYCLIC)
+{
+	this->scanline_           = NULL;
+	this->mirror_             = NULL;
+	this->rel_pos_            = NULL;
+	this->classifierExpected_ = NULL;
+	this->colorModel_         = NULL;
+	this->shm_buffer_filtered = NULL;
 
-  this->scanline_ = NULL;
-  this->mirror_ = NULL;
-  this->rel_pos_ = NULL;
-  this->classifierExpected_ = NULL;
-  this->colorModel_ = NULL;
-  this->shm_buffer_filtered = NULL;
+	this->cspace_to_ = firevision::YUV422_PLANAR;
 
-  this->cspace_to_ = firevision::YUV422_PLANAR;
-
-  this->cfg_color_y_min = 0;
-  this->cfg_color_y_max = 0;
-  this->cfg_color_u_min = 0;
-  this->cfg_color_u_max = 0;
-  this->cfg_color_v_min = 0;
-  this->cfg_color_v_max = 0;
+	this->cfg_color_y_min = 0;
+	this->cfg_color_y_max = 0;
+	this->cfg_color_u_min = 0;
+	this->cfg_color_u_max = 0;
+	this->cfg_color_v_min = 0;
+	this->cfg_color_v_max = 0;
 }
 
-void LightCompassThread::init() {
-  logger->log_info(name(), "starts up");
+void
+LightCompassThread::init()
+{
+	logger->log_info(name(), "starts up");
 
-  this->cfg_prefix_ = "/plugins/light_compass/";
-  this->cfg_camera_ =
-      this->config->get_string((cfg_prefix_ + "camera").c_str());
-  this->cfg_mirror_file_ =
-      std::string(CONFDIR) + "/" +
-      this->config->get_string((cfg_prefix_ + "mirror_file").c_str());
-  this->cfg_frame_ = this->config->get_string((cfg_prefix_ + "frame").c_str());
+	this->cfg_prefix_ = "/plugins/light_compass/";
+	this->cfg_camera_ = this->config->get_string((cfg_prefix_ + "camera").c_str());
+	this->cfg_mirror_file_ =
+	  std::string(CONFDIR) + "/" + this->config->get_string((cfg_prefix_ + "mirror_file").c_str());
+	this->cfg_frame_ = this->config->get_string((cfg_prefix_ + "frame").c_str());
 
-  this->cfg_mirror_height =
-      this->config->get_float((cfg_prefix_ + "mirror_height").c_str());
-  this->cfg_robot_radius_ =
-      this->config->get_float((cfg_prefix_ + "robot_radius").c_str());
+	this->cfg_mirror_height = this->config->get_float((cfg_prefix_ + "mirror_height").c_str());
+	this->cfg_robot_radius_ = this->config->get_float((cfg_prefix_ + "robot_radius").c_str());
 
-  this->cfg_red_height_ =
-      this->config->get_float((cfg_prefix_ + "red_height").c_str());
-  this->cfg_orange_height_ =
-      this->config->get_float((cfg_prefix_ + "orange_height").c_str());
-  this->cfg_green_height_ =
-      this->config->get_float((cfg_prefix_ + "green_height").c_str());
+	this->cfg_red_height_    = this->config->get_float((cfg_prefix_ + "red_height").c_str());
+	this->cfg_orange_height_ = this->config->get_float((cfg_prefix_ + "orange_height").c_str());
+	this->cfg_green_height_  = this->config->get_float((cfg_prefix_ + "green_height").c_str());
 
-  this->cfg_useBulbFile_ =
-      this->config->get_bool((cfg_prefix_ + "mirror_correction").c_str());
-  ;
-  this->cfg_debugOutput_ =
-      this->config->get_bool((cfg_prefix_ + "debug").c_str());
-  ;
+	this->cfg_useBulbFile_ = this->config->get_bool((cfg_prefix_ + "mirror_correction").c_str());
+	;
+	this->cfg_debugOutput_ = this->config->get_bool((cfg_prefix_ + "debug").c_str());
+	;
 
-  this->cfg_threashold_roiMaxSize_ =
-      this->config->get_uint((cfg_prefix_ + "threashold_roiMaxSize").c_str());
+	this->cfg_threashold_roiMaxSize_ =
+	  this->config->get_uint((cfg_prefix_ + "threashold_roiMaxSize").c_str());
 
-  this->cfg_lightDistanceAllowedBetweenFrames = this->config->get_float(
-      (cfg_prefix_ + "light_distance_allowed_betwen_frames").c_str());
+	this->cfg_lightDistanceAllowedBetweenFrames =
+	  this->config->get_float((cfg_prefix_ + "light_distance_allowed_betwen_frames").c_str());
 
-  this->cfg_color_y_min =
-      this->config->get_uint((this->cfg_prefix_ + "color_y_min").c_str());
-  this->cfg_color_y_max =
-      this->config->get_uint((this->cfg_prefix_ + "color_y_max").c_str());
-  this->cfg_color_u_min =
-      this->config->get_uint((this->cfg_prefix_ + "color_u_min").c_str());
-  this->cfg_color_u_max =
-      this->config->get_uint((this->cfg_prefix_ + "color_u_max").c_str());
-  this->cfg_color_v_min =
-      this->config->get_uint((this->cfg_prefix_ + "color_v_min").c_str());
-  this->cfg_color_v_max =
-      this->config->get_uint((this->cfg_prefix_ + "color_v_max").c_str());
+	this->cfg_color_y_min = this->config->get_uint((this->cfg_prefix_ + "color_y_min").c_str());
+	this->cfg_color_y_max = this->config->get_uint((this->cfg_prefix_ + "color_y_max").c_str());
+	this->cfg_color_u_min = this->config->get_uint((this->cfg_prefix_ + "color_u_min").c_str());
+	this->cfg_color_u_max = this->config->get_uint((this->cfg_prefix_ + "color_u_max").c_str());
+	this->cfg_color_v_min = this->config->get_uint((this->cfg_prefix_ + "color_v_min").c_str());
+	this->cfg_color_v_max = this->config->get_uint((this->cfg_prefix_ + "color_v_max").c_str());
 
-  this->lightif =
-      blackboard->open_for_writing<Position3DInterface>("nearest_light_on");
-  this->lightif->set_frame(this->cfg_frame_.c_str());
-  this->lightif->set_visibility_history(-1);
-  this->lightif->write();
+	this->lightif = blackboard->open_for_writing<Position3DInterface>("nearest_light_on");
+	this->lightif->set_frame(this->cfg_frame_.c_str());
+	this->lightif->set_visibility_history(-1);
+	this->lightif->write();
 
-  this->cam_ =
-      vision_master->register_for_camera(this->cfg_camera_.c_str(), this);
-  this->img_width_ = this->cam_->pixel_width();
-  this->img_height_ = this->cam_->pixel_height();
-  this->cspace_from_ = this->cam_->colorspace();
+	this->cam_         = vision_master->register_for_camera(this->cfg_camera_.c_str(), this);
+	this->img_width_   = this->cam_->pixel_width();
+	this->img_height_  = this->cam_->pixel_height();
+	this->cspace_from_ = this->cam_->colorspace();
 
-  // scanline_ model
-  this->scanline_ =
-      new firevision::ScanlineRadial(this->img_width_, this->img_height_,
-                                     this->img_width_ / 2,  // center width
-                                     this->img_height_ / 2, // center height
-                                     2,                     // radius increment
-                                     2,                     // step
-                                     this->img_height_ / 2, // max radius
-                                     100                    // dead radius
-      );
+	// scanline_ model
+	this->scanline_ = new firevision::ScanlineRadial(this->img_width_,
+	                                                 this->img_height_,
+	                                                 this->img_width_ / 2,  // center width
+	                                                 this->img_height_ / 2, // center height
+	                                                 2,                     // radius increment
+	                                                 2,                     // step
+	                                                 this->img_height_ / 2, // max radius
+	                                                 100                    // dead radius
+	);
 
-  this->colorModel_ = new firevision::ColorModelRange(
-      cfg_color_y_min, cfg_color_y_max, cfg_color_u_min, cfg_color_u_max,
-      cfg_color_v_min, cfg_color_v_max);
+	this->colorModel_ = new firevision::ColorModelRange(cfg_color_y_min,
+	                                                    cfg_color_y_max,
+	                                                    cfg_color_u_min,
+	                                                    cfg_color_u_max,
+	                                                    cfg_color_v_min,
+	                                                    cfg_color_v_max);
 
-  this->classifierExpected_ =
-      new firevision::SimpleColorClassifier(this->scanline_,   // scanmodel
-                                            this->colorModel_, // colorModel
-                                            30,                // num_min_points
-                                            0,                 // box_extend
-                                            false,             // upward
-                                            2, // neighberhoud_min_match
-                                            0, // grow_by
-                                            firevision::C_WHITE // color
-      );
+	this->classifierExpected_ = new firevision::SimpleColorClassifier(this->scanline_,   // scanmodel
+	                                                                  this->colorModel_, // colorModel
+	                                                                  30,    // num_min_points
+	                                                                  0,     // box_extend
+	                                                                  false, // upward
+	                                                                  2,     // neighberhoud_min_match
+	                                                                  0,     // grow_by
+	                                                                  firevision::C_WHITE // color
+	);
 
-  // SHM image buffer
-  std::string shmID =
-      this->config->get_string((this->cfg_prefix_ + "shm_image_id").c_str());
+	// SHM image buffer
+	std::string shmID = this->config->get_string((this->cfg_prefix_ + "shm_image_id").c_str());
 
-  // SHM image buffer
-  this->shm_buffer_filtered = new firevision::SharedMemoryImageBuffer(
-      shmID.c_str(), this->cspace_to_, this->img_width_, this->img_height_);
-  if (!shm_buffer_filtered->is_valid()) {
-    throw Exception("Shared memory segment not valid");
-  }
-  this->shm_buffer_filtered->set_frame_id(this->cfg_frame_.c_str());
-  this->buffer_filtered = shm_buffer_filtered->buffer();
+	// SHM image buffer
+	this->shm_buffer_filtered = new firevision::SharedMemoryImageBuffer(shmID.c_str(),
+	                                                                    this->cspace_to_,
+	                                                                    this->img_width_,
+	                                                                    this->img_height_);
+	if (!shm_buffer_filtered->is_valid()) {
+		throw Exception("Shared memory segment not valid");
+	}
+	this->shm_buffer_filtered->set_frame_id(this->cfg_frame_.c_str());
+	this->buffer_filtered = shm_buffer_filtered->buffer();
 
-  this->filterROIDraw = new firevision::FilterROIDraw();
+	this->filterROIDraw = new firevision::FilterROIDraw();
 
-  this->mirror_ = new firevision::Bulb(this->cfg_mirror_file_.c_str());
+	this->mirror_ = new firevision::Bulb(this->cfg_mirror_file_.c_str());
 
-  if (cfg_debugOutput_) {
-    logger->log_debug(name(), "Cam String = %s", this->cfg_camera_.c_str());
-    logger->log_debug(name(), "Mirror     = %s",
-                      this->cfg_mirror_file_.c_str());
-    logger->log_debug(name(), "Frame      = %s", this->cfg_frame_.c_str());
+	if (cfg_debugOutput_) {
+		logger->log_debug(name(), "Cam String = %s", this->cfg_camera_.c_str());
+		logger->log_debug(name(), "Mirror     = %s", this->cfg_mirror_file_.c_str());
+		logger->log_debug(name(), "Frame      = %s", this->cfg_frame_.c_str());
 
-    logger->log_debug(name(), "Mirror H   = %f", this->cfg_mirror_height);
-    logger->log_debug(name(), "Radius H   = %f", this->cfg_robot_radius_);
-    logger->log_debug(name(), "RED    H   = %f", this->cfg_red_height_);
-    logger->log_debug(name(), "ORANGE H   = %f", this->cfg_orange_height_);
-    logger->log_debug(name(), "GREEN  H   = %f", this->cfg_green_height_);
+		logger->log_debug(name(), "Mirror H   = %f", this->cfg_mirror_height);
+		logger->log_debug(name(), "Radius H   = %f", this->cfg_robot_radius_);
+		logger->log_debug(name(), "RED    H   = %f", this->cfg_red_height_);
+		logger->log_debug(name(), "ORANGE H   = %f", this->cfg_orange_height_);
+		logger->log_debug(name(), "GREEN  H   = %f", this->cfg_green_height_);
 
-    logger->log_debug(name(), "ROI max S  = %i",
-                      this->cfg_threashold_roiMaxSize_);
+		logger->log_debug(name(), "ROI max S  = %i", this->cfg_threashold_roiMaxSize_);
 
-    logger->log_info(name(), "Light Compass init done.");
-  }
+		logger->log_info(name(), "Light Compass init done.");
+	}
 }
 
-bool LightCompassThread::prepare_finalize_user() { return true; }
-
-void LightCompassThread::finalize() {
-  logger->log_debug(name(), "Unregistering from vision master");
-  vision_master->unregister_thread(this);
-  delete this->cam_;
-
-  this->lightif->set_visibility_history(0);
-  this->lightif->write();
-  blackboard->close(this->lightif);
-  delete shm_buffer_filtered;
-  delete scanline_;
-  delete colorModel_;
-  delete classifierExpected_;
-  delete filterROIDraw;
-  delete mirror_;
+bool
+LightCompassThread::prepare_finalize_user()
+{
+	return true;
 }
 
-void LightCompassThread::loop() {
-  // lese die Camera
-  cam_->capture();
-  // berechne in einen "guten" Farb-Raum um
-  firevision::convert(cspace_from_, cspace_to_, cam_->buffer(), buffer_filtered,
-                      img_width_, img_height_);
+void
+LightCompassThread::finalize()
+{
+	logger->log_debug(name(), "Unregistering from vision master");
+	vision_master->unregister_thread(this);
+	delete this->cam_;
 
-  cam_->dispose_buffer();
+	this->lightif->set_visibility_history(0);
+	this->lightif->write();
+	blackboard->close(this->lightif);
+	delete shm_buffer_filtered;
+	delete scanline_;
+	delete colorModel_;
+	delete classifierExpected_;
+	delete filterROIDraw;
+	delete mirror_;
+}
 
-  // Suche ROIs Licht PositionEN
-  // unsigned int* lightPosInPicture = this->getBestROI(this->buffer_YCbCr);
-  firevision::ROI *bestRoi = this->getBestROI(this->buffer_filtered);
+void
+LightCompassThread::loop()
+{
+	// lese die Camera
+	cam_->capture();
+	// berechne in einen "guten" Farb-Raum um
+	firevision::convert(
+	  cspace_from_, cspace_to_, cam_->buffer(), buffer_filtered, img_width_, img_height_);
 
-  if (bestRoi != NULL) {
-    // Zeichne ROIS in 2. Buffer
-    this->drawROIInBuffer(this->buffer_filtered, this->img_width_,
-                          this->img_height_, bestRoi);
+	cam_->dispose_buffer();
 
-    // rechne verzerrung um
-    fawkes::polar_coord_2d_t bestLightPosRelPolar =
-        this->mirrorCorrectionOfROI(bestRoi);
+	// Suche ROIs Licht PositionEN
+	// unsigned int* lightPosInPicture = this->getBestROI(this->buffer_YCbCr);
+	firevision::ROI *bestRoi = this->getBestROI(this->buffer_filtered);
 
-    // rechnte cartesische coordinaten
-    float bestPosCartX = 0;
-    float bestPosCartY = 0;
+	if (bestRoi != NULL) {
+		// Zeichne ROIS in 2. Buffer
+		this->drawROIInBuffer(this->buffer_filtered, this->img_width_, this->img_height_, bestRoi);
 
-    fawkes::polar2cart2d(bestLightPosRelPolar.phi, bestLightPosRelPolar.r,
-                         &bestPosCartX, &bestPosCartY);
+		// rechne verzerrung um
+		fawkes::polar_coord_2d_t bestLightPosRelPolar = this->mirrorCorrectionOfROI(bestRoi);
 
-    // translate from relativ to absolute positions
-    Point3d light_relative;
-    light_relative.setX(bestPosCartX);
-    light_relative.setY(bestPosCartY);
+		// rechnte cartesische coordinaten
+		float bestPosCartX = 0;
+		float bestPosCartY = 0;
 
-    try {
-      Point3d puck_absolute = apply_tf_to_global(light_relative);
-      /* logger->log_debug(name(), "original: (%f,%f,%f)   map: (%f,%f,%f)",
+		fawkes::polar2cart2d(bestLightPosRelPolar.phi,
+		                     bestLightPosRelPolar.r,
+		                     &bestPosCartX,
+		                     &bestPosCartY);
+
+		// translate from relativ to absolute positions
+		Point3d light_relative;
+		light_relative.setX(bestPosCartX);
+		light_relative.setY(bestPosCartY);
+
+		try {
+			Point3d puck_absolute = apply_tf_to_global(light_relative);
+			/* logger->log_debug(name(), "original: (%f,%f,%f)   map: (%f,%f,%f)",
                        light_relative.x(), light_relative.y(),
                        light_relative.z(), puck_absolute.x(),
                        puck_absolute.y(), puck_absolute.z());//*/
 
-      double absLightX = puck_absolute.getX();
-      double absLightY = puck_absolute.getY();
+			double absLightX = puck_absolute.getX();
+			double absLightY = puck_absolute.getY();
 
-      // speicher in interface
-      this->UpdateInterface(absLightX, absLightY, cfg_frame_);
-    } catch (Exception &e) {
-      this->UpdateInterface(light_relative.x(), light_relative.y(),
-                            "/base_link");
-    }
+			// speicher in interface
+			this->UpdateInterface(absLightX, absLightY, cfg_frame_);
+		} catch (Exception &e) {
+			this->UpdateInterface(light_relative.x(), light_relative.y(), "/base_link");
+		}
 
-    if (cfg_debugOutput_) {
-      logger->log_debug(name(), "Position Pixel: %u, %u", bestRoi->start.x,
-                        bestRoi->start.y);
-      logger->log_debug(name(), "Position polar (mirror) r: %f phi: %f",
-                        bestLightPosRelPolar.r, bestLightPosRelPolar.phi);
-      logger->log_debug(name(), "Position Cart: %f, %f Rotation: %f Radius: %f",
-                        bestPosCartX, bestPosCartY, bestLightPosRelPolar.phi,
-                        bestLightPosRelPolar.r);
-    }
+		if (cfg_debugOutput_) {
+			logger->log_debug(name(), "Position Pixel: %u, %u", bestRoi->start.x, bestRoi->start.y);
+			logger->log_debug(name(),
+			                  "Position polar (mirror) r: %f phi: %f",
+			                  bestLightPosRelPolar.r,
+			                  bestLightPosRelPolar.phi);
+			logger->log_debug(name(),
+			                  "Position Cart: %f, %f Rotation: %f Radius: %f",
+			                  bestPosCartX,
+			                  bestPosCartY,
+			                  bestLightPosRelPolar.phi,
+			                  bestLightPosRelPolar.r);
+		}
 
-  } else {
-    this->ResetInterface();
-  }
+	} else {
+		this->ResetInterface();
+	}
 }
 
 fawkes::polar_coord_2d_t
-LightCompassThread::mirrorCorrectionOfROI(firevision::ROI *roi) {
-  fawkes::polar_coord_2d_t roiPosPolar;
-  roiPosPolar.r = 0;
-  roiPosPolar.phi = 0;
+LightCompassThread::mirrorCorrectionOfROI(firevision::ROI *roi)
+{
+	fawkes::polar_coord_2d_t roiPosPolar;
+	roiPosPolar.r   = 0;
+	roiPosPolar.phi = 0;
 
-  if (roi != NULL) {
-    // umrechen
-    unsigned int bestRoiCenterPosX = roi->start.x + roi->width / 2;
-    unsigned int bestRoiCenterPosY = roi->start.y + roi->height / 2;
+	if (roi != NULL) {
+		// umrechen
+		unsigned int bestRoiCenterPosX = roi->start.x + roi->width / 2;
+		unsigned int bestRoiCenterPosY = roi->start.y + roi->height / 2;
 
-    if (cfg_useBulbFile_) {
-      roiPosPolar = this->mirror_->getWorldPointRelative(bestRoiCenterPosX,
-                                                         bestRoiCenterPosY);
-    } else {
-      fawkes::cart2polar2d(bestRoiCenterPosX, bestRoiCenterPosY,
-                           &roiPosPolar.phi, &roiPosPolar.r);
-    }
-    roiPosPolar =
-        this->distanceCorrectionOfAmple(roiPosPolar, this->cfg_red_height_);
-  }
-  return roiPosPolar;
+		if (cfg_useBulbFile_) {
+			roiPosPolar = this->mirror_->getWorldPointRelative(bestRoiCenterPosX, bestRoiCenterPosY);
+		} else {
+			fawkes::cart2polar2d(bestRoiCenterPosX, bestRoiCenterPosY, &roiPosPolar.phi, &roiPosPolar.r);
+		}
+		roiPosPolar = this->distanceCorrectionOfAmple(roiPosPolar, this->cfg_red_height_);
+	}
+	return roiPosPolar;
 }
 
-bool LightCompassThread::isValidSuccessor(float px, float py, float cx,
-                                          float cy) {
+bool
+LightCompassThread::isValidSuccessor(float px, float py, float cx, float cy)
+{
+	float dx, dy;
+	dx = cx - px;
+	dy = cy - py;
 
-  float dx, dy;
-  dx = cx - px;
-  dy = cy - py;
-
-  if (std::sqrt((dx * dx) + (dy * dy)) <
-      this->cfg_lightDistanceAllowedBetweenFrames) {
-    return true;
-  }
-  return false;
+	if (std::sqrt((dx * dx) + (dy * dy)) < this->cfg_lightDistanceAllowedBetweenFrames) {
+		return true;
+	}
+	return false;
 }
 
-void LightCompassThread::ResetInterface() {
-  this->lightif->read();
-  if (this->lightif->visibility_history() > -1) {
-    this->lightif->set_visibility_history(-1);
-  } else {
-    this->lightif->set_visibility_history(this->lightif->visibility_history() -
-                                          1);
-  }
-  this->lightif->write();
+void
+LightCompassThread::ResetInterface()
+{
+	this->lightif->read();
+	if (this->lightif->visibility_history() > -1) {
+		this->lightif->set_visibility_history(-1);
+	} else {
+		this->lightif->set_visibility_history(this->lightif->visibility_history() - 1);
+	}
+	this->lightif->write();
 }
 
 LightCompassThread::Point3d
-LightCompassThread::apply_tf_to_global(Point3d src) {
+LightCompassThread::apply_tf_to_global(Point3d src)
+{
+	const char *source_frame = "/base_link";
+	const char *target_frame = cfg_frame_.c_str();
 
-  const char *source_frame = "/base_link";
-  const char *target_frame = cfg_frame_.c_str();
+	src.stamp = Time(0, 0);
+	Point3d targetPoint;
+	targetPoint.frame_id = target_frame;
 
-  src.stamp = Time(0, 0);
-  Point3d targetPoint;
-  targetPoint.frame_id = target_frame;
+	bool link_frame_exists  = tf_listener->frame_exists(target_frame);
+	bool laser_frame_exists = tf_listener->frame_exists(source_frame);
 
-  bool link_frame_exists = tf_listener->frame_exists(target_frame);
-  bool laser_frame_exists = tf_listener->frame_exists(source_frame);
-
-  if (!link_frame_exists || !laser_frame_exists) {
-    logger->log_warn(name(), "Frame missing: %s %s   %s %s", target_frame,
-                     link_frame_exists ? "exists" : "missing", source_frame,
-                     laser_frame_exists ? "exists" : "missing");
-    throw Exception("Frame missing: %s %s   %s %s", target_frame,
-                    link_frame_exists ? "exists" : "missing", source_frame,
-                    laser_frame_exists ? "exists" : "missing");
-  } else {
-    src.frame_id = source_frame;
-    try {
-      tf_listener->transform_point(target_frame, src, targetPoint);
-      return targetPoint;
-    } catch (tf::ExtrapolationException &e) {
-      logger->log_warn(name(), "Extrapolation error: %s",
-                       e.what_no_backtrace());
-      throw;
-    } catch (tf::ConnectivityException &e) {
-      logger->log_warn(name(), "Connectivity exception: %s",
-                       e.what_no_backtrace());
-      throw;
-    } catch (Exception &e) {
-      logger->log_warn(name(), "fawkes exception: %s", e.what_no_backtrace());
-      throw;
-    } catch (std::exception &e) {
-      logger->log_warn(name(), "generic exception: %s", e.what());
-      throw Exception("Generic exception: %s", e.what());
-    }
-  }
+	if (!link_frame_exists || !laser_frame_exists) {
+		logger->log_warn(name(),
+		                 "Frame missing: %s %s   %s %s",
+		                 target_frame,
+		                 link_frame_exists ? "exists" : "missing",
+		                 source_frame,
+		                 laser_frame_exists ? "exists" : "missing");
+		throw Exception("Frame missing: %s %s   %s %s",
+		                target_frame,
+		                link_frame_exists ? "exists" : "missing",
+		                source_frame,
+		                laser_frame_exists ? "exists" : "missing");
+	} else {
+		src.frame_id = source_frame;
+		try {
+			tf_listener->transform_point(target_frame, src, targetPoint);
+			return targetPoint;
+		} catch (tf::ExtrapolationException &e) {
+			logger->log_warn(name(), "Extrapolation error: %s", e.what_no_backtrace());
+			throw;
+		} catch (tf::ConnectivityException &e) {
+			logger->log_warn(name(), "Connectivity exception: %s", e.what_no_backtrace());
+			throw;
+		} catch (Exception &e) {
+			logger->log_warn(name(), "fawkes exception: %s", e.what_no_backtrace());
+			throw;
+		} catch (std::exception &e) {
+			logger->log_warn(name(), "generic exception: %s", e.what());
+			throw Exception("Generic exception: %s", e.what());
+		}
+	}
 }
 
-void LightCompassThread::UpdateInterface(double lightPosX, double lightPosY,
-                                         std::string frame) {
-  // wert in interface schreiben
-  this->lightif->read();
-  double lightifValuse[3];
-  lightifValuse[0] = this->lightif->translation(0);
-  lightifValuse[1] = this->lightif->translation(1);
-  lightifValuse[2] = this->lightif->translation(2);
+void
+LightCompassThread::UpdateInterface(double lightPosX, double lightPosY, std::string frame)
+{
+	// wert in interface schreiben
+	this->lightif->read();
+	double lightifValuse[3];
+	lightifValuse[0] = this->lightif->translation(0);
+	lightifValuse[1] = this->lightif->translation(1);
+	lightifValuse[2] = this->lightif->translation(2);
 
-  if (isValidSuccessor(lightifValuse[0], lightifValuse[1], lightPosX,
-                       lightPosY)) {
-    this->lightif->set_visibility_history(this->lightif->visibility_history() +
-                                          1);
-  } else {
-    this->lightif->set_visibility_history(-1);
-  }
+	if (isValidSuccessor(lightifValuse[0], lightifValuse[1], lightPosX, lightPosY)) {
+		this->lightif->set_visibility_history(this->lightif->visibility_history() + 1);
+	} else {
+		this->lightif->set_visibility_history(-1);
+	}
 
-  lightifValuse[0] = lightPosX;
-  lightifValuse[1] = lightPosY;
+	lightifValuse[0] = lightPosX;
+	lightifValuse[1] = lightPosY;
 
-  this->lightif->set_translation(lightifValuse);
-  // this->lightif->set_rotation(0,(double)lightPol->phi);
-  this->lightif->write();
+	this->lightif->set_translation(lightifValuse);
+	// this->lightif->set_rotation(0,(double)lightPol->phi);
+	this->lightif->write();
 
-  // logger->log_info(name(), "X = %f, Y = %f, R = %f", lightifValuse[0],
-  // lightifValuse[1], lightifValuse[2]);
+	// logger->log_info(name(), "X = %f, Y = %f, R = %f", lightifValuse[0],
+	// lightifValuse[1], lightifValuse[2]);
 }
 
-firevision::ROI *LightCompassThread::getBestROI(unsigned char *bufferYCbCr) {
-  // mögliche rois suchen
-  scanline_->reset();
-  this->classifierExpected_->set_src_buffer(bufferYCbCr, this->img_width_,
-                                            this->img_height_);
-  std::list<firevision::ROI> *rois = this->classifierExpected_->classify();
+firevision::ROI *
+LightCompassThread::getBestROI(unsigned char *bufferYCbCr)
+{
+	// mögliche rois suchen
+	scanline_->reset();
+	this->classifierExpected_->set_src_buffer(bufferYCbCr, this->img_width_, this->img_height_);
+	std::list<firevision::ROI> *rois = this->classifierExpected_->classify();
 
-  if (cfg_debugOutput_) {
-    logger->log_debug(name(), "Classifier ROIs count %i", rois->size());
-  }
+	if (cfg_debugOutput_) {
+		logger->log_debug(name(), "Classifier ROIs count %i", rois->size());
+	}
 
-  // rois die nicht "gut" sind löschen (zu groß / zu nah am Roboter)
-  std::list<firevision::ROI> *roisGood = new std::list<firevision::ROI>();
-  firevision::ROI *roi = NULL;
-  while (!rois->empty()) {
+	// rois die nicht "gut" sind löschen (zu groß / zu nah am Roboter)
+	std::list<firevision::ROI> *roisGood = new std::list<firevision::ROI>();
+	firevision::ROI *           roi      = NULL;
+	while (!rois->empty()) {
+		roi = new firevision::ROI(rois->front());
+		if (cfg_debugOutput_) {
+			logger->log_debug(name(), "Rois: Position: %u, %u", roi->start.x, roi->start.y);
+		}
+		// drawROIInBuffer(this->buffer_filtered, this->img_width_,
+		// this->img_height_, roi);
+		if (roi->get_height() * roi->get_width() > this->cfg_threashold_roiMaxSize_) {
+			logger->log_debug(name(), "DELETED, roi size is %f", roi->get_height() * roi->get_width());
+		} else if (this->mirrorCorrectionOfROI(roi).r < this->cfg_robot_radius_) {
+			logger->log_debug(name(),
+			                  "DELETED: radius to robot is %f",
+			                  this->mirror_->getWorldPointRelative(roi->start.x, roi->start.y).r);
+		} else {
+			roisGood->push_back(*roi);
+		}
+		rois->pop_front();
+	}
 
-    roi = new firevision::ROI(rois->front());
-    if (cfg_debugOutput_) {
-      logger->log_debug(name(), "Rois: Position: %u, %u", roi->start.x,
-                        roi->start.y);
-    }
-    // drawROIInBuffer(this->buffer_filtered, this->img_width_,
-    // this->img_height_, roi);
-    if (roi->get_height() * roi->get_width() >
-        this->cfg_threashold_roiMaxSize_) {
-      logger->log_debug(name(), "DELETED, roi size is %f",
-                        roi->get_height() * roi->get_width());
-    } else if (this->mirrorCorrectionOfROI(roi).r < this->cfg_robot_radius_) {
-      logger->log_debug(
-          name(), "DELETED: radius to robot is %f",
-          this->mirror_->getWorldPointRelative(roi->start.x, roi->start.y).r);
-    } else {
-      roisGood->push_back(*roi);
-    }
-    rois->pop_front();
-  }
+	// firevision::convert(cspace_from_, cspace_to_, cam_->buffer(),
+	// buffer_filtered, img_width_,img_height_);
+	// this->drawROIsInBuffer(this->buffer_filtered, this->img_width_,
+	// this->img_height_, roisGood);
 
-  // firevision::convert(cspace_from_, cspace_to_, cam_->buffer(),
-  // buffer_filtered, img_width_,img_height_);
-  // this->drawROIsInBuffer(this->buffer_filtered, this->img_width_,
-  // this->img_height_, roisGood);
+	// setze ROI mit geringstem abstand zum roboter in return value
+	if (!roisGood->empty()) {
+		roi = new firevision::ROI(roisGood->front());
+		for (std::list<firevision::ROI>::iterator it = roisGood->begin(); it != roisGood->end(); ++it) {
+			float newRoiDistance  = this->mirror_->getWorldPointRelative((*it).start.x, (*it).start.y).r;
+			float oldRoidDistance = this->mirror_->getWorldPointRelative(roi->start.x, roi->start.y).r;
 
-  // setze ROI mit geringstem abstand zum roboter in return value
-  if (!roisGood->empty()) {
-    roi = new firevision::ROI(roisGood->front());
-    for (std::list<firevision::ROI>::iterator it = roisGood->begin();
-         it != roisGood->end(); ++it) {
+			if (newRoiDistance > oldRoidDistance) {
+				roi = new firevision::ROI(*it);
+			}
+		}
+	} else {
+		roi = NULL;
+	}
 
-      float newRoiDistance =
-          this->mirror_->getWorldPointRelative((*it).start.x, (*it).start.y).r;
-      float oldRoidDistance =
-          this->mirror_->getWorldPointRelative(roi->start.x, roi->start.y).r;
+	delete roisGood;
+	delete rois;
 
-      if (newRoiDistance > oldRoidDistance) {
-        roi = new firevision::ROI(*it);
-      }
-    }
-  } else {
-    roi = NULL;
-  }
-
-  delete roisGood;
-  delete rois;
-
-  drawROIInBuffer(this->buffer_filtered, this->img_width_, this->img_height_,
-                  roi);
-  return roi;
+	drawROIInBuffer(this->buffer_filtered, this->img_width_, this->img_height_, roi);
+	return roi;
 }
 
-void LightCompassThread::drawROIsInBuffer(unsigned char *buffer,
-                                          unsigned int width,
-                                          unsigned int height,
-                                          std::list<firevision::ROI> *rois) {
-  this->filterROIDraw->set_src_buffer(
-      buffer, firevision::ROI::full_image(width, height), 0);
-  if (cfg_debugOutput_) {
-    logger->log_debug(name(), "Drawing ROIs count %i", rois->size());
-  }
-  for (std::list<firevision::ROI>::iterator it = rois->begin();
-       it != rois->end(); ++it) {
-    drawROIInBuffer(buffer, width, height, &(*it));
-  }
+void
+LightCompassThread::drawROIsInBuffer(unsigned char *             buffer,
+                                     unsigned int                width,
+                                     unsigned int                height,
+                                     std::list<firevision::ROI> *rois)
+{
+	this->filterROIDraw->set_src_buffer(buffer, firevision::ROI::full_image(width, height), 0);
+	if (cfg_debugOutput_) {
+		logger->log_debug(name(), "Drawing ROIs count %i", rois->size());
+	}
+	for (std::list<firevision::ROI>::iterator it = rois->begin(); it != rois->end(); ++it) {
+		drawROIInBuffer(buffer, width, height, &(*it));
+	}
 }
 
-void LightCompassThread::drawROIInBuffer(unsigned char *buffer,
-                                         unsigned int width,
-                                         unsigned int height,
-                                         firevision::ROI *roi) {
-  this->filterROIDraw->set_src_buffer(
-      buffer, firevision::ROI::full_image(width, height), 0);
-  this->filterROIDraw->set_dst_buffer(buffer, roi);
-  this->filterROIDraw->set_style(firevision::FilterROIDraw::DASHED_HINT);
-  this->filterROIDraw->apply();
+void
+LightCompassThread::drawROIInBuffer(unsigned char *  buffer,
+                                    unsigned int     width,
+                                    unsigned int     height,
+                                    firevision::ROI *roi)
+{
+	this->filterROIDraw->set_src_buffer(buffer, firevision::ROI::full_image(width, height), 0);
+	this->filterROIDraw->set_dst_buffer(buffer, roi);
+	this->filterROIDraw->set_style(firevision::FilterROIDraw::DASHED_HINT);
+	this->filterROIDraw->apply();
 }
 
-fawkes::polar_coord_2d_t LightCompassThread::distanceCorrectionOfAmple(
-    fawkes::polar_coord_2d_t polatCooredOfMessuredLight, float ampleHeight) {
-  float distance = polatCooredOfMessuredLight.r;
+fawkes::polar_coord_2d_t
+LightCompassThread::distanceCorrectionOfAmple(fawkes::polar_coord_2d_t polatCooredOfMessuredLight,
+                                              float                    ampleHeight)
+{
+	float distance = polatCooredOfMessuredLight.r;
 
-  fawkes::polar_coord_2d_t polatCooredOfAmplePosition(
-      polatCooredOfMessuredLight);
+	fawkes::polar_coord_2d_t polatCooredOfAmplePosition(polatCooredOfMessuredLight);
 
-  polatCooredOfAmplePosition.r =
-      distance - ((ampleHeight / this->cfg_mirror_height) * distance);
+	polatCooredOfAmplePosition.r = distance - ((ampleHeight / this->cfg_mirror_height) * distance);
 
-  return polatCooredOfAmplePosition;
+	return polatCooredOfAmplePosition;
 }

--- a/src/plugins/attic/light_compass/light_compass_thread.h
+++ b/src/plugins/attic/light_compass/light_compass_thread.h
@@ -24,38 +24,33 @@
 #define __PLUGINS_LIGHT_COMPASS_THREAD_H_
 
 #include "ColorModelRange.h"
+
 #include <aspect/blackboard.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
+#include <aspect/tf.h>
 #include <aspect/vision.h>
 #include <core/threading/thread.h>
-
-#include <interfaces/Position3DInterface.h>
-
-#include <fvutils/base/roi.h>
-#include <fvutils/color/colorspaces.h>
-#include <fvutils/color/conversions.h>
-#include <fvutils/draw/drawer.h>
-#include <fvutils/ipc/shm_image.h>
-
+#include <fvcams/camera.h>
+#include <fvclassifiers/simple.h>
+#include <fvfilters/roidraw.h>
 #include <fvmodels/global_position/omni_global.h>
 #include <fvmodels/mirror/bulb.h>
 #include <fvmodels/mirror/mirrormodel.h>
 #include <fvmodels/relative_position/omni_relative.h>
 #include <fvmodels/scanlines/radial.h>
-
-#include <fvcams/camera.h>
-#include <fvclassifiers/simple.h>
-#include <fvfilters/roidraw.h>
+#include <fvutils/base/roi.h>
+#include <fvutils/color/colorspaces.h>
+#include <fvutils/color/conversions.h>
+#include <fvutils/draw/drawer.h>
+#include <fvutils/ipc/shm_image.h>
 #include <geometry/hom_point.h>
 #include <geometry/hom_vector.h>
-#include <utils/system/hostinfo.h>
-
-#include <aspect/tf.h>
+#include <interfaces/Position3DInterface.h>
 #include <tf/transform_listener.h>
 #include <tf/types.h>
-
 #include <utils/math/coord.h>
+#include <utils/system/hostinfo.h>
 
 #include <string>
 
@@ -76,82 +71,88 @@ class LightCompassThread : public fawkes::Thread,
                            public fawkes::ConfigurableAspect,
                            public fawkes::VisionAspect,
                            public fawkes::BlackBoardAspect,
-                           public fawkes::TransformAspect {
-
+                           public fawkes::TransformAspect
+{
 public:
-  typedef fawkes::tf::Stamped<fawkes::tf::Point> Point3d;
-  LightCompassThread();
+	typedef fawkes::tf::Stamped<fawkes::tf::Point> Point3d;
+	LightCompassThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual bool prepare_finalize_user();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual bool prepare_finalize_user();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  std::string cfg_prefix_;
-  std::string cfg_camera_;
-  std::string cfg_mirror_file_;
-  std::string cfg_frame_;
+	std::string cfg_prefix_;
+	std::string cfg_camera_;
+	std::string cfg_mirror_file_;
+	std::string cfg_frame_;
 
-  float cfg_mirror_height;
-  float cfg_red_height_;
-  float cfg_orange_height_;
-  float cfg_green_height_;
-  float cfg_robot_radius_;
-  float cfg_lightDistanceAllowedBetweenFrames;
+	float cfg_mirror_height;
+	float cfg_red_height_;
+	float cfg_orange_height_;
+	float cfg_green_height_;
+	float cfg_robot_radius_;
+	float cfg_lightDistanceAllowedBetweenFrames;
 
-  bool cfg_useBulbFile_;
-  bool cfg_debugOutput_;
+	bool cfg_useBulbFile_;
+	bool cfg_debugOutput_;
 
-  unsigned int cfg_threashold_roiMaxSize_;
+	unsigned int cfg_threashold_roiMaxSize_;
 
-  unsigned int cfg_color_y_min;
-  unsigned int cfg_color_y_max;
-  unsigned int cfg_color_u_min;
-  unsigned int cfg_color_u_max;
-  unsigned int cfg_color_v_min;
-  unsigned int cfg_color_v_max;
+	unsigned int cfg_color_y_min;
+	unsigned int cfg_color_y_max;
+	unsigned int cfg_color_u_min;
+	unsigned int cfg_color_u_max;
+	unsigned int cfg_color_v_min;
+	unsigned int cfg_color_v_max;
 
-  void drawROIsInBuffer(unsigned char *buffer, unsigned int width,
-                        unsigned int height, std::list<firevision::ROI> *rois);
-  void drawROIInBuffer(unsigned char *buffer, unsigned int width,
-                       unsigned int height, firevision::ROI *roi);
-  fawkes::polar_coord_2d_t mirrorCorrectionOfROI(firevision::ROI *roi);
+	void                     drawROIsInBuffer(unsigned char *             buffer,
+	                                          unsigned int                width,
+	                                          unsigned int                height,
+	                                          std::list<firevision::ROI> *rois);
+	void                     drawROIInBuffer(unsigned char *  buffer,
+	                                         unsigned int     width,
+	                                         unsigned int     height,
+	                                         firevision::ROI *roi);
+	fawkes::polar_coord_2d_t mirrorCorrectionOfROI(firevision::ROI *roi);
 
-  firevision::ROI *getBestROI(unsigned char *bufferYCbCr);
-  fawkes::polar_coord_2d_t
-  distanceCorrectionOfAmple(fawkes::polar_coord_2d_t polatCooredOfMessuredLight,
-                            float ampleHeight);
-  void UpdateInterface(double lightPosX, double lightPosY,
-                       std::string frame_id);
-  void ResetInterface();
-  bool isValidSuccessor(float px, float py, float cx, float cy);
+	firevision::ROI *getBestROI(unsigned char *bufferYCbCr);
+	fawkes::polar_coord_2d_t
+	     distanceCorrectionOfAmple(fawkes::polar_coord_2d_t polatCooredOfMessuredLight, float ampleHeight);
+	void UpdateInterface(double lightPosX, double lightPosY, std::string frame_id);
+	void ResetInterface();
+	bool isValidSuccessor(float px, float py, float cx, float cy);
 
-  Point3d apply_tf_to_global(Point3d src);
+	Point3d apply_tf_to_global(Point3d src);
 
-  unsigned int img_width_;
-  unsigned int img_height_;
+	unsigned int img_width_;
+	unsigned int img_height_;
 
-  unsigned char *buffer_filtered;
+	unsigned char *buffer_filtered;
 
-  firevision::Camera *cam_;
-  firevision::ScanlineModel *scanline_;
-  // firevision::ColorModel *cm_;
-  firevision::MirrorModel *mirror_;
-  firevision::RelativePositionModel *rel_pos_;
-  firevision::SimpleColorClassifier *classifierExpected_;
-  firevision::SharedMemoryImageBuffer *shm_buffer_filtered;
-  firevision::colorspace_t cspace_from_;
-  firevision::colorspace_t cspace_to_;
-  firevision::ColorModelRange *colorModel_;
+	firevision::Camera *       cam_;
+	firevision::ScanlineModel *scanline_;
+	// firevision::ColorModel *cm_;
+	firevision::MirrorModel *            mirror_;
+	firevision::RelativePositionModel *  rel_pos_;
+	firevision::SimpleColorClassifier *  classifierExpected_;
+	firevision::SharedMemoryImageBuffer *shm_buffer_filtered;
+	firevision::colorspace_t             cspace_from_;
+	firevision::colorspace_t             cspace_to_;
+	firevision::ColorModelRange *        colorModel_;
 
-  firevision::FilterROIDraw *filterROIDraw;
+	firevision::FilterROIDraw *filterROIDraw;
 
-  fawkes::Position3DInterface *lightif;
+	fawkes::Position3DInterface *lightif;
 };
 
 #endif

--- a/src/plugins/attic/light_front/light_front.cpp
+++ b/src/plugins/attic/light_front/light_front.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "light_front_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Light Detection with front cam and Laser
  * @author Florian Nolden & Tobias Neumann
  */
-class LightFront : public fawkes::Plugin {
+class LightFront : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  LightFront(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new LightFrontThread());
-  }
+	LightFront(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new LightFrontThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Front camera light detection")

--- a/src/plugins/attic/light_front/light_front_thread.cpp
+++ b/src/plugins/attic/light_front/light_front_thread.cpp
@@ -14,949 +14,944 @@
 #include "light_front_thread.h"
 
 LightFrontThread::LightFrontThread()
-    : Thread("LightFrontThread", Thread::OPMODE_WAITFORWAKEUP),
-      VisionAspect(VisionAspect::CYCLIC) {
-  cfg_prefix = "";
-  cfg_camera = "";
-  cfg_frame = "";
+: Thread("LightFrontThread", Thread::OPMODE_WAITFORWAKEUP), VisionAspect(VisionAspect::CYCLIC)
+{
+	cfg_prefix = "";
+	cfg_camera = "";
+	cfg_frame  = "";
 
-  cfg_cameraFactorHorizontal = 0;
-  cfg_cameraFactorVertical = 0;
+	cfg_cameraFactorHorizontal = 0;
+	cfg_cameraFactorVertical   = 0;
 
-  cfg_cameraOffsetHorizontal = 0;
-  cfg_cameraOffsetVertical = 0;
+	cfg_cameraOffsetHorizontal = 0;
+	cfg_cameraOffsetVertical   = 0;
 
-  cfg_lightSizeHeight = 0;
-  cfg_lightSizeWidth = 0;
+	cfg_lightSizeHeight = 0;
+	cfg_lightSizeWidth  = 0;
 
-  cfg_lightNumberOfWrongDetections = 0;
-  cfg_detectionCycleTime = 0;
+	cfg_lightNumberOfWrongDetections = 0;
+	cfg_detectionCycleTime           = 0;
 
-  cfg_desiredLoopTime = 0;
-  cfg_detectionCycleTime = 0;
+	cfg_desiredLoopTime    = 0;
+	cfg_detectionCycleTime = 0;
 
-  cfg_brightnessThreshold = 0;
-  cfg_darknessThreshold = 0;
-  cfg_paintROIsActivated = false;
-  cfg_useMinDistanceThreashold = false;
-  cfg_useMulticluster = false;
+	cfg_brightnessThreshold      = 0;
+	cfg_darknessThreshold        = 0;
+	cfg_paintROIsActivated       = false;
+	cfg_useMinDistanceThreashold = false;
+	cfg_useMulticluster          = false;
 
-  cfg_lightOutOfRangeThreshold = 0;
-  cfg_laserVisibilityThreshold = 0;
-  cfg_lightMoveUnderRfidThrashold = 0;
+	cfg_lightOutOfRangeThreshold    = 0;
+	cfg_laserVisibilityThreshold    = 0;
+	cfg_lightMoveUnderRfidThrashold = 0;
 
-  img_width = 0;
-  img_height = 0;
+	img_width  = 0;
+	img_height = 0;
 
-  detectionCycleTimeFrames = 0;
+	detectionCycleTimeFrames = 0;
 
-  historyBufferCluster1 = NULL;
-  historyBufferCluster2 = NULL;
-  historyBufferCluster3 = NULL;
+	historyBufferCluster1 = NULL;
+	historyBufferCluster2 = NULL;
+	historyBufferCluster3 = NULL;
 
-  bufferYCbCr = NULL;
+	bufferYCbCr = NULL;
 
-  cspaceFrom = firevision::YUV422_PLANAR;
-  cspaceTo = firevision::YUV422_PLANAR;
+	cspaceFrom = firevision::YUV422_PLANAR;
+	cspaceTo   = firevision::YUV422_PLANAR;
 
-  camera = NULL;
-  scanline = NULL;
-  colorModel = NULL;
-  classifierWhite = NULL;
-  classifierBlack = NULL;
-  shmBufferYCbCr = NULL;
+	camera          = NULL;
+	scanline        = NULL;
+	colorModel      = NULL;
+	classifierWhite = NULL;
+	classifierBlack = NULL;
+	shmBufferYCbCr  = NULL;
 
-  nearestMaschineIF1 = NULL;
-  nearestMaschineIF2 = NULL;
-  nearestMaschineIF3 = NULL;
-  lightStateIF1 = NULL;
-  lightStateIF2 = NULL;
-  lightStateIF3 = NULL;
+	nearestMaschineIF1 = NULL;
+	nearestMaschineIF2 = NULL;
+	nearestMaschineIF3 = NULL;
+	lightStateIF1      = NULL;
+	lightStateIF2      = NULL;
+	lightStateIF3      = NULL;
 
-  drawer = NULL;
+	drawer = NULL;
 
-  cfg_debugMessagesActivated = false;
+	cfg_debugMessagesActivated = false;
 
-  cfg_lightDistanceAllowedBetweenFrames = 0;
-  lightOutOfRangeCounter = 0;
+	cfg_lightDistanceAllowedBetweenFrames = 0;
+	lightOutOfRangeCounter                = 0;
 }
 
-void LightFrontThread::init() {
-  logger->log_info(name(), "light_front: starts up");
+void
+LightFrontThread::init()
+{
+	logger->log_info(name(), "light_front: starts up");
 
-  lightOutOfRangeCounter = 0;
+	lightOutOfRangeCounter = 0;
 
-  cfg_prefix = "/plugins/light_front/";
+	cfg_prefix = "/plugins/light_front/";
 
-  cfg_frame = config->get_string((cfg_prefix + "frame").c_str());
+	cfg_frame = config->get_string((cfg_prefix + "frame").c_str());
 
-  cfg_camera = config->get_string((cfg_prefix + "camera").c_str());
-  cfg_cameraFactorHorizontal =
-      config->get_float((cfg_prefix + "camera_factor_horizontal").c_str());
-  cfg_cameraFactorVertical =
-      config->get_float((cfg_prefix + "camera_factor_vertical").c_str());
+	cfg_camera                 = config->get_string((cfg_prefix + "camera").c_str());
+	cfg_cameraFactorHorizontal = config->get_float((cfg_prefix + "camera_factor_horizontal").c_str());
+	cfg_cameraFactorVertical   = config->get_float((cfg_prefix + "camera_factor_vertical").c_str());
 
-  cfg_cameraOffsetHorizontal =
-      config->get_int((cfg_prefix + "camera_offset_horizontal").c_str());
-  cfg_cameraOffsetVertical =
-      config->get_int((cfg_prefix + "camera_offset_vertical").c_str());
-  cfg_cameraAngleVerticalRad =
-      config->get_float((cfg_prefix + "camera_angle_vertical_rad").c_str());
-  cfg_cameraAngleHorizontalRad =
-      config->get_float((cfg_prefix + "camera_angle_horizontal_rad").c_str());
-  cfg_lightNumberOfWrongDetections = config->get_int(
-      (cfg_prefix + "light_number_of_wrong_detections").c_str());
+	cfg_cameraOffsetHorizontal = config->get_int((cfg_prefix + "camera_offset_horizontal").c_str());
+	cfg_cameraOffsetVertical   = config->get_int((cfg_prefix + "camera_offset_vertical").c_str());
+	cfg_cameraAngleVerticalRad =
+	  config->get_float((cfg_prefix + "camera_angle_vertical_rad").c_str());
+	cfg_cameraAngleHorizontalRad =
+	  config->get_float((cfg_prefix + "camera_angle_horizontal_rad").c_str());
+	cfg_lightNumberOfWrongDetections =
+	  config->get_int((cfg_prefix + "light_number_of_wrong_detections").c_str());
 
-  cfg_debugMessagesActivated =
-      config->get_bool((cfg_prefix + "show_debug_messages").c_str());
-  cfg_paintROIsActivated = config->get_bool((cfg_prefix + "draw_rois").c_str());
+	cfg_debugMessagesActivated = config->get_bool((cfg_prefix + "show_debug_messages").c_str());
+	cfg_paintROIsActivated     = config->get_bool((cfg_prefix + "draw_rois").c_str());
 
-  cfg_brightnessThreshold =
-      config->get_uint((cfg_prefix + "threashold_brightness").c_str());
-  cfg_darknessThreshold =
-      config->get_uint((cfg_prefix + "threashold_black").c_str());
-  cfg_laserVisibilityThreshold =
-      config->get_int((cfg_prefix + "threashold_laser_visibility").c_str());
-  cfg_lightDistanceAllowedBetweenFrames = config->get_float(
-      (cfg_prefix + "light_distance_allowed_betwen_frames").c_str());
-  cfg_lightOutOfRangeThrashold =
-      config->get_int((cfg_prefix + "light_out_of_range_thrashold").c_str());
-  cfg_lightMoveUnderRfidThrashold = config->get_float(
-      (cfg_prefix + "light_move_under_rfid_thrashold").c_str());
-  cfg_center_x = config->get_int((cfg_prefix + "center_x").c_str());
-  cfg_center_y = config->get_int((cfg_prefix + "center_y").c_str());
-  cfg_center_height = config->get_int((cfg_prefix + "center_height").c_str());
-  cfg_center_width = config->get_int((cfg_prefix + "center_width").c_str());
+	cfg_brightnessThreshold = config->get_uint((cfg_prefix + "threashold_brightness").c_str());
+	cfg_darknessThreshold   = config->get_uint((cfg_prefix + "threashold_black").c_str());
+	cfg_laserVisibilityThreshold =
+	  config->get_int((cfg_prefix + "threashold_laser_visibility").c_str());
+	cfg_lightDistanceAllowedBetweenFrames =
+	  config->get_float((cfg_prefix + "light_distance_allowed_betwen_frames").c_str());
+	cfg_lightOutOfRangeThrashold =
+	  config->get_int((cfg_prefix + "light_out_of_range_thrashold").c_str());
+	cfg_lightMoveUnderRfidThrashold =
+	  config->get_float((cfg_prefix + "light_move_under_rfid_thrashold").c_str());
+	cfg_center_x      = config->get_int((cfg_prefix + "center_x").c_str());
+	cfg_center_y      = config->get_int((cfg_prefix + "center_y").c_str());
+	cfg_center_height = config->get_int((cfg_prefix + "center_height").c_str());
+	cfg_center_width  = config->get_int((cfg_prefix + "center_width").c_str());
 
-  cfg_lightToCloseThrashold =
-      config->get_float((cfg_prefix + "light_to_close_thrashold").c_str());
+	cfg_lightToCloseThrashold = config->get_float((cfg_prefix + "light_to_close_thrashold").c_str());
 
-  cfg_lightSizeHeight =
-      config->get_float((cfg_prefix + "light_size_height").c_str());
-  cfg_lightSizeWidth =
-      config->get_float((cfg_prefix + "light_size_width").c_str());
+	cfg_lightSizeHeight = config->get_float((cfg_prefix + "light_size_height").c_str());
+	cfg_lightSizeWidth  = config->get_float((cfg_prefix + "light_size_width").c_str());
 
-  cfg_detectionCycleTime =
-      config->get_int((cfg_prefix + "detection_cycle_time").c_str());
-  cfg_desiredLoopTime =
-      config->get_float("/fawkes/mainapp/desired_loop_time") / 1000000;
-  detectionCycleTimeFrames = cfg_detectionCycleTime / cfg_desiredLoopTime;
+	cfg_detectionCycleTime   = config->get_int((cfg_prefix + "detection_cycle_time").c_str());
+	cfg_desiredLoopTime      = config->get_float("/fawkes/mainapp/desired_loop_time") / 1000000;
+	detectionCycleTimeFrames = cfg_detectionCycleTime / cfg_desiredLoopTime;
 
-  cfg_useMinDistanceThreashold =
-      config->get_bool((cfg_prefix + "use_min_distance_threashold").c_str());
-  cfg_useMulticluster =
-      config->get_bool((cfg_prefix + "use_multicluster").c_str());
+	cfg_useMinDistanceThreashold =
+	  config->get_bool((cfg_prefix + "use_min_distance_threashold").c_str());
+	cfg_useMulticluster = config->get_bool((cfg_prefix + "use_multicluster").c_str());
 
-  cfg_lightPositionCorrection =
-      config->get_bool((cfg_prefix + "light_position_correction").c_str());
-  cfg_simulateLaserData =
-      config->get_bool((cfg_prefix + "simulate_laser").c_str());
-  cfg_simulate_laser_x =
-      config->get_float((cfg_prefix + "simulate_laser_data_x").c_str());
-  cfg_simulate_laser_y =
-      config->get_float((cfg_prefix + "simulate_laser_data_y").c_str());
-  cfg_simulate_laser_history =
-      config->get_int((cfg_prefix + "simulate_laser_data_visibility").c_str());
+	cfg_lightPositionCorrection =
+	  config->get_bool((cfg_prefix + "light_position_correction").c_str());
+	cfg_simulateLaserData = config->get_bool((cfg_prefix + "simulate_laser").c_str());
+	cfg_simulate_laser_x  = config->get_float((cfg_prefix + "simulate_laser_data_x").c_str());
+	cfg_simulate_laser_y  = config->get_float((cfg_prefix + "simulate_laser_data_y").c_str());
+	cfg_simulate_laser_history =
+	  config->get_int((cfg_prefix + "simulate_laser_data_visibility").c_str());
 
-  logger->log_debug(name(), "Camera offset horizontal: %i",
-                    cfg_cameraOffsetHorizontal);
-  logger->log_debug(name(), "Camera offset vertical: %i",
-                    cfg_cameraOffsetVertical);
+	logger->log_debug(name(), "Camera offset horizontal: %i", cfg_cameraOffsetHorizontal);
+	logger->log_debug(name(), "Camera offset vertical: %i", cfg_cameraOffsetVertical);
 
-  logger->log_debug(name(), "Camera offset angle horizontal: %f",
-                    cfg_cameraAngleHorizontalRad);
-  logger->log_debug(name(), "Camera offset angle vertical: %f",
-                    cfg_cameraAngleVerticalRad);
+	logger->log_debug(name(), "Camera offset angle horizontal: %f", cfg_cameraAngleHorizontalRad);
+	logger->log_debug(name(), "Camera offset angle vertical: %f", cfg_cameraAngleVerticalRad);
 
-  logger->log_debug(name(), "Simulate laser: %b", cfg_simulateLaserData);
+	logger->log_debug(name(), "Simulate laser: %b", cfg_simulateLaserData);
 
-  std::string shmID = config->get_string((cfg_prefix + "shm_image_id").c_str());
+	std::string shmID = config->get_string((cfg_prefix + "shm_image_id").c_str());
 
-  camera = vision_master->register_for_camera(cfg_camera.c_str(), this);
+	camera = vision_master->register_for_camera(cfg_camera.c_str(), this);
 
-  img_width = camera->pixel_width();
-  img_height = camera->pixel_height();
+	img_width  = camera->pixel_width();
+	img_height = camera->pixel_height();
 
-  cspaceFrom = camera->colorspace();
+	cspaceFrom = camera->colorspace();
 
-  scanline = new firevision::ScanlineGrid(img_width, img_height, 1, 1);
-  colorModel = new firevision::ColorModelLuminance(cfg_brightnessThreshold);
+	scanline   = new firevision::ScanlineGrid(img_width, img_height, 1, 1);
+	colorModel = new firevision::ColorModelLuminance(cfg_brightnessThreshold);
 
-  classifierWhite =
-      new firevision::SimpleColorClassifier(scanline,   // scanmodel
-                                            colorModel, // colorModel
-                                            30,         // num_min_points
-                                            0,          // box_extend
-                                            false,      // upward
-                                            2, // neighberhoud_min_match
-                                            0, // grow_by
-                                            firevision::C_WHITE // color
-      );
+	classifierWhite = new firevision::SimpleColorClassifier(scanline,   // scanmodel
+	                                                        colorModel, // colorModel
+	                                                        30,         // num_min_points
+	                                                        0,          // box_extend
+	                                                        false,      // upward
+	                                                        2,          // neighberhoud_min_match
+	                                                        0,          // grow_by
+	                                                        firevision::C_WHITE // color
+	);
 
-  colorModelBlack = new firevision::ColorModelBlack(cfg_darknessThreshold);
-  classifierBlack =
-      new firevision::SimpleColorClassifier(scanline,        // scanmodel
-                                            colorModelBlack, // colorModel
-                                            30,              // num_min_points
-                                            0,               // box_extend
-                                            false,           // upward
-                                            2, // neighberhoud_min_match
-                                            0, // grow_by
-                                            firevision::C_BLACK // color
-      );
+	colorModelBlack = new firevision::ColorModelBlack(cfg_darknessThreshold);
+	classifierBlack = new firevision::SimpleColorClassifier(scanline,        // scanmodel
+	                                                        colorModelBlack, // colorModel
+	                                                        30,              // num_min_points
+	                                                        0,               // box_extend
+	                                                        false,           // upward
+	                                                        2,               // neighberhoud_min_match
+	                                                        0,               // grow_by
+	                                                        firevision::C_BLACK // color
+	);
 
-  // SHM image buffer
-  shmBufferYCbCr = new firevision::SharedMemoryImageBuffer(
-      shmID.c_str(), cspaceTo, img_width, img_height);
-  if (!shmBufferYCbCr->is_valid()) {
-    throw fawkes::Exception("Shared memory segment not valid");
-  }
-  shmBufferYCbCr->set_frame_id(cfg_frame.c_str());
+	// SHM image buffer
+	shmBufferYCbCr =
+	  new firevision::SharedMemoryImageBuffer(shmID.c_str(), cspaceTo, img_width, img_height);
+	if (!shmBufferYCbCr->is_valid()) {
+		throw fawkes::Exception("Shared memory segment not valid");
+	}
+	shmBufferYCbCr->set_frame_id(cfg_frame.c_str());
 
-  bufferYCbCr = shmBufferYCbCr->buffer();
+	bufferYCbCr = shmBufferYCbCr->buffer();
 
-  // Create a ringbuffer with the size of the configured frame count
-  historyBufferCluster1 =
-      new boost::circular_buffer<lightSignal>(detectionCycleTimeFrames);
-  historyBufferCluster2 =
-      new boost::circular_buffer<lightSignal>(detectionCycleTimeFrames);
-  historyBufferCluster3 =
-      new boost::circular_buffer<lightSignal>(detectionCycleTimeFrames);
-  // historyBuffer = new std::deque<lightSignal>();
+	// Create a ringbuffer with the size of the configured frame count
+	historyBufferCluster1 = new boost::circular_buffer<lightSignal>(detectionCycleTimeFrames);
+	historyBufferCluster2 = new boost::circular_buffer<lightSignal>(detectionCycleTimeFrames);
+	historyBufferCluster3 = new boost::circular_buffer<lightSignal>(detectionCycleTimeFrames);
+	// historyBuffer = new std::deque<lightSignal>();
 
-  // open interfaces
-  std::string position_3d_interface_name =
-      config->get_string((cfg_prefix + "light_position_if").c_str());
-  nearestMaschineIF1 =
-      blackboard->open_for_reading<fawkes::Position3DInterface>(
-          (position_3d_interface_name + "1").c_str());
-  nearestMaschineIF2 =
-      blackboard->open_for_reading<fawkes::Position3DInterface>(
-          (position_3d_interface_name + "2").c_str());
-  nearestMaschineIF3 =
-      blackboard->open_for_reading<fawkes::Position3DInterface>(
-          (position_3d_interface_name + "3").c_str());
+	// open interfaces
+	std::string position_3d_interface_name =
+	  config->get_string((cfg_prefix + "light_position_if").c_str());
+	nearestMaschineIF1 = blackboard->open_for_reading<fawkes::Position3DInterface>(
+	  (position_3d_interface_name + "1").c_str());
+	nearestMaschineIF2 = blackboard->open_for_reading<fawkes::Position3DInterface>(
+	  (position_3d_interface_name + "2").c_str());
+	nearestMaschineIF3 = blackboard->open_for_reading<fawkes::Position3DInterface>(
+	  (position_3d_interface_name + "3").c_str());
 
-  std::string light_interface_name =
-      config->get_string((cfg_prefix + "light_state_if").c_str());
-  lightStateIF1 = blackboard->open_for_writing<fawkes::RobotinoLightInterface>(
-      (light_interface_name + "1").c_str());
-  lightStateIF2 = blackboard->open_for_writing<fawkes::RobotinoLightInterface>(
-      (light_interface_name + "2").c_str());
-  lightStateIF3 = blackboard->open_for_writing<fawkes::RobotinoLightInterface>(
-      (light_interface_name + "3").c_str());
+	std::string light_interface_name = config->get_string((cfg_prefix + "light_state_if").c_str());
+	lightStateIF1                    = blackboard->open_for_writing<fawkes::RobotinoLightInterface>(
+    (light_interface_name + "1").c_str());
+	lightStateIF2 = blackboard->open_for_writing<fawkes::RobotinoLightInterface>(
+	  (light_interface_name + "2").c_str());
+	lightStateIF3 = blackboard->open_for_writing<fawkes::RobotinoLightInterface>(
+	  (light_interface_name + "3").c_str());
 
-  try {
-    switchInterface = blackboard->open_for_writing<fawkes::SwitchInterface>(
-        "light_front_switch");
-    switchInterface->set_enabled(true);
-    switchInterface->write();
-  } catch (fawkes::Exception &e) {
-    e.append("Opening switch interface for writing failed");
-    throw;
-  }
+	try {
+		switchInterface = blackboard->open_for_writing<fawkes::SwitchInterface>("light_front_switch");
+		switchInterface->set_enabled(true);
+		switchInterface->write();
+	} catch (fawkes::Exception &e) {
+		e.append("Opening switch interface for writing failed");
+		throw;
+	}
 
-  // ROIs
-  drawer = new firevision::FilterROIDraw();
+	// ROIs
+	drawer = new firevision::FilterROIDraw();
 
-  resetLightInterface(lightStateIF1);
-  resetLightInterface(lightStateIF2);
-  resetLightInterface(lightStateIF3);
+	resetLightInterface(lightStateIF1);
+	resetLightInterface(lightStateIF2);
+	resetLightInterface(lightStateIF3);
 
-  resetLocalHistory();
+	resetLocalHistory();
 
-  logger->log_debug(name(), "end of init()");
+	logger->log_debug(name(), "end of init()");
 }
 
 void LightFrontThread::finalize() // TODO check if everthing gets deleted
 {
-  logger->log_debug(name(), "start to free memory");
+	logger->log_debug(name(), "start to free memory");
 
-  vision_master->unregister_thread(this);
+	vision_master->unregister_thread(this);
 
-  delete camera;
-  delete scanline;
-  delete colorModel;
-  delete classifierWhite;
-  delete shmBufferYCbCr;
-  delete historyBufferCluster1;
-  delete historyBufferCluster2;
-  delete historyBufferCluster3;
+	delete camera;
+	delete scanline;
+	delete colorModel;
+	delete classifierWhite;
+	delete shmBufferYCbCr;
+	delete historyBufferCluster1;
+	delete historyBufferCluster2;
+	delete historyBufferCluster3;
 
-  blackboard->close(nearestMaschineIF1);
-  blackboard->close(nearestMaschineIF2);
-  blackboard->close(nearestMaschineIF3);
-  blackboard->close(lightStateIF1);
-  blackboard->close(lightStateIF2);
-  blackboard->close(lightStateIF3);
+	blackboard->close(nearestMaschineIF1);
+	blackboard->close(nearestMaschineIF2);
+	blackboard->close(nearestMaschineIF3);
+	blackboard->close(lightStateIF1);
+	blackboard->close(lightStateIF2);
+	blackboard->close(lightStateIF3);
 
-  blackboard->close(switchInterface);
+	blackboard->close(switchInterface);
 
-  logger->log_info(name(), "ends");
+	logger->log_info(name(), "ends");
 }
 
-void LightFrontThread::process_light(
-    fawkes::Position3DInterface *position_interface,
-    fawkes::RobotinoLightInterface *light_interface,
-    boost::circular_buffer<LightFrontThread::lightSignal> *buffer) {
-  position_interface->read();
-  bool contiueToPictureProcess = false;
-  fawkes::cart_coord_3d_t lightPosition =
-      getNearestMaschineFromInterface(position_interface);
-  int clusterVisibilityHistory = position_interface->visibility_history();
-  if (cfg_simulateLaserData) {
-    lightPosition.x = cfg_simulate_laser_x;
-    lightPosition.y = cfg_simulate_laser_y;
-    clusterVisibilityHistory = cfg_simulate_laser_history;
-  }
-  fawkes::polar_coord_2d_t lightPositionPolar;
-  if (clusterVisibilityHistory > cfg_laserVisibilityThreshold) {
-    if (clusterVisibilityHistory > 0) {
-      lightPositionPolar = transformCoordinateSystem(
-          lightPosition, position_interface->frame(), cfg_frame);
-      if (isLightInViewarea(lightPositionPolar)) {
-        lightOutOfRangeCounter = 0;
-        contiueToPictureProcess = true;
-      } else {
-        if (lightOutOfRangeCounter < cfg_lightOutOfRangeThreshold) {
-          if (!buffer->empty()) {
-            lightPositionPolar = buffer->front().nearestMaschine_pos;
-            contiueToPictureProcess = true;
-          } else {
-            resetLightInterface(light_interface,
-                                "light is out of range and buffer is empty");
-            buffer->clear();
-          }
-        } else {
-          resetLightInterface(light_interface,
-                              "light is to often out of range for camera");
-          buffer->clear();
-        }
-      }
-    } else if (!buffer->empty()) {
-      lightPositionPolar = buffer->front().nearestMaschine_pos;
-      contiueToPictureProcess = true;
-    } else {
-      resetLightInterface(light_interface,
-                          "laser visibility is < 0 and buffer is empty");
-      buffer->clear();
-    }
-  } else {
-    // if the laser doen't see anything, use it as the robot is directy in front
-    // of the light
-    lightPositionPolar.r = cfg_lightToCloseThrashold;
-    lightPositionPolar.phi = 0.0;
-    contiueToPictureProcess = true;
-    //		resetLightInterface("laser visibility lower than threashold");
-    //		resetLocalHistory();
-  }
-  if (contiueToPictureProcess) {
-    try {
-      LightFrontThread::lightROIs lightROIs =
-          calculateLightPos(lightPositionPolar);
-      takePicture(lightROIs);
-      // correct light position
-      if (cfg_lightPositionCorrection) {
-        lightROIs = correctLightRoisWithBlack(lightROIs);
-        if (cfg_paintROIsActivated) {
-          drawROIIntoBuffer(lightROIs.light);
-          drawROIIntoBuffer(lightROIs.red);
-          drawROIIntoBuffer(lightROIs.yellow);
-          drawROIIntoBuffer(lightROIs.green);
-        }
-      }
-      LightFrontThread::lightSignal lightSignalCurrentPicture =
-          detectLightInCurrentPicture(lightROIs);
-      lightSignalCurrentPicture.nearestMaschine_pos = lightPositionPolar;
-      lightSignalCurrentPicture.nearestMaschine_history =
-          clusterVisibilityHistory;
-      buffer->push_front(lightSignalCurrentPicture);
-      processHistoryBuffer(light_interface, buffer);
-    } catch (fawkes::Exception &e) {
-      resetLightInterface(light_interface, "ROI is outside of the buffer");
-      buffer->clear();
-    }
-  }
+void
+LightFrontThread::process_light(fawkes::Position3DInterface *   position_interface,
+                                fawkes::RobotinoLightInterface *light_interface,
+                                boost::circular_buffer<LightFrontThread::lightSignal> *buffer)
+{
+	position_interface->read();
+	bool                    contiueToPictureProcess = false;
+	fawkes::cart_coord_3d_t lightPosition = getNearestMaschineFromInterface(position_interface);
+	int                     clusterVisibilityHistory = position_interface->visibility_history();
+	if (cfg_simulateLaserData) {
+		lightPosition.x          = cfg_simulate_laser_x;
+		lightPosition.y          = cfg_simulate_laser_y;
+		clusterVisibilityHistory = cfg_simulate_laser_history;
+	}
+	fawkes::polar_coord_2d_t lightPositionPolar;
+	if (clusterVisibilityHistory > cfg_laserVisibilityThreshold) {
+		if (clusterVisibilityHistory > 0) {
+			lightPositionPolar =
+			  transformCoordinateSystem(lightPosition, position_interface->frame(), cfg_frame);
+			if (isLightInViewarea(lightPositionPolar)) {
+				lightOutOfRangeCounter  = 0;
+				contiueToPictureProcess = true;
+			} else {
+				if (lightOutOfRangeCounter < cfg_lightOutOfRangeThreshold) {
+					if (!buffer->empty()) {
+						lightPositionPolar      = buffer->front().nearestMaschine_pos;
+						contiueToPictureProcess = true;
+					} else {
+						resetLightInterface(light_interface, "light is out of range and buffer is empty");
+						buffer->clear();
+					}
+				} else {
+					resetLightInterface(light_interface, "light is to often out of range for camera");
+					buffer->clear();
+				}
+			}
+		} else if (!buffer->empty()) {
+			lightPositionPolar      = buffer->front().nearestMaschine_pos;
+			contiueToPictureProcess = true;
+		} else {
+			resetLightInterface(light_interface, "laser visibility is < 0 and buffer is empty");
+			buffer->clear();
+		}
+	} else {
+		// if the laser doen't see anything, use it as the robot is directy in front
+		// of the light
+		lightPositionPolar.r    = cfg_lightToCloseThrashold;
+		lightPositionPolar.phi  = 0.0;
+		contiueToPictureProcess = true;
+		//		resetLightInterface("laser visibility lower than threashold");
+		//		resetLocalHistory();
+	}
+	if (contiueToPictureProcess) {
+		try {
+			LightFrontThread::lightROIs lightROIs = calculateLightPos(lightPositionPolar);
+			takePicture(lightROIs);
+			// correct light position
+			if (cfg_lightPositionCorrection) {
+				lightROIs = correctLightRoisWithBlack(lightROIs);
+				if (cfg_paintROIsActivated) {
+					drawROIIntoBuffer(lightROIs.light);
+					drawROIIntoBuffer(lightROIs.red);
+					drawROIIntoBuffer(lightROIs.yellow);
+					drawROIIntoBuffer(lightROIs.green);
+				}
+			}
+			LightFrontThread::lightSignal lightSignalCurrentPicture =
+			  detectLightInCurrentPicture(lightROIs);
+			lightSignalCurrentPicture.nearestMaschine_pos     = lightPositionPolar;
+			lightSignalCurrentPicture.nearestMaschine_history = clusterVisibilityHistory;
+			buffer->push_front(lightSignalCurrentPicture);
+			processHistoryBuffer(light_interface, buffer);
+		} catch (fawkes::Exception &e) {
+			resetLightInterface(light_interface, "ROI is outside of the buffer");
+			buffer->clear();
+		}
+	}
 }
 
-void LightFrontThread::loop() {
-  while (!switchInterface->msgq_empty()) {
-    if (fawkes::SwitchInterface::DisableSwitchMessage *msg =
-            switchInterface->msgq_first_safe(msg)) {
-      switchInterface->set_enabled(false);
-      resetLocalHistory();
-      resetLightInterface(lightStateIF1, "Switch disable message received");
-      resetLightInterface(lightStateIF2, "Switch disable message received");
-      resetLightInterface(lightStateIF3, "Switch disable message received");
-    } else if (fawkes::SwitchInterface::EnableSwitchMessage *msg =
-                   switchInterface->msgq_first_safe(msg)) {
-      switchInterface->set_enabled(true);
-      resetLocalHistory();
-      resetLightInterface(lightStateIF1, "Switch enable message received");
-      resetLightInterface(lightStateIF2, "Switch enable message received");
-      resetLightInterface(lightStateIF3, "Switch enable message received");
-    }
-    switchInterface->msgq_pop();
-    switchInterface->write();
-  }
+void
+LightFrontThread::loop()
+{
+	while (!switchInterface->msgq_empty()) {
+		if (fawkes::SwitchInterface::DisableSwitchMessage *msg =
+		      switchInterface->msgq_first_safe(msg)) {
+			switchInterface->set_enabled(false);
+			resetLocalHistory();
+			resetLightInterface(lightStateIF1, "Switch disable message received");
+			resetLightInterface(lightStateIF2, "Switch disable message received");
+			resetLightInterface(lightStateIF3, "Switch disable message received");
+		} else if (fawkes::SwitchInterface::EnableSwitchMessage *msg =
+		             switchInterface->msgq_first_safe(msg)) {
+			switchInterface->set_enabled(true);
+			resetLocalHistory();
+			resetLightInterface(lightStateIF1, "Switch enable message received");
+			resetLightInterface(lightStateIF2, "Switch enable message received");
+			resetLightInterface(lightStateIF3, "Switch enable message received");
+		}
+		switchInterface->msgq_pop();
+		switchInterface->write();
+	}
 
-  if (!switchInterface->is_enabled()) {
-    return;
-  }
+	if (!switchInterface->is_enabled()) {
+		return;
+	}
 
-  // read laser if
-  nearestMaschineIF1->read();
-  process_light(nearestMaschineIF1, lightStateIF1, historyBufferCluster1);
+	// read laser if
+	nearestMaschineIF1->read();
+	process_light(nearestMaschineIF1, lightStateIF1, historyBufferCluster1);
 
-  if (cfg_useMulticluster) {
-    nearestMaschineIF2->read();
-    nearestMaschineIF3->read();
-    process_light(nearestMaschineIF2, lightStateIF2, historyBufferCluster2);
-    process_light(nearestMaschineIF3, lightStateIF3, historyBufferCluster3);
-  }
+	if (cfg_useMulticluster) {
+		nearestMaschineIF2->read();
+		nearestMaschineIF3->read();
+		process_light(nearestMaschineIF2, lightStateIF2, historyBufferCluster2);
+		process_light(nearestMaschineIF3, lightStateIF3, historyBufferCluster3);
+	}
 }
 
-bool LightFrontThread::isLightInViewarea(fawkes::polar_coord_2d_t light) {
-  float cameraAngleDetectionArea = (cfg_cameraFactorHorizontal / 2) - 0.1;
+bool
+LightFrontThread::isLightInViewarea(fawkes::polar_coord_2d_t light)
+{
+	float cameraAngleDetectionArea = (cfg_cameraFactorHorizontal / 2) - 0.1;
 
-  if (std::abs(light.phi) >= cameraAngleDetectionArea &&
-      light.r < cfg_lightToCloseThrashold) {
-    return false;
-  } else {
-    return true;
-  }
+	if (std::abs(light.phi) >= cameraAngleDetectionArea && light.r < cfg_lightToCloseThrashold) {
+		return false;
+	} else {
+		return true;
+	}
 }
 
-void LightFrontThread::takePicture(LightFrontThread::lightROIs lightROIs) {
-  camera->capture();
-  firevision::convert(cspaceFrom, cspaceTo, camera->buffer(), bufferYCbCr,
-                      img_width, img_height);
-  camera->dispose_buffer();
+void
+LightFrontThread::takePicture(LightFrontThread::lightROIs lightROIs)
+{
+	camera->capture();
+	firevision::convert(cspaceFrom, cspaceTo, camera->buffer(), bufferYCbCr, img_width, img_height);
+	camera->dispose_buffer();
 
-  // draw expected light in buffer
-  if (cfg_paintROIsActivated) {
-    drawROIIntoBuffer(lightROIs.light);
-    drawROIIntoBuffer(lightROIs.red);
-    drawROIIntoBuffer(lightROIs.yellow);
-    drawROIIntoBuffer(lightROIs.green);
-  }
+	// draw expected light in buffer
+	if (cfg_paintROIsActivated) {
+		drawROIIntoBuffer(lightROIs.light);
+		drawROIIntoBuffer(lightROIs.red);
+		drawROIIntoBuffer(lightROIs.yellow);
+		drawROIIntoBuffer(lightROIs.green);
+	}
 }
 
 firevision::ROI
-LightFrontThread::getBiggestRoi(std::list<firevision::ROI> *roiList) {
-  firevision::ROI *biggestRoi = new firevision::ROI();
+LightFrontThread::getBiggestRoi(std::list<firevision::ROI> *roiList)
+{
+	firevision::ROI *biggestRoi = new firevision::ROI();
 
-  for (std::list<firevision::ROI>::iterator it = roiList->begin();
-       it != roiList->end(); ++it) {
-    if (biggestRoi == NULL ||
-        biggestRoi->width * biggestRoi->height < (*it).width * (*it).height) {
-      biggestRoi = &(*it);
-    }
-  }
-  return biggestRoi;
+	for (std::list<firevision::ROI>::iterator it = roiList->begin(); it != roiList->end(); ++it) {
+		if (biggestRoi == NULL || biggestRoi->width * biggestRoi->height < (*it).width * (*it).height) {
+			biggestRoi = &(*it);
+		}
+	}
+	return biggestRoi;
 }
 
-LightFrontThread::lightROIs LightFrontThread::correctLightRoisWithBlack(
-    LightFrontThread::lightROIs expectedLight) {
-  // Look in area around the red light for the back top of the light
+LightFrontThread::lightROIs
+LightFrontThread::correctLightRoisWithBlack(LightFrontThread::lightROIs expectedLight)
+{
+	// Look in area around the red light for the back top of the light
 
-  firevision::ROI *searchAreaBottem = new firevision::ROI(expectedLight.light);
-  searchAreaBottem->start.x =
-      expectedLight.light.start.x - 3 * expectedLight.light.width;
-  searchAreaBottem->start.y = expectedLight.light.start.y +
-                              expectedLight.light.height -
-                              expectedLight.light.width;
-  searchAreaBottem->width = expectedLight.light.width * 7;
-  searchAreaBottem->height = 2 * expectedLight.light.width;
+	firevision::ROI *searchAreaBottem = new firevision::ROI(expectedLight.light);
+	searchAreaBottem->start.x         = expectedLight.light.start.x - 3 * expectedLight.light.width;
+	searchAreaBottem->start.y =
+	  expectedLight.light.start.y + expectedLight.light.height - expectedLight.light.width;
+	searchAreaBottem->width  = expectedLight.light.width * 7;
+	searchAreaBottem->height = 2 * expectedLight.light.width;
 
-  if (cfg_paintROIsActivated) {
-    drawROIIntoBuffer(searchAreaBottem);
-  }
+	if (cfg_paintROIsActivated) {
+		drawROIIntoBuffer(searchAreaBottem);
+	}
 
-  std::list<firevision::ROI> *bottemBlackRoiList =
-      classifyInRoi(searchAreaBottem, classifierBlack);
+	std::list<firevision::ROI> *bottemBlackRoiList = classifyInRoi(searchAreaBottem, classifierBlack);
 
-  if (!bottemBlackRoiList->empty()) {
-    firevision::ROI bottemBlackRoi = getBiggestRoi(bottemBlackRoiList);
+	if (!bottemBlackRoiList->empty()) {
+		firevision::ROI bottemBlackRoi = getBiggestRoi(bottemBlackRoiList);
 
-    drawROIIntoBuffer(bottemBlackRoi);
+		drawROIIntoBuffer(bottemBlackRoi);
 
-    if (cfg_debugMessagesActivated) {
-      logger->log_debug(name(), "Bottem: X: %u Y: %u Height: %u Width: %u",
-                        bottemBlackRoi.start.x, bottemBlackRoi.start.y,
-                        bottemBlackRoi.height, bottemBlackRoi.width);
-    }
+		if (cfg_debugMessagesActivated) {
+			logger->log_debug(name(),
+			                  "Bottem: X: %u Y: %u Height: %u Width: %u",
+			                  bottemBlackRoi.start.x,
+			                  bottemBlackRoi.start.y,
+			                  bottemBlackRoi.height,
+			                  bottemBlackRoi.width);
+		}
 
-    // Look in the area around the Red light for a black roi (top cap) for
-    // validation
-    firevision::ROI *searchAreaTop = new firevision::ROI(bottemBlackRoi);
+		// Look in the area around the Red light for a black roi (top cap) for
+		// validation
+		firevision::ROI *searchAreaTop = new firevision::ROI(bottemBlackRoi);
 
-    searchAreaTop->start.y =
-        expectedLight.light.start.y - 2 * (expectedLight.light.height / 3);
-    searchAreaTop->height = expectedLight.green.height * 6;
+		searchAreaTop->start.y = expectedLight.light.start.y - 2 * (expectedLight.light.height / 3);
+		searchAreaTop->height  = expectedLight.green.height * 6;
 
-    std::list<firevision::ROI> *topBlackRoiList =
-        classifyInRoi(searchAreaTop, classifierBlack);
-    if (!topBlackRoiList->empty()) {
+		std::list<firevision::ROI> *topBlackRoiList = classifyInRoi(searchAreaTop, classifierBlack);
+		if (!topBlackRoiList->empty()) {
+			firevision::ROI topBiggestRoi = getBiggestRoi(topBlackRoiList);
+			drawROIIntoBuffer(topBiggestRoi);
 
-      firevision::ROI topBiggestRoi = getBiggestRoi(topBlackRoiList);
-      drawROIIntoBuffer(topBiggestRoi);
+			if (cfg_debugMessagesActivated) {
+				logger->log_debug(name(),
+				                  "Top: X: %u Y: %u Height: %u Width: %u",
+				                  topBiggestRoi.start.x,
+				                  topBiggestRoi.start.y,
+				                  topBiggestRoi.height,
+				                  topBiggestRoi.width);
+			}
+			firevision::ROI light;
+			light.start.x = topBiggestRoi.start.x;
+			light.start.y = topBiggestRoi.start.y + topBiggestRoi.height;
+			light.height  = bottemBlackRoi.start.y - (topBiggestRoi.start.y + topBiggestRoi.height);
+			light.width   = std::min(bottemBlackRoi.width, topBiggestRoi.width);
 
-      if (cfg_debugMessagesActivated) {
-        logger->log_debug(name(), "Top: X: %u Y: %u Height: %u Width: %u",
-                          topBiggestRoi.start.x, topBiggestRoi.start.y,
-                          topBiggestRoi.height, topBiggestRoi.width);
-      }
-      firevision::ROI light;
-      light.start.x = topBiggestRoi.start.x;
-      light.start.y = topBiggestRoi.start.y + topBiggestRoi.height;
-      light.height = bottemBlackRoi.start.y -
-                     (topBiggestRoi.start.y + topBiggestRoi.height);
-      light.width = std::min(bottemBlackRoi.width, topBiggestRoi.width);
+			checkIfROIIsInBuffer(light);
+			expectedLight = createLightROIs(light);
+		} else {
+			logger->log_debug(name(), "No black-bottom roi found");
+		}
+	} else {
+		logger->log_debug(name(), "No black roi found");
+	}
 
-      checkIfROIIsInBuffer(light);
-      expectedLight = createLightROIs(light);
-    } else {
-      logger->log_debug(name(), "No black-bottom roi found");
-    }
-  } else {
-    logger->log_debug(name(), "No black roi found");
-  }
-
-  return expectedLight;
+	return expectedLight;
 }
 
-LightFrontThread::lightSignal LightFrontThread::detectLightInCurrentPicture(
-    LightFrontThread::lightROIs lightROIs) {
-  LightFrontThread::lightSignal lightSignal;
+LightFrontThread::lightSignal
+LightFrontThread::detectLightInCurrentPicture(LightFrontThread::lightROIs lightROIs)
+{
+	LightFrontThread::lightSignal lightSignal;
 
-  lightSignal.red = signalLightCurrentPicture(lightROIs.red);
-  lightSignal.yellow = signalLightCurrentPicture(lightROIs.yellow);
-  lightSignal.green = signalLightCurrentPicture(lightROIs.green);
+	lightSignal.red    = signalLightCurrentPicture(lightROIs.red);
+	lightSignal.yellow = signalLightCurrentPicture(lightROIs.yellow);
+	lightSignal.green  = signalLightCurrentPicture(lightROIs.green);
 
-  return lightSignal;
+	return lightSignal;
 }
 
 void LightFrontThread::processHistoryBuffer(
-    fawkes::RobotinoLightInterface *interface,
-    boost::circular_buffer<LightFrontThread::lightSignal> *
-        buffer) // TODO change function name to say that the interface is writen
+  fawkes::RobotinoLightInterface *interface,
+  boost::circular_buffer<LightFrontThread::lightSignal>
+    *buffer) // TODO change function name to say that the interface is writen
 {
-  if (historyBufferCluster1->full()) {
-    LightFrontThread::lightSignal lighSignal;
+	if (historyBufferCluster1->full()) {
+		LightFrontThread::lightSignal lighSignal;
 
-    if (lightFromHistoryBuffer(buffer, &lighSignal)) {
-      if (lighSignal.red != fawkes::RobotinoLightInterface::UNKNOWN &&
-          lighSignal.yellow != fawkes::RobotinoLightInterface::UNKNOWN &&
-          lighSignal.green != fawkes::RobotinoLightInterface::UNKNOWN &&
-          !(lighSignal.red == fawkes::RobotinoLightInterface::OFF &&
-            lighSignal.yellow == fawkes::RobotinoLightInterface::OFF &&
-            lighSignal.green == fawkes::RobotinoLightInterface::OFF)) {
+		if (lightFromHistoryBuffer(buffer, &lighSignal)) {
+			if (lighSignal.red != fawkes::RobotinoLightInterface::UNKNOWN
+			    && lighSignal.yellow != fawkes::RobotinoLightInterface::UNKNOWN
+			    && lighSignal.green != fawkes::RobotinoLightInterface::UNKNOWN
+			    && !(lighSignal.red == fawkes::RobotinoLightInterface::OFF
+			         && lighSignal.yellow == fawkes::RobotinoLightInterface::OFF
+			         && lighSignal.green == fawkes::RobotinoLightInterface::OFF)) {
+				writeLightInterface(interface, lighSignal, true);
 
-        writeLightInterface(interface, lighSignal, true);
-
-      } else {
-        resetLightInterface(interface, "light couldn't get detected");
-      }
-    } else {
-      resetLightInterface(interface, "cluster jumped");
-    }
-  } else {
-    writeLightInterface(interface, buffer->front(), false);
-  }
+			} else {
+				resetLightInterface(interface, "light couldn't get detected");
+			}
+		} else {
+			resetLightInterface(interface, "cluster jumped");
+		}
+	} else {
+		writeLightInterface(interface, buffer->front(), false);
+	}
 }
 
-LightFrontThread::~LightFrontThread() {
-  // TODO Auto-generated destructor stub
+LightFrontThread::~LightFrontThread()
+{
+	// TODO Auto-generated destructor stub
 }
 
 fawkes::polar_coord_2d_t
 LightFrontThread::transformCoordinateSystem(fawkes::cart_coord_3d_t cartFrom,
-                                            std::string from, std::string to) {
-  fawkes::polar_coord_2d_t polErrorReturnValue;
-  cartToPol(polErrorReturnValue, cartFrom.x, cartFrom.y);
+                                            std::string             from,
+                                            std::string             to)
+{
+	fawkes::polar_coord_2d_t polErrorReturnValue;
+	cartToPol(polErrorReturnValue, cartFrom.x, cartFrom.y);
 
-  bool world_frame_exists = tf_listener->frame_exists(from);
-  bool robot_frame_exists = tf_listener->frame_exists(to);
+	bool world_frame_exists = tf_listener->frame_exists(from);
+	bool robot_frame_exists = tf_listener->frame_exists(to);
 
-  if (!world_frame_exists || !robot_frame_exists) {
-    logger->log_warn(name(), "Frame missing: %s %s   %s %s", from.c_str(),
-                     world_frame_exists ? "exists" : "missing", to.c_str(),
-                     robot_frame_exists ? "exists" : "missing");
-  } else {
-    fawkes::tf::StampedTransform transform;
-    try {
-      tf_listener->lookup_transform(to, from, transform);
-    } catch (fawkes::tf::ExtrapolationException &e) {
-      logger->log_debug(name(), "Extrapolation error");
-      return polErrorReturnValue;
-    } catch (fawkes::tf::ConnectivityException &e) {
-      logger->log_debug(name(), "Connectivity exception: %s", e.what());
-      return polErrorReturnValue;
-    }
+	if (!world_frame_exists || !robot_frame_exists) {
+		logger->log_warn(name(),
+		                 "Frame missing: %s %s   %s %s",
+		                 from.c_str(),
+		                 world_frame_exists ? "exists" : "missing",
+		                 to.c_str(),
+		                 robot_frame_exists ? "exists" : "missing");
+	} else {
+		fawkes::tf::StampedTransform transform;
+		try {
+			tf_listener->lookup_transform(to, from, transform);
+		} catch (fawkes::tf::ExtrapolationException &e) {
+			logger->log_debug(name(), "Extrapolation error");
+			return polErrorReturnValue;
+		} catch (fawkes::tf::ConnectivityException &e) {
+			logger->log_debug(name(), "Connectivity exception: %s", e.what());
+			return polErrorReturnValue;
+		}
 
-    fawkes::tf::Vector3 v = transform.getOrigin();
+		fawkes::tf::Vector3 v = transform.getOrigin();
 
-    fawkes::polar_coord_2d_t polTo;
-    float toX, toY;
+		fawkes::polar_coord_2d_t polTo;
+		float                    toX, toY;
 
-    toX = cartFrom.x + v.getX();
-    toY = cartFrom.y + v.getY();
-    cartToPol(polTo, toX, toY);
+		toX = cartFrom.x + v.getX();
+		toY = cartFrom.y + v.getY();
+		cartToPol(polTo, toX, toY);
 
-    if (cfg_debugMessagesActivated) {
-      logger->log_debug(name(), "From: %s X: %f Y: %f", from.c_str(),
-                        cartFrom.x, cartFrom.y);
-      logger->log_debug(name(), "To  : %s X: %f Y: %f", to.c_str(), toX, toY);
-    }
-    return polTo;
-  }
+		if (cfg_debugMessagesActivated) {
+			logger->log_debug(name(), "From: %s X: %f Y: %f", from.c_str(), cartFrom.x, cartFrom.y);
+			logger->log_debug(name(), "To  : %s X: %f Y: %f", to.c_str(), toX, toY);
+		}
+		return polTo;
+	}
 
-  return polErrorReturnValue;
+	return polErrorReturnValue;
 }
 
-void LightFrontThread::cartToPol(fawkes::polar_coord_2d_t &pol, float x,
-                                 float y) {
-  pol.phi = atan2f(y, x);
-  pol.r = sqrtf(x * x + y * y);
+void
+LightFrontThread::cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y)
+{
+	pol.phi = atan2f(y, x);
+	pol.r   = sqrtf(x * x + y * y);
 
-  if (cfg_debugMessagesActivated) {
-    logger->log_debug(name(), "x: %f; y: %f", x, y);
-    logger->log_debug(name(), "Calculated r: %f; phi: %f", pol.r, pol.phi);
-  }
+	if (cfg_debugMessagesActivated) {
+		logger->log_debug(name(), "x: %f; y: %f", x, y);
+		logger->log_debug(name(), "Calculated r: %f; phi: %f", pol.r, pol.phi);
+	}
 }
 
-void LightFrontThread::polToCart(float &x, float &y,
-                                 fawkes::polar_coord_2d_t pol) {
-  x = pol.r * std::cos(pol.phi);
-  y = pol.r * std::sin(pol.phi);
+void
+LightFrontThread::polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol)
+{
+	x = pol.r * std::cos(pol.phi);
+	y = pol.r * std::sin(pol.phi);
 }
 
-void LightFrontThread::drawROIIntoBuffer(
-    firevision::ROI roi,
-    firevision::FilterROIDraw::border_style_t borderStyle) {
-  drawer->set_src_buffer(bufferYCbCr,
-                         firevision::ROI::full_image(img_width, img_height), 0);
-  drawer->set_dst_buffer(bufferYCbCr, &roi);
-  drawer->set_style(borderStyle);
-  drawer->apply();
+void
+LightFrontThread::drawROIIntoBuffer(firevision::ROI                           roi,
+                                    firevision::FilterROIDraw::border_style_t borderStyle)
+{
+	drawer->set_src_buffer(bufferYCbCr, firevision::ROI::full_image(img_width, img_height), 0);
+	drawer->set_dst_buffer(bufferYCbCr, &roi);
+	drawer->set_style(borderStyle);
+	drawer->apply();
 
-  if (cfg_debugMessagesActivated) {
-    logger->log_debug(name(), "drawed element in buffer");
-  }
+	if (cfg_debugMessagesActivated) {
+		logger->log_debug(name(), "drawed element in buffer");
+	}
 }
 
-void LightFrontThread::checkIfROIIsInBuffer(const firevision::ROI &light) {
-  if (light.start.x >= img_width || light.start.y >= img_height ||
-      light.height + light.start.y >= img_height ||
-      light.width + light.start.x >= img_width) {
-    throw fawkes::Exception("ROI is outsite of the buffer");
-  } else {
-    if (cfg_debugMessagesActivated) {
-      logger->log_info(name(), "Size check ok");
-    }
-  }
+void
+LightFrontThread::checkIfROIIsInBuffer(const firevision::ROI &light)
+{
+	if (light.start.x >= img_width || light.start.y >= img_height
+	    || light.height + light.start.y >= img_height || light.width + light.start.x >= img_width) {
+		throw fawkes::Exception("ROI is outsite of the buffer");
+	} else {
+		if (cfg_debugMessagesActivated) {
+			logger->log_info(name(), "Size check ok");
+		}
+	}
 }
 
-int LightFrontThread::angleCorrectionY(float distance) {
-  return img_height / (distance * cfg_cameraFactorVertical) *
-         tan(cfg_cameraAngleVerticalRad);
+int
+LightFrontThread::angleCorrectionY(float distance)
+{
+	return img_height / (distance * cfg_cameraFactorVertical) * tan(cfg_cameraAngleVerticalRad);
 }
 
-int LightFrontThread::angleCorrectionX(float distance) {
-  return img_width / (distance * cfg_cameraFactorHorizontal) *
-         tan(cfg_cameraAngleHorizontalRad);
-}
-
-LightFrontThread::lightROIs
-LightFrontThread::calculateLightPos(fawkes::polar_coord_2d_t lightPos) {
-  int expectedLightSizeWidth = img_width /
-                               (lightPos.r * cfg_cameraFactorHorizontal) *
-                               cfg_lightSizeWidth;
-  int expectedLightSizeHeigth = img_height /
-                                (lightPos.r * cfg_cameraFactorVertical) *
-                                cfg_lightSizeHeight;
-  float pixelPerRadHorizonal = img_width / cfg_cameraFactorHorizontal;
-
-  int startX = img_width / 2                         // picture center
-               - lightPos.phi * pixelPerRadHorizonal // move to the light
-               - expectedLightSizeWidth / 2;
-
-  int startY =
-      img_height / 2 // picture center
-      - expectedLightSizeHeigth /
-            2; // light center to light cornor;  //light center to light cornor
-
-  startY = startY +
-           cfg_cameraOffsetVertical // error of picture position to light
-           + angleCorrectionY(lightPos.r);
-
-  if (cfg_useMinDistanceThreashold &&
-      cfg_lightMoveUnderRfidThrashold >= lightPos.r) {
-    startX = cfg_center_x;
-    startY = cfg_center_y;
-    expectedLightSizeHeigth = cfg_center_height;
-    expectedLightSizeWidth = cfg_center_width;
-  }
-
-  firevision::ROI light;
-  light.start.x = startX;
-  light.start.y = startY;
-  light.height = expectedLightSizeHeigth;
-  light.width = expectedLightSizeWidth;
-
-  checkIfROIIsInBuffer(light);
-
-  return createLightROIs(light);
+int
+LightFrontThread::angleCorrectionX(float distance)
+{
+	return img_width / (distance * cfg_cameraFactorHorizontal) * tan(cfg_cameraAngleHorizontalRad);
 }
 
 LightFrontThread::lightROIs
-LightFrontThread::createLightROIs(firevision::ROI light) {
-  LightFrontThread::lightROIs lightROIs;
+LightFrontThread::calculateLightPos(fawkes::polar_coord_2d_t lightPos)
+{
+	int expectedLightSizeWidth =
+	  img_width / (lightPos.r * cfg_cameraFactorHorizontal) * cfg_lightSizeWidth;
+	int expectedLightSizeHeigth =
+	  img_height / (lightPos.r * cfg_cameraFactorVertical) * cfg_lightSizeHeight;
+	float pixelPerRadHorizonal = img_width / cfg_cameraFactorHorizontal;
 
-  // light ROI size
-  lightROIs.light = light;
-  lightROIs.light.image_height = img_height;
-  lightROIs.light.image_width = img_width;
+	int startX = img_width / 2                         // picture center
+	             - lightPos.phi * pixelPerRadHorizonal // move to the light
+	             - expectedLightSizeWidth / 2;
 
-  // Signale ROIs
+	int startY =
+	  img_height / 2                 // picture center
+	  - expectedLightSizeHeigth / 2; // light center to light cornor;  //light center to light cornor
 
-  lightROIs.red = lightROIs.light;
-  lightROIs.yellow = lightROIs.light;
-  lightROIs.green = lightROIs.light;
+	startY = startY + cfg_cameraOffsetVertical // error of picture position to light
+	         + angleCorrectionY(lightPos.r);
 
-  float roiHeight = ((float)lightROIs.light.height) / 9;
+	if (cfg_useMinDistanceThreashold && cfg_lightMoveUnderRfidThrashold >= lightPos.r) {
+		startX                  = cfg_center_x;
+		startY                  = cfg_center_y;
+		expectedLightSizeHeigth = cfg_center_height;
+		expectedLightSizeWidth  = cfg_center_width;
+	}
 
-  lightROIs.red.height = roiHeight;
-  lightROIs.red.start.y += roiHeight; // Middle of the top thirds
+	firevision::ROI light;
+	light.start.x = startX;
+	light.start.y = startY;
+	light.height  = expectedLightSizeHeigth;
+	light.width   = expectedLightSizeWidth;
 
-  lightROIs.yellow.height = roiHeight;
-  lightROIs.yellow.start.y += roiHeight * 4; // Middle of the middle thirds
+	checkIfROIIsInBuffer(light);
 
-  lightROIs.green.height = roiHeight;
-  lightROIs.green.start.y += roiHeight * 7; // Middle of the bottom thirds
-
-  if (cfg_debugMessagesActivated) {
-    logger->log_info(name(), "light.start.x %u, light.start.y %u, height: %u",
-                     lightROIs.light.start.x, lightROIs.light.start.y,
-                     lightROIs.light.height);
-    logger->log_info(name(), "red.start.x %u, red.start.y %u, red: %u",
-                     lightROIs.red.start.x, lightROIs.red.start.y,
-                     lightROIs.red.height);
-    logger->log_info(name(), "yellow.start.x %u, yellow.start.y %u, yellow: %u",
-                     lightROIs.yellow.start.x, lightROIs.yellow.start.y,
-                     lightROIs.yellow.height);
-    logger->log_info(name(), "green.start.x %u, green.start.y %u, green: %u",
-                     lightROIs.green.start.x, lightROIs.green.start.y,
-                     lightROIs.green.height);
-  }
-
-  return lightROIs;
+	return createLightROIs(light);
 }
 
-void LightFrontThread::writeLightInterface(
-    fawkes::RobotinoLightInterface *interface,
-    LightFrontThread::lightSignal lightSignal, bool ready) {
-  lightStateIF1->read();
-  int vis = lightStateIF1->visibility_history();
+LightFrontThread::lightROIs
+LightFrontThread::createLightROIs(firevision::ROI light)
+{
+	LightFrontThread::lightROIs lightROIs;
 
-  if (vis < 0 || lightStateIF1->red() != lightSignal.red ||
-      lightStateIF1->yellow() != lightSignal.yellow ||
-      lightStateIF1->green() != lightSignal.green) {
-    vis = 1;
-    ready = false;
-  } else {
-    vis++;
-  }
+	// light ROI size
+	lightROIs.light              = light;
+	lightROIs.light.image_height = img_height;
+	lightROIs.light.image_width  = img_width;
 
-  lightStateIF1->set_visibility_history(vis);
+	// Signale ROIs
 
-  lightStateIF1->set_red(lightSignal.red);
-  lightStateIF1->set_yellow(lightSignal.yellow);
-  lightStateIF1->set_green(lightSignal.green);
+	lightROIs.red    = lightROIs.light;
+	lightROIs.yellow = lightROIs.light;
+	lightROIs.green  = lightROIs.light;
 
-  if (vis >= detectionCycleTimeFrames) {
-    lightStateIF1->set_ready(ready);
-  } else {
-    lightStateIF1->set_ready(false);
-  }
+	float roiHeight = ((float)lightROIs.light.height) / 9;
 
-  lightStateIF1->write();
+	lightROIs.red.height = roiHeight;
+	lightROIs.red.start.y += roiHeight; // Middle of the top thirds
+
+	lightROIs.yellow.height = roiHeight;
+	lightROIs.yellow.start.y += roiHeight * 4; // Middle of the middle thirds
+
+	lightROIs.green.height = roiHeight;
+	lightROIs.green.start.y += roiHeight * 7; // Middle of the bottom thirds
+
+	if (cfg_debugMessagesActivated) {
+		logger->log_info(name(),
+		                 "light.start.x %u, light.start.y %u, height: %u",
+		                 lightROIs.light.start.x,
+		                 lightROIs.light.start.y,
+		                 lightROIs.light.height);
+		logger->log_info(name(),
+		                 "red.start.x %u, red.start.y %u, red: %u",
+		                 lightROIs.red.start.x,
+		                 lightROIs.red.start.y,
+		                 lightROIs.red.height);
+		logger->log_info(name(),
+		                 "yellow.start.x %u, yellow.start.y %u, yellow: %u",
+		                 lightROIs.yellow.start.x,
+		                 lightROIs.yellow.start.y,
+		                 lightROIs.yellow.height);
+		logger->log_info(name(),
+		                 "green.start.x %u, green.start.y %u, green: %u",
+		                 lightROIs.green.start.x,
+		                 lightROIs.green.start.y,
+		                 lightROIs.green.height);
+	}
+
+	return lightROIs;
 }
 
-void LightFrontThread::resetLocalHistory() {
-  historyBufferCluster1->clear();
-  historyBufferCluster2->clear();
-  historyBufferCluster3->clear();
+void
+LightFrontThread::writeLightInterface(fawkes::RobotinoLightInterface *interface,
+                                      LightFrontThread::lightSignal   lightSignal,
+                                      bool                            ready)
+{
+	lightStateIF1->read();
+	int vis = lightStateIF1->visibility_history();
+
+	if (vis < 0 || lightStateIF1->red() != lightSignal.red
+	    || lightStateIF1->yellow() != lightSignal.yellow
+	    || lightStateIF1->green() != lightSignal.green) {
+		vis   = 1;
+		ready = false;
+	} else {
+		vis++;
+	}
+
+	lightStateIF1->set_visibility_history(vis);
+
+	lightStateIF1->set_red(lightSignal.red);
+	lightStateIF1->set_yellow(lightSignal.yellow);
+	lightStateIF1->set_green(lightSignal.green);
+
+	if (vis >= detectionCycleTimeFrames) {
+		lightStateIF1->set_ready(ready);
+	} else {
+		lightStateIF1->set_ready(false);
+	}
+
+	lightStateIF1->write();
 }
 
-void LightFrontThread::resetLightInterface(
-    fawkes::RobotinoLightInterface *interface, std::string message) {
-  interface->read();
-  int vis = interface->visibility_history();
+void
+LightFrontThread::resetLocalHistory()
+{
+	historyBufferCluster1->clear();
+	historyBufferCluster2->clear();
+	historyBufferCluster3->clear();
+}
 
-  if (vis < 0) {
-    vis--;
-  } else {
-    vis = -1;
-  }
-  interface->set_visibility_history(vis);
+void
+LightFrontThread::resetLightInterface(fawkes::RobotinoLightInterface *interface,
+                                      std::string                     message)
+{
+	interface->read();
+	int vis = interface->visibility_history();
 
-  interface->set_ready(false);
-  interface->write();
+	if (vis < 0) {
+		vis--;
+	} else {
+		vis = -1;
+	}
+	interface->set_visibility_history(vis);
 
-  if (cfg_debugMessagesActivated) {
-    logger->log_info(name(), "Resetting interface, %s", message.c_str());
-  }
+	interface->set_ready(false);
+	interface->write();
+
+	if (cfg_debugMessagesActivated) {
+		logger->log_info(name(), "Resetting interface, %s", message.c_str());
+	}
 }
 
 std::list<firevision::ROI> *
-LightFrontThread::classifyInRoi(firevision::ROI searchArea,
-                                firevision::Classifier *classifier) {
-  scanline->reset();
-  scanline->set_roi(&searchArea);
+LightFrontThread::classifyInRoi(firevision::ROI searchArea, firevision::Classifier *classifier)
+{
+	scanline->reset();
+	scanline->set_roi(&searchArea);
 
-  classifier->set_src_buffer(bufferYCbCr, img_width, img_height);
+	classifier->set_src_buffer(bufferYCbCr, img_width, img_height);
 
-  std::list<firevision::ROI> *ROIs = classifier->classify();
+	std::list<firevision::ROI> *ROIs = classifier->classify();
 
-  return ROIs;
+	return ROIs;
 }
 
 fawkes::RobotinoLightInterface::LightState
-LightFrontThread::signalLightCurrentPicture(firevision::ROI signal) {
-  scanline->reset();
-  scanline->set_roi(&signal);
+LightFrontThread::signalLightCurrentPicture(firevision::ROI signal)
+{
+	scanline->reset();
+	scanline->set_roi(&signal);
 
-  classifierWhite->set_src_buffer(bufferYCbCr, img_width, img_height);
+	classifierWhite->set_src_buffer(bufferYCbCr, img_width, img_height);
 
-  std::list<firevision::ROI> *ROIs = classifierWhite->classify();
+	std::list<firevision::ROI> *ROIs = classifierWhite->classify();
 
-  bool isOn = !ROIs->empty();
+	bool isOn = !ROIs->empty();
 
-  if (cfg_debugMessagesActivated) {
-    int countedROIs = (int)ROIs->size();
-    logger->log_debug(name(), "Detect: %i", countedROIs);
-  }
-  if (cfg_paintROIsActivated) {
-    int countedROIs = (int)ROIs->size();
-    for (int i = 0; i < countedROIs; ++i) {
-      drawROIIntoBuffer(ROIs->front());
-      ROIs->pop_front();
-    }
-  }
+	if (cfg_debugMessagesActivated) {
+		int countedROIs = (int)ROIs->size();
+		logger->log_debug(name(), "Detect: %i", countedROIs);
+	}
+	if (cfg_paintROIsActivated) {
+		int countedROIs = (int)ROIs->size();
+		for (int i = 0; i < countedROIs; ++i) {
+			drawROIIntoBuffer(ROIs->front());
+			ROIs->pop_front();
+		}
+	}
 
-  delete ROIs;
+	delete ROIs;
 
-  if (isOn) {
-    return fawkes::RobotinoLightInterface::ON;
-  } else {
-    return fawkes::RobotinoLightInterface::OFF;
-  }
+	if (isOn) {
+		return fawkes::RobotinoLightInterface::ON;
+	} else {
+		return fawkes::RobotinoLightInterface::OFF;
+	}
 }
 
-bool LightFrontThread::lightFromHistoryBuffer(
-    boost::circular_buffer<LightFrontThread::lightSignal> *buffer,
-    LightFrontThread::lightSignal *lighSignal) {
+bool
+LightFrontThread::lightFromHistoryBuffer(
+  boost::circular_buffer<LightFrontThread::lightSignal> *buffer,
+  LightFrontThread::lightSignal *                        lighSignal)
+{
+	int red    = 0;
+	int yellow = 0;
+	int green  = 0;
 
-  int red = 0;
-  int yellow = 0;
-  int green = 0;
+	LightFrontThread::lightSignal previousLight;
+	for (boost::circular_buffer<LightFrontThread::lightSignal>::iterator it = buffer->begin();
+	     it != buffer->end();
+	     ++it) {
+		if (it != buffer->begin()) {
+			if (!isValidSuccessor(*it, previousLight)) {
+				return false;
+			}
+		}
+		if (it->red == fawkes::RobotinoLightInterface::ON) {
+			red++;
+		}
 
-  LightFrontThread::lightSignal previousLight;
-  for (boost::circular_buffer<LightFrontThread::lightSignal>::iterator it =
-           buffer->begin();
-       it != buffer->end(); ++it) {
-    if (it != buffer->begin()) {
-      if (!isValidSuccessor(*it, previousLight)) {
-        return false;
-      }
-    }
-    if (it->red == fawkes::RobotinoLightInterface::ON) {
-      red++;
-    }
+		if (it->yellow == fawkes::RobotinoLightInterface::ON) {
+			yellow++;
+		}
 
-    if (it->yellow == fawkes::RobotinoLightInterface::ON) {
-      yellow++;
-    }
+		if (it->green == fawkes::RobotinoLightInterface::ON) {
+			green++;
+		}
 
-    if (it->green == fawkes::RobotinoLightInterface::ON) {
-      green++;
-    }
+		previousLight = *it;
+	}
 
-    previousLight = *it;
-  }
+	lighSignal->red    = signalLightWithHistory(red, buffer->size());
+	lighSignal->yellow = signalLightWithHistory(yellow, buffer->size());
+	lighSignal->green  = signalLightWithHistory(green, buffer->size());
 
-  lighSignal->red = signalLightWithHistory(red, buffer->size());
-  lighSignal->yellow = signalLightWithHistory(yellow, buffer->size());
-  lighSignal->green = signalLightWithHistory(green, buffer->size());
-
-  return true;
+	return true;
 }
 
-bool LightFrontThread::isValidSuccessor(lightSignal previous,
-                                        lightSignal current) {
-  float px, py;
-  float cx, cy;
-  float dx, dy;
+bool
+LightFrontThread::isValidSuccessor(lightSignal previous, lightSignal current)
+{
+	float px, py;
+	float cx, cy;
+	float dx, dy;
 
-  polToCart(px, py, previous.nearestMaschine_pos);
-  polToCart(cx, cy, current.nearestMaschine_pos);
-  dx = cx - px;
-  dy = cy - py;
+	polToCart(px, py, previous.nearestMaschine_pos);
+	polToCart(cx, cy, current.nearestMaschine_pos);
+	dx = cx - px;
+	dy = cy - py;
 
-  if (std::sqrt((dx * dx) + (dy * dy)) <
-      cfg_lightDistanceAllowedBetweenFrames) {
-    return true;
-  }
-  return false;
+	if (std::sqrt((dx * dx) + (dy * dy)) < cfg_lightDistanceAllowedBetweenFrames) {
+		return true;
+	}
+	return false;
 }
 
 fawkes::RobotinoLightInterface::LightState
-LightFrontThread::signalLightWithHistory(int lightHistory, int buffer_size) {
-  int visibilityHistory = buffer_size; // historyBufferCluster1->size();
+LightFrontThread::signalLightWithHistory(int lightHistory, int buffer_size)
+{
+	int visibilityHistory = buffer_size; // historyBufferCluster1->size();
 
-  if (lightHistory >= (visibilityHistory - cfg_lightNumberOfWrongDetections)) {
-    return fawkes::RobotinoLightInterface::ON;
+	if (lightHistory >= (visibilityHistory - cfg_lightNumberOfWrongDetections)) {
+		return fawkes::RobotinoLightInterface::ON;
 
-  } else if (lightHistory >=
-                 visibilityHistory / 2 - cfg_lightNumberOfWrongDetections &&
-             lightHistory <=
-                 visibilityHistory / 2 + cfg_lightNumberOfWrongDetections) {
-    return fawkes::RobotinoLightInterface::BLINKING;
+	} else if (lightHistory >= visibilityHistory / 2 - cfg_lightNumberOfWrongDetections
+	           && lightHistory <= visibilityHistory / 2 + cfg_lightNumberOfWrongDetections) {
+		return fawkes::RobotinoLightInterface::BLINKING;
 
-  } else if (lightHistory <= cfg_lightNumberOfWrongDetections) {
-    return fawkes::RobotinoLightInterface::OFF;
-  } else {
-    if (cfg_debugMessagesActivated) {
-      logger->log_info(
-          name(),
-          "Detected: %i ON out of %i Pictures (ON: %i OFF: %i BLINKING: %i)",
-          lightHistory, visibilityHistory, visibilityHistory, 0,
-          visibilityHistory / 2);
-    }
-    return fawkes::RobotinoLightInterface::UNKNOWN;
-  }
+	} else if (lightHistory <= cfg_lightNumberOfWrongDetections) {
+		return fawkes::RobotinoLightInterface::OFF;
+	} else {
+		if (cfg_debugMessagesActivated) {
+			logger->log_info(name(),
+			                 "Detected: %i ON out of %i Pictures (ON: %i OFF: %i BLINKING: %i)",
+			                 lightHistory,
+			                 visibilityHistory,
+			                 visibilityHistory,
+			                 0,
+			                 visibilityHistory / 2);
+		}
+		return fawkes::RobotinoLightInterface::UNKNOWN;
+	}
 }
 
-fawkes::cart_coord_3d_t LightFrontThread::getNearestMaschineFromInterface(
-    fawkes::Position3DInterface *interface) {
-  fawkes::cart_coord_3d_t lightPosition;
+fawkes::cart_coord_3d_t
+LightFrontThread::getNearestMaschineFromInterface(fawkes::Position3DInterface *interface)
+{
+	fawkes::cart_coord_3d_t lightPosition;
 
-  interface->read();
-  lightPosition.x = interface->translation(0);
-  lightPosition.y = interface->translation(1);
-  lightPosition.z = interface->translation(2);
+	interface->read();
+	lightPosition.x = interface->translation(0);
+	lightPosition.y = interface->translation(1);
+	lightPosition.z = interface->translation(2);
 
-  // if the light is directly in front (by x coordinate) set y to 0 because it
-  // is likly to detecd wrong values
-  if (lightPosition.x < cfg_lightMoveUnderRfidThrashold) {
-    lightPosition.y = 0.0;
-  } else {
-    if (cfg_debugMessagesActivated) {
-      logger->log_debug(name(), "Not a close mashine");
-    }
-  }
+	// if the light is directly in front (by x coordinate) set y to 0 because it
+	// is likly to detecd wrong values
+	if (lightPosition.x < cfg_lightMoveUnderRfidThrashold) {
+		lightPosition.y = 0.0;
+	} else {
+		if (cfg_debugMessagesActivated) {
+			logger->log_debug(name(), "Not a close mashine");
+		}
+	}
 
-  return lightPosition;
+	return lightPosition;
 }

--- a/src/plugins/attic/light_front/light_front_thread.h
+++ b/src/plugins/attic/light_front/light_front_thread.h
@@ -20,30 +20,25 @@
 #include <aspect/tf.h>
 #include <aspect/vision.h>
 #include <core/threading/thread.h>
-
 #include <interfaces/Position3DInterface.h>
 #include <interfaces/RobotinoLightInterface.h>
 #include <interfaces/SwitchInterface.h>
 
 //#include <fvcams/camera.h>
 #include <fvcams/fileloader.h>
-
+#include <fvclassifiers/simple.h>
+#include <fvfilters/roidraw.h>
 #include <fvmodels/color/thresholds_black.h>
 #include <fvmodels/color/thresholds_luminance.h>
 #include <fvmodels/scanlines/grid.h>
+#include <fvutils/base/roi.h>
 #include <fvutils/color/conversions.h>
 #include <fvutils/ipc/shm_image.h>
 
-#include <fvclassifiers/simple.h>
-
-#include <fvfilters/roidraw.h>
-#include <fvutils/base/roi.h>
-
+#include <boost/circular_buffer.hpp>
 #include <cmath>
 #include <list>
 #include <string>
-
-#include <boost/circular_buffer.hpp>
 
 namespace fawkes {
 class Position3DInterface;
@@ -58,185 +53,180 @@ class LightFrontThread : public fawkes::Thread,
                          public fawkes::ConfigurableAspect,
                          public fawkes::VisionAspect,
                          public fawkes::BlackBoardAspect,
-                         public fawkes::TransformAspect {
-
+                         public fawkes::TransformAspect
+{
 private:
-  struct lightROIs {
-    firevision::ROI light;
-    firevision::ROI red;
-    firevision::ROI yellow;
-    firevision::ROI green;
-  };
+	struct lightROIs
+	{
+		firevision::ROI light;
+		firevision::ROI red;
+		firevision::ROI yellow;
+		firevision::ROI green;
+	};
 
-  struct lightSignal {
-    fawkes::RobotinoLightInterface::LightState red;
-    fawkes::RobotinoLightInterface::LightState yellow;
-    fawkes::RobotinoLightInterface::LightState green;
-    fawkes::polar_coord_2d_t nearestMaschine_pos;
-    int nearestMaschine_history;
-  };
+	struct lightSignal
+	{
+		fawkes::RobotinoLightInterface::LightState red;
+		fawkes::RobotinoLightInterface::LightState yellow;
+		fawkes::RobotinoLightInterface::LightState green;
+		fawkes::polar_coord_2d_t                   nearestMaschine_pos;
+		int                                        nearestMaschine_history;
+	};
 
-  //	struct light{
-  //
-  //		fawkes::RobotinoLightInterface interface_lightState;
-  //		boost::circular_buffer<lightSignal> history_buffer;
-  //	};
+	//	struct light{
+	//
+	//		fawkes::RobotinoLightInterface interface_lightState;
+	//		boost::circular_buffer<lightSignal> history_buffer;
+	//	};
 
-  std::string cfg_prefix;
+	std::string cfg_prefix;
 
-  std::string cfg_camera;
-  float cfg_cameraFactorHorizontal;
-  float cfg_cameraFactorVertical;
-  float cfg_cameraAngleVerticalRad;
-  float cfg_cameraAngleHorizontalRad;
-  unsigned int img_width;
-  unsigned int img_height;
+	std::string  cfg_camera;
+	float        cfg_cameraFactorHorizontal;
+	float        cfg_cameraFactorVertical;
+	float        cfg_cameraAngleVerticalRad;
+	float        cfg_cameraAngleHorizontalRad;
+	unsigned int img_width;
+	unsigned int img_height;
 
-  int cfg_cameraOffsetVertical;
-  int cfg_cameraOffsetHorizontal;
+	int cfg_cameraOffsetVertical;
+	int cfg_cameraOffsetHorizontal;
 
-  int cfg_lightNumberOfWrongDetections;
+	int cfg_lightNumberOfWrongDetections;
 
-  float cfg_lightMoveUnderRfidThrashold;
-  int cfg_lightOutOfRangeThrashold;
-  int cfg_laserVisibilityThreshold;
-  int cfg_center_x;
-  int cfg_center_y;
-  int cfg_center_height;
-  int cfg_center_width;
+	float cfg_lightMoveUnderRfidThrashold;
+	int   cfg_lightOutOfRangeThrashold;
+	int   cfg_laserVisibilityThreshold;
+	int   cfg_center_x;
+	int   cfg_center_y;
+	int   cfg_center_height;
+	int   cfg_center_width;
 
-  int cfg_laserVisibilityThreashold;
-  float cfg_lightDistanceAllowedBetweenFrames;
+	int   cfg_laserVisibilityThreashold;
+	float cfg_lightDistanceAllowedBetweenFrames;
 
-  int cfg_detectionCycleTime;
-  int detectionCycleTimeFrames;
+	int cfg_detectionCycleTime;
+	int detectionCycleTimeFrames;
 
-  int lightOutOfRangeCounter;
-  int cfg_lightOutOfRangeThreshold;
-  float cfg_lightToCloseThrashold;
+	int   lightOutOfRangeCounter;
+	int   cfg_lightOutOfRangeThreshold;
+	float cfg_lightToCloseThrashold;
 
-  std::string cfg_frame;
+	std::string cfg_frame;
 
-  unsigned int cfg_brightnessThreshold;
-  unsigned int cfg_darknessThreshold;
-  float cfg_lightSizeWidth;
-  float cfg_lightSizeHeight;
+	unsigned int cfg_brightnessThreshold;
+	unsigned int cfg_darknessThreshold;
+	float        cfg_lightSizeWidth;
+	float        cfg_lightSizeHeight;
 
-  float cfg_desiredLoopTime;
+	float cfg_desiredLoopTime;
 
-  bool cfg_lightPositionCorrection;
-  bool cfg_debugMessagesActivated;
-  bool cfg_paintROIsActivated;
-  bool cfg_simulateLaserData;
-  bool cfg_useMinDistanceThreashold;
-  bool cfg_useMulticluster;
-  float cfg_simulate_laser_x;
-  float cfg_simulate_laser_y;
-  int cfg_simulate_laser_history;
+	bool  cfg_lightPositionCorrection;
+	bool  cfg_debugMessagesActivated;
+	bool  cfg_paintROIsActivated;
+	bool  cfg_simulateLaserData;
+	bool  cfg_useMinDistanceThreashold;
+	bool  cfg_useMulticluster;
+	float cfg_simulate_laser_x;
+	float cfg_simulate_laser_y;
+	int   cfg_simulate_laser_history;
 
-  boost::circular_buffer<lightSignal> *historyBufferCluster1;
-  boost::circular_buffer<lightSignal> *historyBufferCluster2;
-  boost::circular_buffer<lightSignal> *historyBufferCluster3;
-  // std::deque<lightSignal> *historyBufferCluster1;
+	boost::circular_buffer<lightSignal> *historyBufferCluster1;
+	boost::circular_buffer<lightSignal> *historyBufferCluster2;
+	boost::circular_buffer<lightSignal> *historyBufferCluster3;
+	// std::deque<lightSignal> *historyBufferCluster1;
 
-  firevision::Camera *camera;
-  firevision::ScanlineModel *scanline;
-  firevision::ColorModelLuminance *colorModel;
-  firevision::ColorModelBlack *colorModelBlack;
-  firevision::SimpleColorClassifier *classifierWhite;
-  firevision::SimpleColorClassifier *classifierBlack;
-  firevision::SharedMemoryImageBuffer *shmBufferYCbCr;
-  unsigned char *bufferYCbCr; // reference to the buffer of shm_buffer_YCbCr (to
-                              // use in code)
+	firevision::Camera *                 camera;
+	firevision::ScanlineModel *          scanline;
+	firevision::ColorModelLuminance *    colorModel;
+	firevision::ColorModelBlack *        colorModelBlack;
+	firevision::SimpleColorClassifier *  classifierWhite;
+	firevision::SimpleColorClassifier *  classifierBlack;
+	firevision::SharedMemoryImageBuffer *shmBufferYCbCr;
+	unsigned char *bufferYCbCr; // reference to the buffer of shm_buffer_YCbCr (to
+	                            // use in code)
 
-  firevision::colorspace_t cspaceFrom;
-  firevision::colorspace_t cspaceTo;
+	firevision::colorspace_t cspaceFrom;
+	firevision::colorspace_t cspaceTo;
 
-  fawkes::Position3DInterface *nearestMaschineIF1;
-  fawkes::Position3DInterface *nearestMaschineIF2;
-  fawkes::Position3DInterface *nearestMaschineIF3;
+	fawkes::Position3DInterface *nearestMaschineIF1;
+	fawkes::Position3DInterface *nearestMaschineIF2;
+	fawkes::Position3DInterface *nearestMaschineIF3;
 
-  fawkes::RobotinoLightInterface *lightStateIF1;
-  fawkes::RobotinoLightInterface *lightStateIF2;
-  fawkes::RobotinoLightInterface *lightStateIF3;
+	fawkes::RobotinoLightInterface *lightStateIF1;
+	fawkes::RobotinoLightInterface *lightStateIF2;
+	fawkes::RobotinoLightInterface *lightStateIF3;
 
-  fawkes::SwitchInterface *switchInterface;
+	fawkes::SwitchInterface *switchInterface;
 
-  firevision::FilterROIDraw *drawer;
+	firevision::FilterROIDraw *drawer;
 
-  LightFrontThread::lightSignal
-  detectLightInCurrentPicture(LightFrontThread::lightROIs lightROIs);
-  LightFrontThread::lightROIs
-  correctLightRoisWithBlack(LightFrontThread::lightROIs expectedLight);
-  fawkes::RobotinoLightInterface::LightState
-  signalLightCurrentPicture(firevision::ROI signal);
-  fawkes::RobotinoLightInterface::LightState
-  signalLightWithHistory(int lightHistory, int buffersize);
-  std::list<firevision::ROI> *classifyInRoi(firevision::ROI searchArea,
-                                            firevision::Classifier *classifier);
-  bool lightFromHistoryBuffer(
-      boost::circular_buffer<LightFrontThread::lightSignal> *buffer,
-      LightFrontThread::lightSignal *lighSignal);
+	LightFrontThread::lightSignal detectLightInCurrentPicture(LightFrontThread::lightROIs lightROIs);
+	LightFrontThread::lightROIs correctLightRoisWithBlack(LightFrontThread::lightROIs expectedLight);
+	fawkes::RobotinoLightInterface::LightState signalLightCurrentPicture(firevision::ROI signal);
+	fawkes::RobotinoLightInterface::LightState signalLightWithHistory(int lightHistory,
+	                                                                  int buffersize);
+	std::list<firevision::ROI> *               classifyInRoi(firevision::ROI         searchArea,
+	                                                         firevision::Classifier *classifier);
+	bool lightFromHistoryBuffer(boost::circular_buffer<LightFrontThread::lightSignal> *buffer,
+	                            LightFrontThread::lightSignal *                        lighSignal);
 
-  unsigned char *calculatePositionInCamBuffer();
+	unsigned char *calculatePositionInCamBuffer();
 
-  int angleCorrectionY(float distance);
-  int angleCorrectionX(float distance);
-  LightFrontThread::lightROIs
-  calculateLightPos(fawkes::polar_coord_2d_t lightPos);
-  LightFrontThread::lightROIs createLightROIs(firevision::ROI light);
+	int                         angleCorrectionY(float distance);
+	int                         angleCorrectionX(float distance);
+	LightFrontThread::lightROIs calculateLightPos(fawkes::polar_coord_2d_t lightPos);
+	LightFrontThread::lightROIs createLightROIs(firevision::ROI light);
 
-  bool isValidSuccessor(lightSignal previous, lightSignal current);
+	bool isValidSuccessor(lightSignal previous, lightSignal current);
 
-  //	void updateLocalHistory(LightFrontThread::lightSignal
-  // lightSignalCurrent);
+	//	void updateLocalHistory(LightFrontThread::lightSignal
+	// lightSignalCurrent);
 
-  void drawROIIntoBuffer(firevision::ROI roi,
-                         firevision::FilterROIDraw::border_style_t borderStyle =
-                             firevision::FilterROIDraw::DASHED_HINT);
-  fawkes::polar_coord_2d_t
-  transformCoordinateSystem(fawkes::cart_coord_3d_t cartFrom, std::string from,
-                            std::string to);
+	void drawROIIntoBuffer(
+	  firevision::ROI                           roi,
+	  firevision::FilterROIDraw::border_style_t borderStyle = firevision::FilterROIDraw::DASHED_HINT);
+	fawkes::polar_coord_2d_t
+	transformCoordinateSystem(fawkes::cart_coord_3d_t cartFrom, std::string from, std::string to);
 
-  void cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y);
-  void polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol);
+	void cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y);
+	void polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol);
 
-  void resetLightInterface(fawkes::RobotinoLightInterface *interface,
-                           std::string message = "");
-  void resetLocalHistory();
-  void writeLightInterface(fawkes::RobotinoLightInterface *interface,
-                           LightFrontThread::lightSignal lightSignal,
-                           bool ready);
-  fawkes::cart_coord_3d_t
-  getNearestMaschineFromInterface(fawkes::Position3DInterface *interface);
+	void resetLightInterface(fawkes::RobotinoLightInterface *interface, std::string message = "");
+	void resetLocalHistory();
+	void writeLightInterface(fawkes::RobotinoLightInterface *interface,
+	                         LightFrontThread::lightSignal   lightSignal,
+	                         bool                            ready);
+	fawkes::cart_coord_3d_t getNearestMaschineFromInterface(fawkes::Position3DInterface *interface);
 
-  void createUnknownLightSignal();
+	void createUnknownLightSignal();
 
-  bool isLightInViewarea(fawkes::polar_coord_2d_t light);
-  void takePicture(LightFrontThread::lightROIs lightROIs);
+	bool isLightInViewarea(fawkes::polar_coord_2d_t light);
+	void takePicture(LightFrontThread::lightROIs lightROIs);
 
-  void processHistoryBuffer(
-      fawkes::RobotinoLightInterface *interface,
-      boost::circular_buffer<LightFrontThread::lightSignal> *buffer);
-  firevision::ROI getBiggestRoi(std::list<firevision::ROI> *roiList);
-  void checkIfROIIsInBuffer(const firevision::ROI &light);
-  void processSignal(fawkes::cart_coord_3d_t lightPosition,
-                     bool contiueToPictureProcess);
-  void
-  process_light(fawkes::Position3DInterface *position_interface,
-                fawkes::RobotinoLightInterface *interface,
-                boost::circular_buffer<LightFrontThread::lightSignal> *buffer);
+	void            processHistoryBuffer(fawkes::RobotinoLightInterface *                       interface,
+	                                     boost::circular_buffer<LightFrontThread::lightSignal> *buffer);
+	firevision::ROI getBiggestRoi(std::list<firevision::ROI> *roiList);
+	void            checkIfROIIsInBuffer(const firevision::ROI &light);
+	void processSignal(fawkes::cart_coord_3d_t lightPosition, bool contiueToPictureProcess);
+	void process_light(fawkes::Position3DInterface *                          position_interface,
+	                   fawkes::RobotinoLightInterface *                       interface,
+	                   boost::circular_buffer<LightFrontThread::lightSignal> *buffer);
 
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 public:
-  LightFrontThread();
-  virtual ~LightFrontThread();
+	LightFrontThread();
+	virtual ~LightFrontThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 };
 
 #endif /* LIGHT_FRONT_THREAD_H_ */

--- a/src/plugins/attic/machine-signal/custom_rois.cpp
+++ b/src/plugins/attic/machine-signal/custom_rois.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "custom_rois.h"
+
 #include <climits>
 
 namespace firevision {
@@ -28,18 +29,25 @@ namespace firevision {
  * geometry.
  */
 
-HistoricSmoothROI::HistoricSmoothROI(unsigned int history_len)
-    : ROI(), history_(history_len) {}
+HistoricSmoothROI::HistoricSmoothROI(unsigned int history_len) : ROI(), history_(history_len)
+{
+}
 
 HistoricSmoothROI::HistoricSmoothROI(HistoricSmoothROI const &other)
-    : ROI(other), history_(other.history_) {}
+: ROI(other), history_(other.history_)
+{
+}
 
 HistoricSmoothROI::HistoricSmoothROI(ROI const &other, unsigned int history_len)
-    : ROI(other), history_(history_len) {}
+: ROI(other), history_(history_len)
+{
+}
 
-void HistoricSmoothROI::update(ROI const &next_roi) {
-  history_.push_front(next_roi);
-  /*  unsigned long int start_x_sum = start.x;
+void
+HistoricSmoothROI::update(ROI const &next_roi)
+{
+	history_.push_front(next_roi);
+	/*  unsigned long int start_x_sum = start.x;
     unsigned long int start_y_sum = start.y;
     unsigned long int width_sum = width;
     unsigned long int height_sum = height;
@@ -56,28 +64,30 @@ void HistoricSmoothROI::update(ROI const &next_roi) {
     height = height_sum / (history_.size() + 1);
   */
 
-  start.x = next_roi.start.x;
-  start.y = next_roi.start.y;
-  width = next_roi.width;
-  height = next_roi.height;
+	start.x = next_roi.start.x;
+	start.y = next_roi.start.y;
+	width   = next_roi.width;
+	height  = next_roi.height;
 }
 
-HistoricSmoothROI &HistoricSmoothROI::operator=(HistoricSmoothROI const &roi) {
-  this->start.x = roi.start.x;
-  this->start.y = roi.start.y;
-  this->width = roi.width;
-  this->height = roi.height;
-  this->image_width = roi.image_width;
-  this->image_height = roi.image_height;
-  this->line_step = roi.line_step;
-  this->pixel_step = roi.pixel_step;
-  this->hint = roi.hint;
-  this->color = roi.color;
-  this->num_hint_points = roi.num_hint_points;
+HistoricSmoothROI &
+HistoricSmoothROI::operator=(HistoricSmoothROI const &roi)
+{
+	this->start.x         = roi.start.x;
+	this->start.y         = roi.start.y;
+	this->width           = roi.width;
+	this->height          = roi.height;
+	this->image_width     = roi.image_width;
+	this->image_height    = roi.image_height;
+	this->line_step       = roi.line_step;
+	this->pixel_step      = roi.pixel_step;
+	this->hint            = roi.hint;
+	this->color           = roi.color;
+	this->num_hint_points = roi.num_hint_points;
 
-  this->history_ = boost::circular_buffer<ROI>(roi.history_);
+	this->history_ = boost::circular_buffer<ROI>(roi.history_);
 
-  return *this;
+	return *this;
 }
 
 } /* namespace firevision */

--- a/src/plugins/attic/machine-signal/custom_rois.h
+++ b/src/plugins/attic/machine-signal/custom_rois.h
@@ -21,29 +21,34 @@
 #ifndef __FIREVISION_HISTORICSMOOTHROI_H_
 #define __FIREVISION_HISTORICSMOOTHROI_H_
 
-#include <boost/circular_buffer.hpp>
 #include <fvutils/base/roi.h>
 #include <tf/types.h>
 
+#include <boost/circular_buffer.hpp>
+
 namespace firevision {
 
-class HistoricSmoothROI : public ROI {
+class HistoricSmoothROI : public ROI
+{
 private:
-  HistoricSmoothROI();
-  boost::circular_buffer<ROI> history_;
+	HistoricSmoothROI();
+	boost::circular_buffer<ROI> history_;
 
 public:
-  HistoricSmoothROI(unsigned int history_length);
-  HistoricSmoothROI(ROI const &other, unsigned int history_length = 0);
-  HistoricSmoothROI(HistoricSmoothROI const &other);
-  HistoricSmoothROI &operator=(HistoricSmoothROI const &other);
-  void update(ROI const &next_roi);
+	HistoricSmoothROI(unsigned int history_length);
+	HistoricSmoothROI(ROI const &other, unsigned int history_length = 0);
+	HistoricSmoothROI(HistoricSmoothROI const &other);
+	HistoricSmoothROI &operator=(HistoricSmoothROI const &other);
+	void               update(ROI const &next_roi);
 };
 
-class WorldROI : public firevision::ROI {
+class WorldROI : public firevision::ROI
+{
 public:
-  std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>> world_pos;
-  WorldROI() : ROI() {}
+	std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>> world_pos;
+	WorldROI() : ROI()
+	{
+	}
 };
 
 } /* namespace firevision */

--- a/src/plugins/attic/machine-signal/pipeline_thread.cpp
+++ b/src/plugins/attic/machine-signal/pipeline_thread.cpp
@@ -18,16 +18,18 @@
  */
 
 #include "pipeline_thread.h"
-#include <algorithm>
-#include <aspect/logging.h>
-#include <cmath>
-#include <core/threading/mutex_locker.h>
-#include <cstring>
-#include <fvfilters/colorthreshold.h>
-#include <fvutils/color/colorspaces.h>
-#include <limits>
 
 #include "custom_rois.h"
+
+#include <aspect/logging.h>
+#include <core/threading/mutex_locker.h>
+#include <fvfilters/colorthreshold.h>
+#include <fvutils/color/colorspaces.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
 
 using namespace fawkes;
 using namespace fawkes::tf;
@@ -35,1055 +37,1047 @@ using namespace std;
 using namespace firevision;
 
 MachineSignalPipelineThread::MachineSignalPipelineThread()
-    : Thread("MachineSignal", Thread::OPMODE_CONTINUOUS),
-      VisionAspect(VisionAspect::CONTINUOUS),
-      ConfigurationChangeHandler(CFG_PREFIX) {
-  new_data_ = false;
+: Thread("MachineSignal", Thread::OPMODE_CONTINUOUS),
+  VisionAspect(VisionAspect::CONTINUOUS),
+  ConfigurationChangeHandler(CFG_PREFIX)
+{
+	new_data_ = false;
 
-  cam_width_ = 0;
-  cam_height_ = 0;
-  cfg_light_on_threshold_ = 0;
-  camera_ = NULL;
+	cam_width_              = 0;
+	cam_height_             = 0;
+	cfg_light_on_threshold_ = 0;
+	camera_                 = NULL;
 
-  time_wait_ = NULL;
-  cfg_fps_ = 0;
-  desired_frametime_ = 0;
+	time_wait_         = NULL;
+	cfg_fps_           = 0;
+	desired_frametime_ = 0;
 
-  cfy_ctxt_red_1_.colormodel = NULL;
-  cfy_ctxt_red_1_.classifier = NULL;
-  cfy_ctxt_red_1_.scanline_grid = NULL;
-  cfy_ctxt_red_1_.color_expect = C_RED;
-  cfy_ctxt_red_0_.colormodel = NULL;
-  cfy_ctxt_red_0_.classifier = NULL;
-  cfy_ctxt_red_0_.scanline_grid = NULL;
-  cfy_ctxt_red_0_.color_expect = C_RED;
-  cfy_ctxt_green_1_.colormodel = NULL;
-  cfy_ctxt_green_1_.classifier = NULL;
-  cfy_ctxt_green_1_.scanline_grid = NULL;
-  cfy_ctxt_green_1_.color_expect = C_GREEN;
-  cfy_ctxt_green_0_.colormodel = NULL;
-  cfy_ctxt_green_0_.classifier = NULL;
-  cfy_ctxt_green_0_.scanline_grid = NULL;
-  cfy_ctxt_green_0_.color_expect = C_GREEN;
+	cfy_ctxt_red_1_.colormodel      = NULL;
+	cfy_ctxt_red_1_.classifier      = NULL;
+	cfy_ctxt_red_1_.scanline_grid   = NULL;
+	cfy_ctxt_red_1_.color_expect    = C_RED;
+	cfy_ctxt_red_0_.colormodel      = NULL;
+	cfy_ctxt_red_0_.classifier      = NULL;
+	cfy_ctxt_red_0_.scanline_grid   = NULL;
+	cfy_ctxt_red_0_.color_expect    = C_RED;
+	cfy_ctxt_green_1_.colormodel    = NULL;
+	cfy_ctxt_green_1_.classifier    = NULL;
+	cfy_ctxt_green_1_.scanline_grid = NULL;
+	cfy_ctxt_green_1_.color_expect  = C_GREEN;
+	cfy_ctxt_green_0_.colormodel    = NULL;
+	cfy_ctxt_green_0_.classifier    = NULL;
+	cfy_ctxt_green_0_.scanline_grid = NULL;
+	cfy_ctxt_green_0_.color_expect  = C_GREEN;
 
-  cfg_changed_ = false;
-  cam_changed_ = false;
+	cfg_changed_ = false;
+	cam_changed_ = false;
 
-  shmbuf_ = NULL;
-  shmbuf_cam_ = NULL;
+	shmbuf_     = NULL;
+	shmbuf_cam_ = NULL;
 
-  light_classifier_ = NULL;
-  light_colormodel_ = NULL;
-  light_scangrid_ = NULL;
-  cfg_light_on_min_neighborhood_ = 0;
-  cfg_light_on_min_points_ = 0;
+	light_classifier_              = NULL;
+	light_colormodel_              = NULL;
+	light_scangrid_                = NULL;
+	cfg_light_on_min_neighborhood_ = 0;
+	cfg_light_on_min_points_       = 0;
 
-  black_classifier_ = NULL;
-  black_colormodel_ = NULL;
-  black_scangrid_ = NULL;
-  cfg_black_min_neighborhood_ = 0;
-  cfg_black_min_points_ = 0;
-  cfg_black_y_thresh_ = 30;
-  cfg_black_u_thresh_ = 30;
-  cfg_black_v_thresh_ = 30;
-  cfg_black_u_ref_ = 128;
-  cfg_black_v_ref_ = 128;
+	black_classifier_           = NULL;
+	black_colormodel_           = NULL;
+	black_scangrid_             = NULL;
+	cfg_black_min_neighborhood_ = 0;
+	cfg_black_min_points_       = 0;
+	cfg_black_y_thresh_         = 30;
+	cfg_black_u_thresh_         = 30;
+	cfg_black_v_thresh_         = 30;
+	cfg_black_u_ref_            = 128;
+	cfg_black_v_ref_            = 128;
 
-  roi_drawer_ = NULL;
-  color_filter_ = NULL;
-  cfg_roi_max_aspect_ratio_ = 1.7;
-  combined_colormodel_ = NULL;
-  last_second_ = NULL;
-  buflen_ = 0;
-  bb_enable_switch_ = NULL;
-  cfg_enable_switch_ = false;
+	roi_drawer_               = NULL;
+	color_filter_             = NULL;
+	cfg_roi_max_aspect_ratio_ = 1.7;
+	combined_colormodel_      = NULL;
+	last_second_              = NULL;
+	buflen_                   = 0;
+	bb_enable_switch_         = NULL;
+	cfg_enable_switch_        = false;
 
-  pos2pixel_ = NULL;
-  cfg_cam_angle_y_ = 0;
-  cfg_cam_aperture_x_ = 0;
-  cfg_cam_aperture_y_ = 0;
+	pos2pixel_          = NULL;
+	cfg_cam_angle_y_    = 0;
+	cfg_cam_aperture_x_ = 0;
+	cfg_cam_aperture_y_ = 0;
 
-  bb_laser_clusters_[0] = NULL;
-  bb_laser_clusters_[1] = NULL;
-  bb_laser_clusters_[2] = NULL;
+	bb_laser_clusters_[0] = NULL;
+	bb_laser_clusters_[1] = NULL;
+	bb_laser_clusters_[2] = NULL;
 
-  cluster_rois_ = NULL;
+	cluster_rois_ = NULL;
 
-  bb_signal_position_estimate_ = NULL;
+	bb_signal_position_estimate_ = NULL;
 
-  memset(bb_laser_lines_, NUM_LASER_LINES, sizeof(LaserLineInterface *));
+	memset(bb_laser_lines_, NUM_LASER_LINES, sizeof(LaserLineInterface *));
 }
 
-MachineSignalPipelineThread::~MachineSignalPipelineThread() {}
-
-bool MachineSignalPipelineThread::color_data_consistent(
-    color_classifier_context_t_ *color_data) {
-  bool rv = (color_data->cfg_ref_col.size() ==
-             (3 * color_data->cfg_chroma_thresh.size())) &&
-            (color_data->cfg_ref_col.size() ==
-             (3 * color_data->cfg_sat_thresh.size())) &&
-            (color_data->cfg_ref_col.size() ==
-             (3 * color_data->cfg_luma_thresh.size()));
-  return rv;
+MachineSignalPipelineThread::~MachineSignalPipelineThread()
+{
 }
 
-void MachineSignalPipelineThread::setup_color_classifier(
-    color_classifier_context_t_ *color_data, ROI *roi) {
-  delete color_data->classifier;
-  delete color_data->colormodel;
-  delete color_data->scanline_grid;
-
-  for (std::vector<ColorModelSimilarity::color_class_t *>::iterator it =
-           color_data->color_class.begin();
-       it != color_data->color_class.end(); it++) {
-    delete *it;
-  }
-  color_data->color_class.clear();
-
-  // Update the color class used by the combined color model for the tuning
-  // filter
-  std::vector<int>::iterator it_sat = color_data->cfg_sat_thresh.begin();
-  std::vector<int>::iterator it_luma = color_data->cfg_luma_thresh.begin();
-  std::vector<unsigned int>::iterator it_ref = color_data->cfg_ref_col.begin();
-  std::vector<int>::iterator it_chroma = color_data->cfg_chroma_thresh.begin();
-  while (it_chroma != color_data->cfg_chroma_thresh.end()) {
-    std::vector<unsigned int> ref_col(it_ref, it_ref + 3);
-    ColorModelSimilarity::color_class_t *color_class =
-        new ColorModelSimilarity::color_class_t(color_data->color_expect,
-                                                ref_col, *(it_chroma++),
-                                                *(it_sat++), *(it_luma++));
-    it_ref += 3;
-    color_data->color_class.push_back(color_class);
-  }
-
-  color_data->colormodel = new ColorModelSimilarity();
-  color_data->colormodel->add_colors(color_data->color_class);
-  color_data->scanline_grid = new ScanlineGrid(
-      cam_width_, cam_height_, color_data->cfg_scangrid_x_offset,
-      color_data->cfg_scangrid_y_offset, roi);
-
-  color_data->classifier = new SimpleColorClassifier(
-      color_data->scanline_grid, color_data->colormodel,
-      color_data->cfg_roi_min_points, color_data->cfg_roi_basic_size, false,
-      color_data->cfg_roi_neighborhood_min_match, 0, color_data->color_expect);
+bool
+MachineSignalPipelineThread::color_data_consistent(color_classifier_context_t_ *color_data)
+{
+	bool rv = (color_data->cfg_ref_col.size() == (3 * color_data->cfg_chroma_thresh.size()))
+	          && (color_data->cfg_ref_col.size() == (3 * color_data->cfg_sat_thresh.size()))
+	          && (color_data->cfg_ref_col.size() == (3 * color_data->cfg_luma_thresh.size()));
+	return rv;
 }
 
-void MachineSignalPipelineThread::init() {
-  // Configure camera
-  cfg_camera_ = config->get_string(CFG_PREFIX "/camera");
-  setup_camera();
+void
+MachineSignalPipelineThread::setup_color_classifier(color_classifier_context_t_ *color_data,
+                                                    ROI *                        roi)
+{
+	delete color_data->classifier;
+	delete color_data->colormodel;
+	delete color_data->scanline_grid;
 
-  shmbuf_ = new SharedMemoryImageBuffer("machine-signal", YUV422_PLANAR,
-                                        cam_width_, cam_height_);
-  shmbuf_cam_ = new SharedMemoryImageBuffer("machine-cam", YUV422_PLANAR,
-                                            cam_width_, cam_height_);
-  roi_drawer_ = new FilterROIDraw(&drawn_rois_, FilterROIDraw::DASHED_HINT);
+	for (std::vector<ColorModelSimilarity::color_class_t *>::iterator it =
+	       color_data->color_class.begin();
+	     it != color_data->color_class.end();
+	     it++) {
+		delete *it;
+	}
+	color_data->color_class.clear();
 
-  // Configure RED ON classifier
-  cfy_ctxt_red_1_.cfg_ref_col =
-      config->get_uints(CFG_PREFIX "/red_on/reference_color");
-  cfy_ctxt_red_1_.cfg_chroma_thresh =
-      config->get_ints(CFG_PREFIX "/red_on/chroma_thresh");
-  cfy_ctxt_red_1_.cfg_sat_thresh =
-      config->get_ints(CFG_PREFIX "/red_on/saturation_thresh");
-  cfy_ctxt_red_1_.cfg_luma_thresh =
-      config->get_ints(CFG_PREFIX "/red_on/luma_thresh");
-  cfy_ctxt_red_1_.cfg_roi_min_points =
-      config->get_int(CFG_PREFIX "/red_on/min_points");
-  cfy_ctxt_red_1_.cfg_roi_basic_size =
-      config->get_int(CFG_PREFIX "/red_on/basic_roi_size");
-  cfy_ctxt_red_1_.cfg_roi_neighborhood_min_match =
-      config->get_int(CFG_PREFIX "/red_on/neighborhood_min_match");
-  cfy_ctxt_red_1_.cfg_scangrid_x_offset =
-      config->get_int(CFG_PREFIX "/red_on/scangrid_x_offset");
-  cfy_ctxt_red_1_.cfg_scangrid_y_offset =
-      config->get_int(CFG_PREFIX "/red_on/scangrid_y_offset");
-  cfy_ctxt_red_1_.visualize = config->get_bool(CFG_PREFIX "/red_on/visualize");
+	// Update the color class used by the combined color model for the tuning
+	// filter
+	std::vector<int>::iterator          it_sat    = color_data->cfg_sat_thresh.begin();
+	std::vector<int>::iterator          it_luma   = color_data->cfg_luma_thresh.begin();
+	std::vector<unsigned int>::iterator it_ref    = color_data->cfg_ref_col.begin();
+	std::vector<int>::iterator          it_chroma = color_data->cfg_chroma_thresh.begin();
+	while (it_chroma != color_data->cfg_chroma_thresh.end()) {
+		std::vector<unsigned int>            ref_col(it_ref, it_ref + 3);
+		ColorModelSimilarity::color_class_t *color_class = new ColorModelSimilarity::color_class_t(
+		  color_data->color_expect, ref_col, *(it_chroma++), *(it_sat++), *(it_luma++));
+		it_ref += 3;
+		color_data->color_class.push_back(color_class);
+	}
 
-  setup_color_classifier(&cfy_ctxt_red_1_);
+	color_data->colormodel = new ColorModelSimilarity();
+	color_data->colormodel->add_colors(color_data->color_class);
+	color_data->scanline_grid = new ScanlineGrid(cam_width_,
+	                                             cam_height_,
+	                                             color_data->cfg_scangrid_x_offset,
+	                                             color_data->cfg_scangrid_y_offset,
+	                                             roi);
 
-  // Configure RED OFF classifier
-  cfy_ctxt_red_0_.cfg_ref_col =
-      config->get_uints(CFG_PREFIX "/red_off/reference_color");
-  cfy_ctxt_red_0_.cfg_chroma_thresh =
-      config->get_ints(CFG_PREFIX "/red_off/chroma_thresh");
-  cfy_ctxt_red_0_.cfg_sat_thresh =
-      config->get_ints(CFG_PREFIX "/red_off/saturation_thresh");
-  cfy_ctxt_red_0_.cfg_luma_thresh =
-      config->get_ints(CFG_PREFIX "/red_off/luma_thresh");
-  cfy_ctxt_red_0_.cfg_roi_min_points =
-      config->get_int(CFG_PREFIX "/red_off/min_points");
-  cfy_ctxt_red_0_.cfg_roi_basic_size =
-      config->get_int(CFG_PREFIX "/red_off/basic_roi_size");
-  cfy_ctxt_red_0_.cfg_roi_neighborhood_min_match =
-      config->get_int(CFG_PREFIX "/red_off/neighborhood_min_match");
-  cfy_ctxt_red_0_.cfg_scangrid_x_offset =
-      config->get_int(CFG_PREFIX "/red_off/scangrid_x_offset");
-  cfy_ctxt_red_0_.cfg_scangrid_y_offset =
-      config->get_int(CFG_PREFIX "/red_off/scangrid_y_offset");
-  cfy_ctxt_red_0_.visualize = config->get_bool(CFG_PREFIX "/red_off/visualize");
-
-  setup_color_classifier(&cfy_ctxt_red_0_);
-
-  // Configure GREEN ON classifier
-  cfy_ctxt_green_1_.cfg_ref_col =
-      config->get_uints(CFG_PREFIX "/green_on/reference_color");
-  cfy_ctxt_green_1_.cfg_chroma_thresh =
-      config->get_ints(CFG_PREFIX "/green_on/chroma_thresh");
-  cfy_ctxt_green_1_.cfg_sat_thresh =
-      config->get_ints(CFG_PREFIX "/green_on/saturation_thresh");
-  cfy_ctxt_green_1_.cfg_luma_thresh =
-      config->get_ints(CFG_PREFIX "/green_on/luma_thresh");
-  cfy_ctxt_green_1_.cfg_roi_min_points =
-      config->get_int(CFG_PREFIX "/green_on/min_points");
-  cfy_ctxt_green_1_.cfg_roi_basic_size =
-      config->get_int(CFG_PREFIX "/green_on/basic_roi_size");
-  cfy_ctxt_green_1_.cfg_roi_neighborhood_min_match =
-      config->get_int(CFG_PREFIX "/green_on/neighborhood_min_match");
-  cfy_ctxt_green_1_.cfg_scangrid_x_offset =
-      config->get_int(CFG_PREFIX "/green_on/scangrid_x_offset");
-  cfy_ctxt_green_1_.cfg_scangrid_y_offset =
-      config->get_int(CFG_PREFIX "/green_on/scangrid_y_offset");
-  cfy_ctxt_green_1_.visualize =
-      config->get_bool(CFG_PREFIX "/green_on/visualize");
-
-  setup_color_classifier(&cfy_ctxt_green_1_);
-
-  // Configure GREEN OFF classifier
-  cfy_ctxt_green_0_.cfg_ref_col =
-      config->get_uints(CFG_PREFIX "/green_off/reference_color");
-  cfy_ctxt_green_0_.cfg_chroma_thresh =
-      config->get_ints(CFG_PREFIX "/green_off/chroma_thresh");
-  cfy_ctxt_green_0_.cfg_sat_thresh =
-      config->get_ints(CFG_PREFIX "/green_off/saturation_thresh");
-  cfy_ctxt_green_0_.cfg_luma_thresh =
-      config->get_ints(CFG_PREFIX "/green_off/luma_thresh");
-  cfy_ctxt_green_0_.cfg_roi_min_points =
-      config->get_int(CFG_PREFIX "/green_off/min_points");
-  cfy_ctxt_green_0_.cfg_roi_basic_size =
-      config->get_int(CFG_PREFIX "/green_off/basic_roi_size");
-  cfy_ctxt_green_0_.cfg_roi_neighborhood_min_match =
-      config->get_int(CFG_PREFIX "/green_off/neighborhood_min_match");
-  cfy_ctxt_green_0_.cfg_scangrid_x_offset =
-      config->get_int(CFG_PREFIX "/green_off/scangrid_x_offset");
-  cfy_ctxt_green_0_.cfg_scangrid_y_offset =
-      config->get_int(CFG_PREFIX "/green_off/scangrid_y_offset");
-  cfy_ctxt_green_0_.visualize =
-      config->get_bool(CFG_PREFIX "/green_off/visualize");
-
-  setup_color_classifier(&cfy_ctxt_green_0_);
-
-  // Configure brightness classifier
-  cfg_light_on_threshold_ =
-      config->get_uint(CFG_PREFIX "/bright_light/min_brightness");
-  cfg_light_on_min_points_ =
-      config->get_uint(CFG_PREFIX "/bright_light/min_points");
-  cfg_light_on_min_neighborhood_ =
-      config->get_uint(CFG_PREFIX "/bright_light/neighborhood_min_match");
-  cfg_light_on_min_area_cover_ =
-      config->get_float(CFG_PREFIX "/bright_light/min_area_cover");
-
-  // Configure black classifier
-  cfg_black_y_thresh_ = config->get_uint(CFG_PREFIX "/black/y_threshold");
-  cfg_black_u_thresh_ = config->get_uint(CFG_PREFIX "/black/u_threshold");
-  cfg_black_v_thresh_ = config->get_uint(CFG_PREFIX "/black/v_threshold");
-  cfg_black_u_ref_ = config->get_uint(CFG_PREFIX "/black/u_reference");
-  cfg_black_v_ref_ = config->get_uint(CFG_PREFIX "/black/v_reference");
-  cfg_black_min_neighborhood_ =
-      config->get_uint(CFG_PREFIX "/black/neighborhood_min_match");
-  cfg_black_min_points_ = config->get_uint(CFG_PREFIX "/black/min_points");
-
-  // General config
-  cfg_roi_max_aspect_ratio_ =
-      config->get_float(CFG_PREFIX "/roi_max_aspect_ratio");
-  cfg_roi_max_width_ratio_ =
-      config->get_float(CFG_PREFIX "/roi_max_r2g_width_ratio");
-  cfg_roi_max_height_ = config->get_uint(CFG_PREFIX "/roi_max_height");
-  cfg_roi_max_width_ = config->get_uint(CFG_PREFIX "/roi_max_width");
-  cfg_roi_xalign_ = config->get_float(CFG_PREFIX "/roi_xalign_by_width");
-  cfg_roi_green_horizon = config->get_uint(CFG_PREFIX "/roi_green_horizon");
-  cfg_tuning_mode_ = config->get_bool(CFG_PREFIX "/tuning_mode");
-  cfg_max_jitter_ = config->get_float(CFG_PREFIX "/max_jitter");
-  cfg_draw_processed_rois_ =
-      config->get_bool(CFG_PREFIX "/draw_processed_rois");
-  cfg_enable_switch_ = config->get_bool(CFG_PREFIX "/start_enabled");
-  cfg_fps_ = config->get_uint(CFG_PREFIX "/fps");
-  cfg_debug_blink_ = config->get_bool(CFG_PREFIX "/debug_blink");
-  cfg_debug_processing_ = config->get_bool(CFG_PREFIX "/debug_processing");
-  cfg_debug_tf_ = config->get_bool(CFG_PREFIX "/debug_tf");
-
-  cfg_lasercluster_frame_ = config->get_string(CFG_PREFIX "/laser_frame");
-  cfg_lasercluster_signal_radius_ =
-      0.5 * config->get_float(CFG_PREFIX "/signal_width");
-  cfg_lasercluster_signal_top_ = config->get_float(CFG_PREFIX "/signal_top");
-  cfg_lasercluster_signal_bottom_ =
-      config->get_float(CFG_PREFIX "/signal_bottom");
-  cfg_cam_aperture_x_ = config->get_float(CFG_PREFIX "/cam_aperture_x");
-  cfg_cam_aperture_y_ = config->get_float(CFG_PREFIX "/cam_aperture_y");
-  cfg_cam_angle_y_ = config->get_float(CFG_PREFIX "/cam_angle");
-  cfg_cam_frame_ = config->get_string(CFG_PREFIX "/cam_frame");
-
-  // Laser-lines config
-  cfg_laser_lines_enabled_ = config->get_bool(CFG_PREFIX "/laser-lines/enable");
-  cfg_laser_lines_min_vis_hist_ =
-      config->get_uint(CFG_PREFIX "/laser-lines/min_visibility_history");
-  cfg_laser_lines_moving_avg_ =
-      config->get_bool(CFG_PREFIX "/laser-lines/moving_avg");
-
-  // Laser Cluster config
-  cfg_lasercluster_enabled_ =
-      config->get_bool(CFG_PREFIX "/lasercluster/enable");
-  cfg_lasercluster_min_vis_hist_ =
-      config->get_uint(CFG_PREFIX "/lasercluster/min_visibility_history");
-
-  pos2pixel_ = new PositionToPixel(tf_listener, cfg_cam_frame_,
-                                   cfg_cam_aperture_x_, cfg_cam_aperture_y_,
-                                   cam_width_, cam_height_, cfg_cam_angle_y_);
-
-  // Setup combined ColorModel for tuning filter
-  combined_colormodel_ = new ColorModelSimilarity();
-  if (cfy_ctxt_red_1_.visualize)
-    combined_colormodel_->add_colors(cfy_ctxt_red_1_.color_class);
-  if (cfy_ctxt_red_0_.visualize)
-    combined_colormodel_->add_colors(cfy_ctxt_red_0_.color_class);
-  if (cfy_ctxt_green_1_.visualize)
-    combined_colormodel_->add_colors(cfy_ctxt_green_1_.color_class);
-  if (cfy_ctxt_green_0_.visualize)
-    combined_colormodel_->add_colors(cfy_ctxt_green_0_.color_class);
-  color_filter_ = new FilterColorThreshold(combined_colormodel_);
-
-  // Setup luminance classifier for light on/off detection
-  light_scangrid_ = new ScanlineGrid(cam_width_, cam_height_, 1, 1);
-  light_colormodel_ = new ColorModelLuminance(cfg_light_on_threshold_);
-  light_classifier_ = new SimpleColorClassifier(
-      light_scangrid_, light_colormodel_, cfg_light_on_min_points_, 8, false,
-      cfg_light_on_min_neighborhood_, 0, C_WHITE);
-  light_classifier_->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
-
-  // Setup black classifier for top/bottom recognition
-  black_scangrid_ = new ScanlineGrid(cam_width_, cam_height_, 1, 1);
-  black_colormodel_ = new ColorModelBlack(
-      cfg_black_y_thresh_, cfg_black_u_thresh_, cfg_black_v_thresh_,
-      cfg_black_u_ref_, cfg_black_v_ref_);
-  black_classifier_ = new SimpleColorClassifier(
-      black_scangrid_, black_colormodel_, cfg_black_min_points_, 6, false,
-      cfg_black_min_neighborhood_, 0, C_BLACK);
-  black_classifier_->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
-
-  // Initialize frame rate detection & buffer lengths for blinking detection
-  buflen_ = (unsigned int)ceil(cfg_fps_ / 4) + 1;
-  desired_frametime_ = 1 / (double)cfg_fps_;
-  time_wait_ = new TimeWait(clock, (long int)(1000000 * desired_frametime_));
-  buflen_ += 1 - (buflen_ % 2); // make sure buflen is uneven
-  logger->log_info(name(), "Buffer length: %d", buflen_);
-  last_second_ = new Time(clock);
-
-  bb_enable_switch_ =
-      blackboard->open_for_writing<SwitchInterface>("/machine-signal");
-  bb_enable_switch_->set_enabled(cfg_enable_switch_);
-  bb_enable_switch_->write();
-
-  bb_laser_clusters_[0] = blackboard->open_for_reading<Position3DInterface>(
-      "/laser-cluster/ampel/1");
-  bb_laser_clusters_[1] = blackboard->open_for_reading<Position3DInterface>(
-      "/laser-cluster/ampel/2");
-  bb_laser_clusters_[2] = blackboard->open_for_reading<Position3DInterface>(
-      "/laser-cluster/ampel/3");
-
-  bb_signal_position_estimate_ =
-      blackboard->open_for_writing<SignalHintInterface>(
-          "/machine-signal/position-hint");
-
-  bb_open_laser_lines();
-
-  config->add_change_handler(this);
+	color_data->classifier = new SimpleColorClassifier(color_data->scanline_grid,
+	                                                   color_data->colormodel,
+	                                                   color_data->cfg_roi_min_points,
+	                                                   color_data->cfg_roi_basic_size,
+	                                                   false,
+	                                                   color_data->cfg_roi_neighborhood_min_match,
+	                                                   0,
+	                                                   color_data->color_expect);
 }
 
-void MachineSignalPipelineThread::bb_open_laser_lines() {
-  string avg_suffix = "";
-  if (cfg_laser_lines_moving_avg_)
-    avg_suffix = "/moving_avg";
-  for (uint i = 0; i < NUM_LASER_LINES; ++i) {
-    bb_laser_lines_[i] = blackboard->open_for_reading_f<LaserLineInterface>(
-        "/laser-lines/%d%s", i + 1, avg_suffix.c_str());
-  }
+void
+MachineSignalPipelineThread::init()
+{
+	// Configure camera
+	cfg_camera_ = config->get_string(CFG_PREFIX "/camera");
+	setup_camera();
+
+	shmbuf_ = new SharedMemoryImageBuffer("machine-signal", YUV422_PLANAR, cam_width_, cam_height_);
+	shmbuf_cam_ = new SharedMemoryImageBuffer("machine-cam", YUV422_PLANAR, cam_width_, cam_height_);
+	roi_drawer_ = new FilterROIDraw(&drawn_rois_, FilterROIDraw::DASHED_HINT);
+
+	// Configure RED ON classifier
+	cfy_ctxt_red_1_.cfg_ref_col        = config->get_uints(CFG_PREFIX "/red_on/reference_color");
+	cfy_ctxt_red_1_.cfg_chroma_thresh  = config->get_ints(CFG_PREFIX "/red_on/chroma_thresh");
+	cfy_ctxt_red_1_.cfg_sat_thresh     = config->get_ints(CFG_PREFIX "/red_on/saturation_thresh");
+	cfy_ctxt_red_1_.cfg_luma_thresh    = config->get_ints(CFG_PREFIX "/red_on/luma_thresh");
+	cfy_ctxt_red_1_.cfg_roi_min_points = config->get_int(CFG_PREFIX "/red_on/min_points");
+	cfy_ctxt_red_1_.cfg_roi_basic_size = config->get_int(CFG_PREFIX "/red_on/basic_roi_size");
+	cfy_ctxt_red_1_.cfg_roi_neighborhood_min_match =
+	  config->get_int(CFG_PREFIX "/red_on/neighborhood_min_match");
+	cfy_ctxt_red_1_.cfg_scangrid_x_offset = config->get_int(CFG_PREFIX "/red_on/scangrid_x_offset");
+	cfy_ctxt_red_1_.cfg_scangrid_y_offset = config->get_int(CFG_PREFIX "/red_on/scangrid_y_offset");
+	cfy_ctxt_red_1_.visualize             = config->get_bool(CFG_PREFIX "/red_on/visualize");
+
+	setup_color_classifier(&cfy_ctxt_red_1_);
+
+	// Configure RED OFF classifier
+	cfy_ctxt_red_0_.cfg_ref_col        = config->get_uints(CFG_PREFIX "/red_off/reference_color");
+	cfy_ctxt_red_0_.cfg_chroma_thresh  = config->get_ints(CFG_PREFIX "/red_off/chroma_thresh");
+	cfy_ctxt_red_0_.cfg_sat_thresh     = config->get_ints(CFG_PREFIX "/red_off/saturation_thresh");
+	cfy_ctxt_red_0_.cfg_luma_thresh    = config->get_ints(CFG_PREFIX "/red_off/luma_thresh");
+	cfy_ctxt_red_0_.cfg_roi_min_points = config->get_int(CFG_PREFIX "/red_off/min_points");
+	cfy_ctxt_red_0_.cfg_roi_basic_size = config->get_int(CFG_PREFIX "/red_off/basic_roi_size");
+	cfy_ctxt_red_0_.cfg_roi_neighborhood_min_match =
+	  config->get_int(CFG_PREFIX "/red_off/neighborhood_min_match");
+	cfy_ctxt_red_0_.cfg_scangrid_x_offset = config->get_int(CFG_PREFIX "/red_off/scangrid_x_offset");
+	cfy_ctxt_red_0_.cfg_scangrid_y_offset = config->get_int(CFG_PREFIX "/red_off/scangrid_y_offset");
+	cfy_ctxt_red_0_.visualize             = config->get_bool(CFG_PREFIX "/red_off/visualize");
+
+	setup_color_classifier(&cfy_ctxt_red_0_);
+
+	// Configure GREEN ON classifier
+	cfy_ctxt_green_1_.cfg_ref_col        = config->get_uints(CFG_PREFIX "/green_on/reference_color");
+	cfy_ctxt_green_1_.cfg_chroma_thresh  = config->get_ints(CFG_PREFIX "/green_on/chroma_thresh");
+	cfy_ctxt_green_1_.cfg_sat_thresh     = config->get_ints(CFG_PREFIX "/green_on/saturation_thresh");
+	cfy_ctxt_green_1_.cfg_luma_thresh    = config->get_ints(CFG_PREFIX "/green_on/luma_thresh");
+	cfy_ctxt_green_1_.cfg_roi_min_points = config->get_int(CFG_PREFIX "/green_on/min_points");
+	cfy_ctxt_green_1_.cfg_roi_basic_size = config->get_int(CFG_PREFIX "/green_on/basic_roi_size");
+	cfy_ctxt_green_1_.cfg_roi_neighborhood_min_match =
+	  config->get_int(CFG_PREFIX "/green_on/neighborhood_min_match");
+	cfy_ctxt_green_1_.cfg_scangrid_x_offset =
+	  config->get_int(CFG_PREFIX "/green_on/scangrid_x_offset");
+	cfy_ctxt_green_1_.cfg_scangrid_y_offset =
+	  config->get_int(CFG_PREFIX "/green_on/scangrid_y_offset");
+	cfy_ctxt_green_1_.visualize = config->get_bool(CFG_PREFIX "/green_on/visualize");
+
+	setup_color_classifier(&cfy_ctxt_green_1_);
+
+	// Configure GREEN OFF classifier
+	cfy_ctxt_green_0_.cfg_ref_col       = config->get_uints(CFG_PREFIX "/green_off/reference_color");
+	cfy_ctxt_green_0_.cfg_chroma_thresh = config->get_ints(CFG_PREFIX "/green_off/chroma_thresh");
+	cfy_ctxt_green_0_.cfg_sat_thresh    = config->get_ints(CFG_PREFIX "/green_off/saturation_thresh");
+	cfy_ctxt_green_0_.cfg_luma_thresh   = config->get_ints(CFG_PREFIX "/green_off/luma_thresh");
+	cfy_ctxt_green_0_.cfg_roi_min_points = config->get_int(CFG_PREFIX "/green_off/min_points");
+	cfy_ctxt_green_0_.cfg_roi_basic_size = config->get_int(CFG_PREFIX "/green_off/basic_roi_size");
+	cfy_ctxt_green_0_.cfg_roi_neighborhood_min_match =
+	  config->get_int(CFG_PREFIX "/green_off/neighborhood_min_match");
+	cfy_ctxt_green_0_.cfg_scangrid_x_offset =
+	  config->get_int(CFG_PREFIX "/green_off/scangrid_x_offset");
+	cfy_ctxt_green_0_.cfg_scangrid_y_offset =
+	  config->get_int(CFG_PREFIX "/green_off/scangrid_y_offset");
+	cfy_ctxt_green_0_.visualize = config->get_bool(CFG_PREFIX "/green_off/visualize");
+
+	setup_color_classifier(&cfy_ctxt_green_0_);
+
+	// Configure brightness classifier
+	cfg_light_on_threshold_  = config->get_uint(CFG_PREFIX "/bright_light/min_brightness");
+	cfg_light_on_min_points_ = config->get_uint(CFG_PREFIX "/bright_light/min_points");
+	cfg_light_on_min_neighborhood_ =
+	  config->get_uint(CFG_PREFIX "/bright_light/neighborhood_min_match");
+	cfg_light_on_min_area_cover_ = config->get_float(CFG_PREFIX "/bright_light/min_area_cover");
+
+	// Configure black classifier
+	cfg_black_y_thresh_         = config->get_uint(CFG_PREFIX "/black/y_threshold");
+	cfg_black_u_thresh_         = config->get_uint(CFG_PREFIX "/black/u_threshold");
+	cfg_black_v_thresh_         = config->get_uint(CFG_PREFIX "/black/v_threshold");
+	cfg_black_u_ref_            = config->get_uint(CFG_PREFIX "/black/u_reference");
+	cfg_black_v_ref_            = config->get_uint(CFG_PREFIX "/black/v_reference");
+	cfg_black_min_neighborhood_ = config->get_uint(CFG_PREFIX "/black/neighborhood_min_match");
+	cfg_black_min_points_       = config->get_uint(CFG_PREFIX "/black/min_points");
+
+	// General config
+	cfg_roi_max_aspect_ratio_ = config->get_float(CFG_PREFIX "/roi_max_aspect_ratio");
+	cfg_roi_max_width_ratio_  = config->get_float(CFG_PREFIX "/roi_max_r2g_width_ratio");
+	cfg_roi_max_height_       = config->get_uint(CFG_PREFIX "/roi_max_height");
+	cfg_roi_max_width_        = config->get_uint(CFG_PREFIX "/roi_max_width");
+	cfg_roi_xalign_           = config->get_float(CFG_PREFIX "/roi_xalign_by_width");
+	cfg_roi_green_horizon     = config->get_uint(CFG_PREFIX "/roi_green_horizon");
+	cfg_tuning_mode_          = config->get_bool(CFG_PREFIX "/tuning_mode");
+	cfg_max_jitter_           = config->get_float(CFG_PREFIX "/max_jitter");
+	cfg_draw_processed_rois_  = config->get_bool(CFG_PREFIX "/draw_processed_rois");
+	cfg_enable_switch_        = config->get_bool(CFG_PREFIX "/start_enabled");
+	cfg_fps_                  = config->get_uint(CFG_PREFIX "/fps");
+	cfg_debug_blink_          = config->get_bool(CFG_PREFIX "/debug_blink");
+	cfg_debug_processing_     = config->get_bool(CFG_PREFIX "/debug_processing");
+	cfg_debug_tf_             = config->get_bool(CFG_PREFIX "/debug_tf");
+
+	cfg_lasercluster_frame_         = config->get_string(CFG_PREFIX "/laser_frame");
+	cfg_lasercluster_signal_radius_ = 0.5 * config->get_float(CFG_PREFIX "/signal_width");
+	cfg_lasercluster_signal_top_    = config->get_float(CFG_PREFIX "/signal_top");
+	cfg_lasercluster_signal_bottom_ = config->get_float(CFG_PREFIX "/signal_bottom");
+	cfg_cam_aperture_x_             = config->get_float(CFG_PREFIX "/cam_aperture_x");
+	cfg_cam_aperture_y_             = config->get_float(CFG_PREFIX "/cam_aperture_y");
+	cfg_cam_angle_y_                = config->get_float(CFG_PREFIX "/cam_angle");
+	cfg_cam_frame_                  = config->get_string(CFG_PREFIX "/cam_frame");
+
+	// Laser-lines config
+	cfg_laser_lines_enabled_ = config->get_bool(CFG_PREFIX "/laser-lines/enable");
+	cfg_laser_lines_min_vis_hist_ =
+	  config->get_uint(CFG_PREFIX "/laser-lines/min_visibility_history");
+	cfg_laser_lines_moving_avg_ = config->get_bool(CFG_PREFIX "/laser-lines/moving_avg");
+
+	// Laser Cluster config
+	cfg_lasercluster_enabled_ = config->get_bool(CFG_PREFIX "/lasercluster/enable");
+	cfg_lasercluster_min_vis_hist_ =
+	  config->get_uint(CFG_PREFIX "/lasercluster/min_visibility_history");
+
+	pos2pixel_ = new PositionToPixel(tf_listener,
+	                                 cfg_cam_frame_,
+	                                 cfg_cam_aperture_x_,
+	                                 cfg_cam_aperture_y_,
+	                                 cam_width_,
+	                                 cam_height_,
+	                                 cfg_cam_angle_y_);
+
+	// Setup combined ColorModel for tuning filter
+	combined_colormodel_ = new ColorModelSimilarity();
+	if (cfy_ctxt_red_1_.visualize)
+		combined_colormodel_->add_colors(cfy_ctxt_red_1_.color_class);
+	if (cfy_ctxt_red_0_.visualize)
+		combined_colormodel_->add_colors(cfy_ctxt_red_0_.color_class);
+	if (cfy_ctxt_green_1_.visualize)
+		combined_colormodel_->add_colors(cfy_ctxt_green_1_.color_class);
+	if (cfy_ctxt_green_0_.visualize)
+		combined_colormodel_->add_colors(cfy_ctxt_green_0_.color_class);
+	color_filter_ = new FilterColorThreshold(combined_colormodel_);
+
+	// Setup luminance classifier for light on/off detection
+	light_scangrid_   = new ScanlineGrid(cam_width_, cam_height_, 1, 1);
+	light_colormodel_ = new ColorModelLuminance(cfg_light_on_threshold_);
+	light_classifier_ = new SimpleColorClassifier(light_scangrid_,
+	                                              light_colormodel_,
+	                                              cfg_light_on_min_points_,
+	                                              8,
+	                                              false,
+	                                              cfg_light_on_min_neighborhood_,
+	                                              0,
+	                                              C_WHITE);
+	light_classifier_->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
+
+	// Setup black classifier for top/bottom recognition
+	black_scangrid_   = new ScanlineGrid(cam_width_, cam_height_, 1, 1);
+	black_colormodel_ = new ColorModelBlack(cfg_black_y_thresh_,
+	                                        cfg_black_u_thresh_,
+	                                        cfg_black_v_thresh_,
+	                                        cfg_black_u_ref_,
+	                                        cfg_black_v_ref_);
+	black_classifier_ = new SimpleColorClassifier(black_scangrid_,
+	                                              black_colormodel_,
+	                                              cfg_black_min_points_,
+	                                              6,
+	                                              false,
+	                                              cfg_black_min_neighborhood_,
+	                                              0,
+	                                              C_BLACK);
+	black_classifier_->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
+
+	// Initialize frame rate detection & buffer lengths for blinking detection
+	buflen_            = (unsigned int)ceil(cfg_fps_ / 4) + 1;
+	desired_frametime_ = 1 / (double)cfg_fps_;
+	time_wait_         = new TimeWait(clock, (long int)(1000000 * desired_frametime_));
+	buflen_ += 1 - (buflen_ % 2); // make sure buflen is uneven
+	logger->log_info(name(), "Buffer length: %d", buflen_);
+	last_second_ = new Time(clock);
+
+	bb_enable_switch_ = blackboard->open_for_writing<SwitchInterface>("/machine-signal");
+	bb_enable_switch_->set_enabled(cfg_enable_switch_);
+	bb_enable_switch_->write();
+
+	bb_laser_clusters_[0] =
+	  blackboard->open_for_reading<Position3DInterface>("/laser-cluster/ampel/1");
+	bb_laser_clusters_[1] =
+	  blackboard->open_for_reading<Position3DInterface>("/laser-cluster/ampel/2");
+	bb_laser_clusters_[2] =
+	  blackboard->open_for_reading<Position3DInterface>("/laser-cluster/ampel/3");
+
+	bb_signal_position_estimate_ =
+	  blackboard->open_for_writing<SignalHintInterface>("/machine-signal/position-hint");
+
+	bb_open_laser_lines();
+
+	config->add_change_handler(this);
 }
 
-void MachineSignalPipelineThread::bb_close_laser_lines() {
-  string avg_suffix = "";
-  if (cfg_laser_lines_moving_avg_)
-    avg_suffix = "/moving_avg";
-  for (LaserLineInterface *bb_laser_line : bb_laser_lines_) {
-    blackboard->close(bb_laser_line);
-  }
+void
+MachineSignalPipelineThread::bb_open_laser_lines()
+{
+	string avg_suffix = "";
+	if (cfg_laser_lines_moving_avg_)
+		avg_suffix = "/moving_avg";
+	for (uint i = 0; i < NUM_LASER_LINES; ++i) {
+		bb_laser_lines_[i] = blackboard->open_for_reading_f<LaserLineInterface>("/laser-lines/%d%s",
+		                                                                        i + 1,
+		                                                                        avg_suffix.c_str());
+	}
 }
 
-void MachineSignalPipelineThread::setup_camera() {
-  camera_ = vision_master->register_for_camera(cfg_camera_.c_str(), this);
-  cam_width_ = camera_->pixel_width();
-  cam_height_ = camera_->pixel_height();
+void
+MachineSignalPipelineThread::bb_close_laser_lines()
+{
+	string avg_suffix = "";
+	if (cfg_laser_lines_moving_avg_)
+		avg_suffix = "/moving_avg";
+	for (LaserLineInterface *bb_laser_line : bb_laser_lines_) {
+		blackboard->close(bb_laser_line);
+	}
 }
 
-void MachineSignalPipelineThread::finalize() {
-  delete camera_;
-  delete roi_drawer_;
-  delete last_second_;
-
-  delete cfy_ctxt_red_1_.colormodel;
-  delete cfy_ctxt_red_1_.classifier;
-  delete cfy_ctxt_red_1_.scanline_grid;
-  for (std::vector<ColorModelSimilarity::color_class_t *>::iterator it =
-           cfy_ctxt_red_1_.color_class.begin();
-       it != cfy_ctxt_red_1_.color_class.end(); it++) {
-    delete *it;
-  }
-  delete cfy_ctxt_green_1_.colormodel;
-  delete cfy_ctxt_green_1_.classifier;
-  delete cfy_ctxt_green_1_.scanline_grid;
-  for (std::vector<ColorModelSimilarity::color_class_t *>::iterator it =
-           cfy_ctxt_green_1_.color_class.begin();
-       it != cfy_ctxt_green_1_.color_class.end(); it++) {
-    delete *it;
-  }
-
-  blackboard->close(bb_enable_switch_);
-  for (Position3DInterface *iface : bb_laser_clusters_) {
-    blackboard->close(iface);
-  }
-  blackboard->close(bb_signal_position_estimate_);
-  bb_close_laser_lines();
-
-  vision_master->unregister_thread(this);
-
-  delete shmbuf_;
-  delete shmbuf_cam_;
-
-  delete light_scangrid_;
-  delete light_colormodel_;
-  delete light_classifier_;
-
-  delete black_scangrid_;
-  delete black_colormodel_;
-  delete black_classifier_;
-
-  delete combined_colormodel_;
-  delete color_filter_;
+void
+MachineSignalPipelineThread::setup_camera()
+{
+	camera_     = vision_master->register_for_camera(cfg_camera_.c_str(), this);
+	cam_width_  = camera_->pixel_width();
+	cam_height_ = camera_->pixel_height();
 }
 
-bool MachineSignalPipelineThread::lock_if_new_data() {
-  data_mutex_.lock();
-  if (new_data_) {
-    return true;
-  } else {
-    data_mutex_.unlock();
-    return false;
-  }
+void
+MachineSignalPipelineThread::finalize()
+{
+	delete camera_;
+	delete roi_drawer_;
+	delete last_second_;
+
+	delete cfy_ctxt_red_1_.colormodel;
+	delete cfy_ctxt_red_1_.classifier;
+	delete cfy_ctxt_red_1_.scanline_grid;
+	for (std::vector<ColorModelSimilarity::color_class_t *>::iterator it =
+	       cfy_ctxt_red_1_.color_class.begin();
+	     it != cfy_ctxt_red_1_.color_class.end();
+	     it++) {
+		delete *it;
+	}
+	delete cfy_ctxt_green_1_.colormodel;
+	delete cfy_ctxt_green_1_.classifier;
+	delete cfy_ctxt_green_1_.scanline_grid;
+	for (std::vector<ColorModelSimilarity::color_class_t *>::iterator it =
+	       cfy_ctxt_green_1_.color_class.begin();
+	     it != cfy_ctxt_green_1_.color_class.end();
+	     it++) {
+		delete *it;
+	}
+
+	blackboard->close(bb_enable_switch_);
+	for (Position3DInterface *iface : bb_laser_clusters_) {
+		blackboard->close(iface);
+	}
+	blackboard->close(bb_signal_position_estimate_);
+	bb_close_laser_lines();
+
+	vision_master->unregister_thread(this);
+
+	delete shmbuf_;
+	delete shmbuf_cam_;
+
+	delete light_scangrid_;
+	delete light_colormodel_;
+	delete light_classifier_;
+
+	delete black_scangrid_;
+	delete black_colormodel_;
+	delete black_classifier_;
+
+	delete combined_colormodel_;
+	delete color_filter_;
 }
 
-void MachineSignalPipelineThread::unlock() { data_mutex_.unlock(); }
+bool
+MachineSignalPipelineThread::lock_if_new_data()
+{
+	data_mutex_.lock();
+	if (new_data_) {
+		return true;
+	} else {
+		data_mutex_.unlock();
+		return false;
+	}
+}
 
-std::list<SignalState> &MachineSignalPipelineThread::get_known_signals() {
-  return known_signals_;
+void
+MachineSignalPipelineThread::unlock()
+{
+	data_mutex_.unlock();
+}
+
+std::list<SignalState> &
+MachineSignalPipelineThread::get_known_signals()
+{
+	return known_signals_;
 }
 
 std::list<SignalState>::iterator
-MachineSignalPipelineThread::get_best_signal() {
-  return best_signal_;
+MachineSignalPipelineThread::get_best_signal()
+{
+	return best_signal_;
 }
 
-bool MachineSignalPipelineThread::bb_switch_is_enabled(SwitchInterface *sw) {
-  bool rv = sw->is_enabled();
-  while (!sw->msgq_empty()) {
-    if (sw->msgq_first_is<SwitchInterface::DisableSwitchMessage>()) {
-      rv = false;
-    } else if (sw->msgq_first_is<SwitchInterface::EnableSwitchMessage>()) {
-      rv = true;
-    }
+bool
+MachineSignalPipelineThread::bb_switch_is_enabled(SwitchInterface *sw)
+{
+	bool rv = sw->is_enabled();
+	while (!sw->msgq_empty()) {
+		if (sw->msgq_first_is<SwitchInterface::DisableSwitchMessage>()) {
+			rv = false;
+		} else if (sw->msgq_first_is<SwitchInterface::EnableSwitchMessage>()) {
+			rv = true;
+		}
 
-    sw->msgq_pop();
-  }
-  if (rv != sw->is_enabled()) {
-    logger->log_info(name(), "*** enabled: %s", rv ? "yes" : "no");
-    sw->set_enabled(rv);
-    sw->write();
-  }
-  return rv;
+		sw->msgq_pop();
+	}
+	if (rv != sw->is_enabled()) {
+		logger->log_info(name(), "*** enabled: %s", rv ? "yes" : "no");
+		sw->set_enabled(rv);
+		sw->write();
+	}
+	return rv;
 }
 
-#define LIMIT_VALUE(min, value, max)                                           \
-  std::min(std::max((long int)min, (long int)value), (long int)max)
+#define LIMIT_VALUE(min, value, max) \
+	std::min(std::max((long int)min, (long int)value), (long int)max)
 
 firevision::WorldROI
-MachineSignalPipelineThread::pos3d_to_roi(const Stamped<Point> &cluster_laser) {
-  // Transform laser cluster into camera frame
-  Stamped<Point> cluster_cam;
-  tf_listener->transform_point(cfg_cam_frame_, cluster_laser, cluster_cam);
+MachineSignalPipelineThread::pos3d_to_roi(const Stamped<Point> &cluster_laser)
+{
+	// Transform laser cluster into camera frame
+	Stamped<Point> cluster_cam;
+	tf_listener->transform_point(cfg_cam_frame_, cluster_laser, cluster_cam);
 
-  // Then compute the upper left and bottom right corner we expect to see
-  // (Account for cam parallax when adding the signal radius)
-  cart_coord_3d_t top_left, bottom_right;
-  float x = cluster_cam.getX();
-  float y = cluster_cam.getY();
-  float phi = atan2f(y, x);
-  float edge_x = sinf(phi) * cfg_lasercluster_signal_radius_;
-  float edge_y = cosf(phi) * cfg_lasercluster_signal_radius_;
+	// Then compute the upper left and bottom right corner we expect to see
+	// (Account for cam parallax when adding the signal radius)
+	cart_coord_3d_t top_left, bottom_right;
+	float           x      = cluster_cam.getX();
+	float           y      = cluster_cam.getY();
+	float           phi    = atan2f(y, x);
+	float           edge_x = sinf(phi) * cfg_lasercluster_signal_radius_;
+	float           edge_y = cosf(phi) * cfg_lasercluster_signal_radius_;
 
-  top_left.x = cluster_cam.x() - edge_x;
-  top_left.y = cluster_cam.y() + edge_y;
-  top_left.z = cluster_cam.z() + cfg_lasercluster_signal_top_;
+	top_left.x = cluster_cam.x() - edge_x;
+	top_left.y = cluster_cam.y() + edge_y;
+	top_left.z = cluster_cam.z() + cfg_lasercluster_signal_top_;
 
-  bottom_right.x = cluster_cam.x() + edge_x;
-  bottom_right.y = cluster_cam.y() - edge_y;
-  bottom_right.z = cluster_cam.z() + cfg_lasercluster_signal_bottom_;
+	bottom_right.x = cluster_cam.x() + edge_x;
+	bottom_right.y = cluster_cam.y() - edge_y;
+	bottom_right.z = cluster_cam.z() + cfg_lasercluster_signal_bottom_;
 
-  if (unlikely(cfg_debug_tf_)) {
-    logger->log_debug(name(),
-                      "Signal top_left: %f, %f, %f; bottom_right: %f, %f, %f.",
-                      top_left.x, top_left.y, top_left.z, bottom_right.x,
-                      bottom_right.y, bottom_right.z);
-  }
+	if (unlikely(cfg_debug_tf_)) {
+		logger->log_debug(name(),
+		                  "Signal top_left: %f, %f, %f; bottom_right: %f, %f, %f.",
+		                  top_left.x,
+		                  top_left.y,
+		                  top_left.z,
+		                  bottom_right.x,
+		                  bottom_right.y,
+		                  bottom_right.z);
+	}
 
-  // And finally compute a ROI that (hopefully) contains the real signal
-  point_t top_left_px_tmp =
-      pos2pixel_->get_pixel_position_unchecked(top_left, cfg_cam_frame_, clock);
-  point_t bot_right_px_tmp = pos2pixel_->get_pixel_position_unchecked(
-      bottom_right, cfg_cam_frame_, clock);
-  upoint_t top_left_px, bot_right_px;
+	// And finally compute a ROI that (hopefully) contains the real signal
+	point_t top_left_px_tmp =
+	  pos2pixel_->get_pixel_position_unchecked(top_left, cfg_cam_frame_, clock);
+	point_t bot_right_px_tmp =
+	  pos2pixel_->get_pixel_position_unchecked(bottom_right, cfg_cam_frame_, clock);
+	upoint_t top_left_px, bot_right_px;
 
-  top_left_px.x =
-      min((long int)max(0, top_left_px_tmp.x), (long int)cam_width_);
-  top_left_px.y =
-      min((long int)max(0, top_left_px_tmp.y), (long int)cam_height_);
-  bot_right_px.x =
-      min((long int)max(0, bot_right_px_tmp.x), (long int)cam_width_);
-  bot_right_px.y =
-      min((long int)max(0, bot_right_px_tmp.y), (long int)cam_height_);
+	top_left_px.x  = min((long int)max(0, top_left_px_tmp.x), (long int)cam_width_);
+	top_left_px.y  = min((long int)max(0, top_left_px_tmp.y), (long int)cam_height_);
+	bot_right_px.x = min((long int)max(0, bot_right_px_tmp.x), (long int)cam_width_);
+	bot_right_px.y = min((long int)max(0, bot_right_px_tmp.y), (long int)cam_height_);
 
-  WorldROI cluster_roi;
-  cluster_roi.set_start(top_left_px);
-  cluster_roi.set_width(bot_right_px.x - top_left_px.x);
-  cluster_roi.set_height(bot_right_px.y - top_left_px.y);
-  cluster_roi.set_image_width(cam_width_);
-  cluster_roi.set_image_height(cam_height_);
-  cluster_roi.color = C_MAGENTA;
-  cluster_roi.world_pos = shared_ptr<Stamped<Point>>(new Stamped<Point>(
-      cluster_laser, cluster_laser.stamp, cluster_laser.frame_id));
-  /* if (tf_listener->can_transform("/map", cluster_laser.frame_id,
+	WorldROI cluster_roi;
+	cluster_roi.set_start(top_left_px);
+	cluster_roi.set_width(bot_right_px.x - top_left_px.x);
+	cluster_roi.set_height(bot_right_px.y - top_left_px.y);
+	cluster_roi.set_image_width(cam_width_);
+	cluster_roi.set_image_height(cam_height_);
+	cluster_roi.color     = C_MAGENTA;
+	cluster_roi.world_pos = shared_ptr<Stamped<Point>>(
+	  new Stamped<Point>(cluster_laser, cluster_laser.stamp, cluster_laser.frame_id));
+	/* if (tf_listener->can_transform("/map", cluster_laser.frame_id,
   clock->now())) { cluster_roi.world_pos = new Stamped<Point>();
     tf_listener->transform_point("/map", cluster_laser,
   *(cluster_roi.world_pos));
   } */
-  return cluster_roi;
+	return cluster_roi;
 }
 
 set<firevision::WorldROI, SignalState::compare_rois_by_area> *
-MachineSignalPipelineThread::bb_get_laser_rois() {
-  set<WorldROI, SignalState::compare_rois_by_area> *rv =
-      new set<WorldROI, SignalState::compare_rois_by_area>();
-  if (unlikely(cfg_lasercluster_enabled_)) {
-    for (Position3DInterface *bb_pos : bb_laser_clusters_) {
-      bb_pos->read();
-      if (bb_pos && bb_pos->has_writer() &&
-          bb_pos->visibility_history() >=
-              (long int)cfg_lasercluster_min_vis_hist_) {
-        try {
-          WorldROI laser_in_cam = pos3d_to_roi(Stamped<Point>(
-              Point(bb_pos->translation(0), bb_pos->translation(1),
-                    bb_pos->translation(2)),
-              Time(0, 0), bb_pos->frame()));
-          if (laser_in_cam.get_width() > 20 && laser_in_cam.get_height() > 40) {
-            rv->insert(laser_in_cam);
-          }
-        } catch (OutOfBoundsException &e) {
-          // This is a pretty normal case, getting a 3D position that is outside
-          // the cam viewport
-          // logger->log_debug(name(), e);
-        } catch (Exception &e) {
-          logger->log_error(name(), e);
-        }
-      }
-    }
-  }
+MachineSignalPipelineThread::bb_get_laser_rois()
+{
+	set<WorldROI, SignalState::compare_rois_by_area> *rv =
+	  new set<WorldROI, SignalState::compare_rois_by_area>();
+	if (unlikely(cfg_lasercluster_enabled_)) {
+		for (Position3DInterface *bb_pos : bb_laser_clusters_) {
+			bb_pos->read();
+			if (bb_pos && bb_pos->has_writer()
+			    && bb_pos->visibility_history() >= (long int)cfg_lasercluster_min_vis_hist_) {
+				try {
+					WorldROI laser_in_cam = pos3d_to_roi(Stamped<Point>(
+					  Point(bb_pos->translation(0), bb_pos->translation(1), bb_pos->translation(2)),
+					  Time(0, 0),
+					  bb_pos->frame()));
+					if (laser_in_cam.get_width() > 20 && laser_in_cam.get_height() > 40) {
+						rv->insert(laser_in_cam);
+					}
+				} catch (OutOfBoundsException &e) {
+					// This is a pretty normal case, getting a 3D position that is outside
+					// the cam viewport
+					// logger->log_debug(name(), e);
+				} catch (Exception &e) {
+					logger->log_error(name(), e);
+				}
+			}
+		}
+	}
 
-  Point *signal_hint_msg = nullptr;
-  while (!bb_signal_position_estimate_->msgq_empty()) {
-    // Process new signal hint messages
-    SignalHintInterface::SignalPositionMessage *msg = nullptr;
-    if ((msg = bb_signal_position_estimate_->msgq_first_safe(msg))) {
-      signal_hint_msg = new btVector3(msg->translation(0), msg->translation(1),
-                                      msg->translation(2));
-    } else {
-      logger->log_error(
-          name(),
-          "EEEK! Invalid message in SignalHintInterface! This is a Bug!");
-    }
-    bb_signal_position_estimate_->msgq_pop();
-  }
+	Point *signal_hint_msg = nullptr;
+	while (!bb_signal_position_estimate_->msgq_empty()) {
+		// Process new signal hint messages
+		SignalHintInterface::SignalPositionMessage *msg = nullptr;
+		if ((msg = bb_signal_position_estimate_->msgq_first_safe(msg))) {
+			signal_hint_msg =
+			  new btVector3(msg->translation(0), msg->translation(1), msg->translation(2));
+		} else {
+			logger->log_error(name(), "EEEK! Invalid message in SignalHintInterface! This is a Bug!");
+		}
+		bb_signal_position_estimate_->msgq_pop();
+	}
 
-  if (likely(cfg_laser_lines_enabled_)) {
-    if (signal_hint_msg) {
-      // Only update BB with sent MSGs if we're actually using them
-      bb_signal_position_estimate_->set_translation(0, signal_hint_msg->getX());
-      bb_signal_position_estimate_->set_translation(1, signal_hint_msg->getY());
-      bb_signal_position_estimate_->set_translation(2, signal_hint_msg->getZ());
-      bb_signal_position_estimate_->write();
-      logger->log_info(name(), "Signal hint: %f, %f, %f",
-                       signal_hint_msg->getX(), signal_hint_msg->getY(),
-                       signal_hint_msg->getZ());
-    }
+	if (likely(cfg_laser_lines_enabled_)) {
+		if (signal_hint_msg) {
+			// Only update BB with sent MSGs if we're actually using them
+			bb_signal_position_estimate_->set_translation(0, signal_hint_msg->getX());
+			bb_signal_position_estimate_->set_translation(1, signal_hint_msg->getY());
+			bb_signal_position_estimate_->set_translation(2, signal_hint_msg->getZ());
+			bb_signal_position_estimate_->write();
+			logger->log_info(name(),
+			                 "Signal hint: %f, %f, %f",
+			                 signal_hint_msg->getX(),
+			                 signal_hint_msg->getY(),
+			                 signal_hint_msg->getZ());
+		}
 
-    bb_signal_position_estimate_->read();
-    Point current_signal_hint(bb_signal_position_estimate_->translation(0),
-                              bb_signal_position_estimate_->translation(1),
-                              bb_signal_position_estimate_->translation(2));
+		bb_signal_position_estimate_->read();
+		Point current_signal_hint(bb_signal_position_estimate_->translation(0),
+		                          bb_signal_position_estimate_->translation(1),
+		                          bb_signal_position_estimate_->translation(2));
 
-    LaserLineInterface *best_line = bb_laser_lines_[0];
-    best_line->read();
+		LaserLineInterface *best_line = bb_laser_lines_[0];
+		best_line->read();
 
-    if (string(best_line->frame_id()) != "") {
-      // Find the leftmost endpoint, as seen from base_link
-      float *ep1 = best_line->end_point_1();
-      float *ep2 = best_line->end_point_2();
-      float *left_end;
-      if (atan2f(ep2[1], ep2[0]) > atan2f(ep1[1], ep1[0]))
-        left_end = ep2;
-      else
-        left_end = ep1;
+		if (string(best_line->frame_id()) != "") {
+			// Find the leftmost endpoint, as seen from base_link
+			float *ep1 = best_line->end_point_1();
+			float *ep2 = best_line->end_point_2();
+			float *left_end;
+			if (atan2f(ep2[1], ep2[0]) > atan2f(ep1[1], ep1[0]))
+				left_end = ep2;
+			else
+				left_end = ep1;
 
-      Stamped<Point> ep_laser =
-          Stamped<Point>(Point(left_end[0], left_end[1], left_end[2]),
-                         Time(0, 0), best_line->frame_id());
+			Stamped<Point> ep_laser = Stamped<Point>(Point(left_end[0], left_end[1], left_end[2]),
+			                                         Time(0, 0),
+			                                         best_line->frame_id());
 
-      if (tf_listener->can_transform("/base_link", ep_laser.frame_id,
-                                     ep_laser.stamp)) {
-        Stamped<Point> ep_bl;
-        tf_listener->transform_point("/base_link", ep_laser, ep_bl);
-        // Table height is measured from the floor, i.e. in /base_link z=0.
-        ep_bl.setZ(0);
+			if (tf_listener->can_transform("/base_link", ep_laser.frame_id, ep_laser.stamp)) {
+				Stamped<Point> ep_bl;
+				tf_listener->transform_point("/base_link", ep_laser, ep_bl);
+				// Table height is measured from the floor, i.e. in /base_link z=0.
+				ep_bl.setZ(0);
 
-        Stamped<Point> signal_hint_now(ep_bl + current_signal_hint, Time(0, 0),
-                                       ep_bl.frame_id);
-        if (best_line->visibility_history() >=
-                (long int)cfg_laser_lines_min_vis_hist_ ||
-            (best_line->visibility_history() > 0 &&
-             signal_hint_now.distance(signal_hint_) < 0.01)) {
-          // Either visibility history is good, or it is bad but the line has
-          // moved by less than a centimeter.
-          signal_hint_ = signal_hint_now;
-          try {
-            WorldROI signal_in_cam = pos3d_to_roi(signal_hint_now);
-            if (signal_in_cam.get_width() > 20 &&
-                signal_in_cam.get_height() > 40) {
-              rv->insert(signal_in_cam);
-            }
-          } catch (OutOfBoundsException &e) {
-          } catch (Exception &e) {
-            logger->log_error(name(), e.what());
-          }
-        }
-      } else {
-        logger->log_error(name(), "Missing transform from %s to /base_link!",
-                          best_line->frame_id());
-      }
-    }
-  }
-  delete signal_hint_msg;
-  return rv;
+				Stamped<Point> signal_hint_now(ep_bl + current_signal_hint, Time(0, 0), ep_bl.frame_id);
+				if (best_line->visibility_history() >= (long int)cfg_laser_lines_min_vis_hist_
+				    || (best_line->visibility_history() > 0
+				        && signal_hint_now.distance(signal_hint_) < 0.01)) {
+					// Either visibility history is good, or it is bad but the line has
+					// moved by less than a centimeter.
+					signal_hint_ = signal_hint_now;
+					try {
+						WorldROI signal_in_cam = pos3d_to_roi(signal_hint_now);
+						if (signal_in_cam.get_width() > 20 && signal_in_cam.get_height() > 40) {
+							rv->insert(signal_in_cam);
+						}
+					} catch (OutOfBoundsException &e) {
+					} catch (Exception &e) {
+						logger->log_error(name(), e.what());
+					}
+				}
+			} else {
+				logger->log_error(name(),
+				                  "Missing transform from %s to /base_link!",
+				                  best_line->frame_id());
+			}
+		}
+	}
+	delete signal_hint_msg;
+	return rv;
 }
 
-inline void MachineSignalPipelineThread::reinit_color_config() {
-  combined_colormodel_->delete_colors();
+inline void
+MachineSignalPipelineThread::reinit_color_config()
+{
+	combined_colormodel_->delete_colors();
 
-  setup_color_classifier(&cfy_ctxt_red_1_);
-  setup_color_classifier(&cfy_ctxt_red_0_);
-  setup_color_classifier(&cfy_ctxt_green_1_);
-  setup_color_classifier(&cfy_ctxt_green_0_);
+	setup_color_classifier(&cfy_ctxt_red_1_);
+	setup_color_classifier(&cfy_ctxt_red_0_);
+	setup_color_classifier(&cfy_ctxt_green_1_);
+	setup_color_classifier(&cfy_ctxt_green_0_);
 
-  if (cfy_ctxt_red_1_.visualize)
-    combined_colormodel_->add_colors(cfy_ctxt_red_1_.color_class);
-  if (cfy_ctxt_red_0_.visualize)
-    combined_colormodel_->add_colors(cfy_ctxt_red_0_.color_class);
-  if (cfy_ctxt_green_1_.visualize)
-    combined_colormodel_->add_colors(cfy_ctxt_green_1_.color_class);
-  if (cfy_ctxt_green_0_.visualize)
-    combined_colormodel_->add_colors(cfy_ctxt_green_0_.color_class);
+	if (cfy_ctxt_red_1_.visualize)
+		combined_colormodel_->add_colors(cfy_ctxt_red_1_.color_class);
+	if (cfy_ctxt_red_0_.visualize)
+		combined_colormodel_->add_colors(cfy_ctxt_red_0_.color_class);
+	if (cfy_ctxt_green_1_.visualize)
+		combined_colormodel_->add_colors(cfy_ctxt_green_1_.color_class);
+	if (cfy_ctxt_green_0_.visualize)
+		combined_colormodel_->add_colors(cfy_ctxt_green_0_.color_class);
 
-  delete light_classifier_;
-  light_classifier_ = new SimpleColorClassifier(
-      light_scangrid_, new ColorModelLuminance(cfg_light_on_threshold_),
-      cfg_light_on_min_points_, 8, false, cfg_light_on_min_neighborhood_, 0,
-      C_WHITE);
+	delete light_classifier_;
+	light_classifier_ = new SimpleColorClassifier(light_scangrid_,
+	                                              new ColorModelLuminance(cfg_light_on_threshold_),
+	                                              cfg_light_on_min_points_,
+	                                              8,
+	                                              false,
+	                                              cfg_light_on_min_neighborhood_,
+	                                              0,
+	                                              C_WHITE);
 
-  delete black_classifier_;
-  delete black_colormodel_;
-  black_colormodel_ = new ColorModelBlack(
-      cfg_black_y_thresh_, cfg_black_u_thresh_, cfg_black_v_thresh_,
-      cfg_black_u_ref_, cfg_black_v_ref_);
-  black_classifier_ = new SimpleColorClassifier(
-      black_scangrid_, black_colormodel_, cfg_black_min_points_, 6, false,
-      cfg_black_min_neighborhood_, 0, C_BLACK);
+	delete black_classifier_;
+	delete black_colormodel_;
+	black_colormodel_ = new ColorModelBlack(cfg_black_y_thresh_,
+	                                        cfg_black_u_thresh_,
+	                                        cfg_black_v_thresh_,
+	                                        cfg_black_u_ref_,
+	                                        cfg_black_v_ref_);
+	black_classifier_ = new SimpleColorClassifier(black_scangrid_,
+	                                              black_colormodel_,
+	                                              cfg_black_min_points_,
+	                                              6,
+	                                              false,
+	                                              cfg_black_min_neighborhood_,
+	                                              0,
+	                                              C_BLACK);
 
-  delete pos2pixel_;
-  pos2pixel_ = new PositionToPixel(tf_listener, cfg_cam_frame_,
-                                   cfg_cam_aperture_x_, cfg_cam_aperture_y_,
-                                   cam_width_, cam_height_, cfg_cam_angle_y_);
+	delete pos2pixel_;
+	pos2pixel_ = new PositionToPixel(tf_listener,
+	                                 cfg_cam_frame_,
+	                                 cfg_cam_aperture_x_,
+	                                 cfg_cam_aperture_y_,
+	                                 cam_width_,
+	                                 cam_height_,
+	                                 cfg_cam_angle_y_);
 }
 
-static inline float symmetry(const ROI &r) {
-  return r.width <= r.height ? float(r.width) / float(r.height)
-                             : float(r.height) / float(r.width);
+static inline float
+symmetry(const ROI &r)
+{
+	return r.width <= r.height ? float(r.width) / float(r.height) : float(r.height) / float(r.width);
 }
 
-static inline float similarity(const ROI &r1, const ROI &r2) {
-  ROI roi_union(std::min(r1.start.x, r2.start.x),
-                std::min(r1.start.y, r2.start.y), std::max(r1.width, r2.width),
-                std::max(r1.height, r2.height), r1.image_width,
-                r1.image_height);
-  ROI roi_intersection = r1.intersect(r2);
+static inline float
+similarity(const ROI &r1, const ROI &r2)
+{
+	ROI roi_union(std::min(r1.start.x, r2.start.x),
+	              std::min(r1.start.y, r2.start.y),
+	              std::max(r1.width, r2.width),
+	              std::max(r1.height, r2.height),
+	              r1.image_width,
+	              r1.image_height);
+	ROI roi_intersection = r1.intersect(r2);
 
-  return float(roi_intersection.width * roi_intersection.height) /
-         float(roi_union.width * roi_union.height);
+	return float(roi_intersection.width * roi_intersection.height)
+	       / float(roi_union.width * roi_union.height);
 }
 
 inline float
-MachineSignalPipelineThread::compactness(const SignalState::signal_rois_t_ &s,
-                                         const ROI &laser_roi) {
-  // unsigned int gap1 = std::abs(s.yellow_roi->start.y - (s.red_roi->start.y +
-  // s.red_roi->height)); unsigned int gap2 = std::abs(s.green_roi->start.y -
-  // (s.yellow_roi->start.y + s.yellow_roi->height));
-  float h = std::abs(static_cast<long>(
-      (s.green_roi->start.y + s.green_roi->height) - s.red_roi->start.y));
-  // float gappitude = 1 - (float(gap1 + gap2) / h);
-  float shortitude = 1 - (h / float(laser_roi.height));
-  return shortitude;
-  // return 1 - (h / float(laser_roi.height));
+MachineSignalPipelineThread::compactness(const SignalState::signal_rois_t_ &s, const ROI &laser_roi)
+{
+	// unsigned int gap1 = std::abs(s.yellow_roi->start.y - (s.red_roi->start.y +
+	// s.red_roi->height)); unsigned int gap2 = std::abs(s.green_roi->start.y -
+	// (s.yellow_roi->start.y + s.yellow_roi->height));
+	float h =
+	  std::abs(static_cast<long>((s.green_roi->start.y + s.green_roi->height) - s.red_roi->start.y));
+	// float gappitude = 1 - (float(gap1 + gap2) / h);
+	float shortitude = 1 - (h / float(laser_roi.height));
+	return shortitude;
+	// return 1 - (h / float(laser_roi.height));
 }
 
-float MachineSignalPipelineThread::signal_beauty(
-    const SignalState::signal_rois_t_ &s, const ROI &laser_roi) {
-  ROI opt_R(*(s.red_roi));
-  opt_R.start.x = laser_roi.start.x;
-  opt_R.width = laser_roi.width;
-  opt_R.height = laser_roi.width;
+float
+MachineSignalPipelineThread::signal_beauty(const SignalState::signal_rois_t_ &s,
+                                           const ROI &                        laser_roi)
+{
+	ROI opt_R(*(s.red_roi));
+	opt_R.start.x = laser_roi.start.x;
+	opt_R.width   = laser_roi.width;
+	opt_R.height  = laser_roi.width;
 
-  ROI opt_G(*(s.green_roi));
-  opt_G.start.x = laser_roi.start.x;
-  opt_G.width = laser_roi.width;
-  opt_G.height = laser_roi.width;
+	ROI opt_G(*(s.green_roi));
+	opt_G.start.x = laser_roi.start.x;
+	opt_G.width   = laser_roi.width;
+	opt_G.height  = laser_roi.width;
 
-  float cmp = compactness(s, laser_roi);
+	float cmp = compactness(s, laser_roi);
 
-  if (cfg_debug_processing_)
-    debug_proc_string_ +=
-        " truth: " + to_string(s.truth) + ", compactness: " + to_string(cmp);
+	if (cfg_debug_processing_)
+		debug_proc_string_ += " truth: " + to_string(s.truth) + ", compactness: " + to_string(cmp);
 
-  return similarity(*(s.red_roi), opt_R) * similarity(*(s.green_roi), opt_G) *
-         s.truth * cmp;
+	return similarity(*(s.red_roi), opt_R) * similarity(*(s.green_roi), opt_G) * s.truth * cmp;
 }
 
-void MachineSignalPipelineThread::loop() {
-  time_wait_->mark_start();
+void
+MachineSignalPipelineThread::loop()
+{
+	time_wait_->mark_start();
 
-  Time now(clock);
-  double frametime = now - last_second_;
-  last_second_ = &(last_second_->stamp());
-  if (frametime >= desired_frametime_ * 1.1) {
-    logger->log_warn(
-        name(),
-        "Running too slow (%f sec/frame). Blink detection will be unreliable!",
-        frametime);
-  }
+	Time   now(clock);
+	double frametime = now - last_second_;
+	last_second_     = &(last_second_->stamp());
+	if (frametime >= desired_frametime_ * 1.1) {
+		logger->log_warn(name(),
+		                 "Running too slow (%f sec/frame). Blink detection will be unreliable!",
+		                 frametime);
+	}
 
-  cfg_enable_switch_ = bb_switch_is_enabled(bb_enable_switch_);
+	cfg_enable_switch_ = bb_switch_is_enabled(bb_enable_switch_);
 
-  if (cfg_enable_switch_) {
+	if (cfg_enable_switch_) {
+		std::list<ROI> *rois_R_1, *rois_R_0, *rois_G_1, *rois_G_0;
+		MutexLocker     lock(&cfg_mutex_);
 
-    std::list<ROI> *rois_R_1, *rois_R_0, *rois_G_1, *rois_G_0;
-    MutexLocker lock(&cfg_mutex_);
+		// Reallocate classifiers if their config changed
+		if (unlikely(cfg_changed_ && color_data_consistent(&cfy_ctxt_red_1_)
+		             && color_data_consistent(&cfy_ctxt_red_0_)
+		             && color_data_consistent(&cfy_ctxt_green_1_)
+		             && color_data_consistent(&cfy_ctxt_green_0_))) {
+			reinit_color_config();
+			bb_close_laser_lines();
+			try {
+				bb_open_laser_lines();
+			} catch (Exception &e) {
+				logger->log_error(name(), e.what());
+				logger->log_error(name(),
+				                  "Error opening smoothed LaserLineInterface. "
+				                  "Retrying with moving_avg = false");
+				cfg_laser_lines_moving_avg_ = false;
+				bb_open_laser_lines();
+			}
+			cfg_changed_ = false;
+		}
 
-    // Reallocate classifiers if their config changed
-    if (unlikely(cfg_changed_ && color_data_consistent(&cfy_ctxt_red_1_) &&
-                 color_data_consistent(&cfy_ctxt_red_0_) &&
-                 color_data_consistent(&cfy_ctxt_green_1_) &&
-                 color_data_consistent(&cfy_ctxt_green_0_))) {
-      reinit_color_config();
-      bb_close_laser_lines();
-      try {
-        bb_open_laser_lines();
-      } catch (Exception &e) {
-        logger->log_error(name(), e.what());
-        logger->log_error(name(), "Error opening smoothed LaserLineInterface. "
-                                  "Retrying with moving_avg = false");
-        cfg_laser_lines_moving_avg_ = false;
-        bb_open_laser_lines();
-      }
-      cfg_changed_ = false;
-    }
+		camera_->capture();
 
-    camera_->capture();
+		light_classifier_->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
+		black_classifier_->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
 
-    light_classifier_->set_src_buffer(camera_->buffer(), cam_width_,
-                                      cam_height_);
-    black_classifier_->set_src_buffer(camera_->buffer(), cam_width_,
-                                      cam_height_);
+		cfy_ctxt_red_1_.classifier->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
+		cfy_ctxt_red_0_.classifier->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
+		cfy_ctxt_green_1_.classifier->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
+		cfy_ctxt_green_0_.classifier->set_src_buffer(camera_->buffer(), cam_width_, cam_height_);
 
-    cfy_ctxt_red_1_.classifier->set_src_buffer(camera_->buffer(), cam_width_,
-                                               cam_height_);
-    cfy_ctxt_red_0_.classifier->set_src_buffer(camera_->buffer(), cam_width_,
-                                               cam_height_);
-    cfy_ctxt_green_1_.classifier->set_src_buffer(camera_->buffer(), cam_width_,
-                                                 cam_height_);
-    cfy_ctxt_green_0_.classifier->set_src_buffer(camera_->buffer(), cam_width_,
-                                                 cam_height_);
+		drawn_rois_.clear();
 
-    drawn_rois_.clear();
+		cluster_rois_ = bb_get_laser_rois();
 
-    cluster_rois_ = bb_get_laser_rois();
+		if (cluster_rois_ && cluster_rois_->size() == 1) {
+			ROI r(*(cluster_rois_->begin()));
+			cfy_ctxt_red_1_.scanline_grid->set_roi(&r);
+			cfy_ctxt_red_0_.scanline_grid->set_roi(&r);
+			cfy_ctxt_green_1_.scanline_grid->set_roi(&r);
+			cfy_ctxt_green_0_.scanline_grid->set_roi(&r);
+		} else {
+			ROI top_half(0, 0, cam_width_, cam_height_ * 0.7, cam_width_, cam_height_);
+			cfy_ctxt_red_1_.scanline_grid->set_roi(&top_half);
+			cfy_ctxt_red_0_.scanline_grid->set_roi(&top_half);
+			ROI bot_half(0, cam_height_ * 0.25, cam_width_, cam_height_ * 0.75, cam_width_, cam_height_);
+			cfy_ctxt_green_1_.scanline_grid->set_roi(&bot_half);
+			cfy_ctxt_green_0_.scanline_grid->set_roi(&bot_half);
+		}
 
-    if (cluster_rois_ && cluster_rois_->size() == 1) {
-      ROI r(*(cluster_rois_->begin()));
-      cfy_ctxt_red_1_.scanline_grid->set_roi(&r);
-      cfy_ctxt_red_0_.scanline_grid->set_roi(&r);
-      cfy_ctxt_green_1_.scanline_grid->set_roi(&r);
-      cfy_ctxt_green_0_.scanline_grid->set_roi(&r);
-    } else {
-      ROI top_half(0, 0, cam_width_, cam_height_ * 0.7, cam_width_,
-                   cam_height_);
-      cfy_ctxt_red_1_.scanline_grid->set_roi(&top_half);
-      cfy_ctxt_red_0_.scanline_grid->set_roi(&top_half);
-      ROI bot_half(0, cam_height_ * 0.25, cam_width_, cam_height_ * 0.75,
-                   cam_width_, cam_height_);
-      cfy_ctxt_green_1_.scanline_grid->set_roi(&bot_half);
-      cfy_ctxt_green_0_.scanline_grid->set_roi(&bot_half);
-    }
+		rois_R_1 = cfy_ctxt_red_1_.classifier->classify();
+		rois_R_0 = cfy_ctxt_red_0_.classifier->classify();
+		rois_G_1 = cfy_ctxt_green_1_.classifier->classify();
+		rois_G_0 = cfy_ctxt_green_0_.classifier->classify();
 
-    rois_R_1 = cfy_ctxt_red_1_.classifier->classify();
-    rois_R_0 = cfy_ctxt_red_0_.classifier->classify();
-    rois_G_1 = cfy_ctxt_green_1_.classifier->classify();
-    rois_G_0 = cfy_ctxt_green_0_.classifier->classify();
+		if (unlikely(cfg_tuning_mode_ && !cfg_draw_processed_rois_)) {
+			if (cfy_ctxt_red_1_.visualize)
+				drawn_rois_.insert(drawn_rois_.end(), rois_R_1->begin(), rois_R_1->end());
+			if (cfy_ctxt_red_0_.visualize)
+				drawn_rois_.insert(drawn_rois_.end(), rois_R_0->begin(), rois_R_0->end());
+			if (cfy_ctxt_green_1_.visualize)
+				drawn_rois_.insert(drawn_rois_.end(), rois_G_1->begin(), rois_G_1->end());
+			if (cfy_ctxt_green_0_.visualize)
+				drawn_rois_.insert(drawn_rois_.end(), rois_G_0->begin(), rois_G_0->end());
+		}
 
-    if (unlikely(cfg_tuning_mode_ && !cfg_draw_processed_rois_)) {
-      if (cfy_ctxt_red_1_.visualize)
-        drawn_rois_.insert(drawn_rois_.end(), rois_R_1->begin(),
-                           rois_R_1->end());
-      if (cfy_ctxt_red_0_.visualize)
-        drawn_rois_.insert(drawn_rois_.end(), rois_R_0->begin(),
-                           rois_R_0->end());
-      if (cfy_ctxt_green_1_.visualize)
-        drawn_rois_.insert(drawn_rois_.end(), rois_G_1->begin(),
-                           rois_G_1->end());
-      if (cfy_ctxt_green_0_.visualize)
-        drawn_rois_.insert(drawn_rois_.end(), rois_G_0->begin(),
-                           rois_G_0->end());
-    }
+		// Create and group ROIs that make up the red, yellow and green lights of a
+		// signal
+		if (cfg_debug_processing_)
+			debug_proc_string_ = "";
+		list<SignalState::signal_rois_t_> *signal_rois = new list<SignalState::signal_rois_t_>();
 
-    // Create and group ROIs that make up the red, yellow and green lights of a
-    // signal
-    if (cfg_debug_processing_)
-      debug_proc_string_ = "";
-    list<SignalState::signal_rois_t_> *signal_rois =
-        new list<SignalState::signal_rois_t_>();
+		for (const ROI &laser_roi : *cluster_rois_) {
+			list<SignalState::signal_rois_t_> laser_signals;
+			SignalState::signal_rois_t_ *     signal;
 
-    for (const ROI &laser_roi : *cluster_rois_) {
-      list<SignalState::signal_rois_t_> laser_signals;
-      SignalState::signal_rois_t_ *signal;
+			signal = create_laser_signals(laser_roi, rois_R_0, rois_G_0);
+			if (signal)
+				laser_signals.push_back(*signal);
+			delete signal;
 
-      signal = create_laser_signals(laser_roi, rois_R_0, rois_G_0);
-      if (signal)
-        laser_signals.push_back(*signal);
-      delete signal;
+			signal = create_laser_signals(laser_roi, rois_R_0, rois_G_1);
+			if (signal)
+				laser_signals.push_back(*signal);
+			delete signal;
 
-      signal = create_laser_signals(laser_roi, rois_R_0, rois_G_1);
-      if (signal)
-        laser_signals.push_back(*signal);
-      delete signal;
+			signal = create_laser_signals(laser_roi, rois_R_1, rois_G_0);
+			if (signal)
+				laser_signals.push_back(*signal);
+			delete signal;
 
-      signal = create_laser_signals(laser_roi, rois_R_1, rois_G_0);
-      if (signal)
-        laser_signals.push_back(*signal);
-      delete signal;
+			signal = create_laser_signals(laser_roi, rois_R_1, rois_G_1);
+			if (signal)
+				laser_signals.push_back(*signal);
+			delete signal;
 
-      signal = create_laser_signals(laser_roi, rois_R_1, rois_G_1);
-      if (signal)
-        laser_signals.push_back(*signal);
-      delete signal;
+			laser_signals.sort([&laser_roi, this](const SignalState::signal_rois_t_ &a,
+			                                      const SignalState::signal_rois_t_ &b) -> bool {
+				return this->signal_beauty(a, laser_roi) >= this->signal_beauty(b, laser_roi);
+			});
+			if (!laser_signals.empty())
+				signal_rois->push_back(laser_signals.front());
+		}
 
-      laser_signals.sort(
-          [&laser_roi, this](const SignalState::signal_rois_t_ &a,
-                             const SignalState::signal_rois_t_ &b) -> bool {
-            return this->signal_beauty(a, laser_roi) >=
-                   this->signal_beauty(b, laser_roi);
-          });
-      if (!laser_signals.empty())
-        signal_rois->push_back(laser_signals.front());
-    }
+		if (signal_rois->size() == 0) {
+			// No signals found with laser, try vanilla algorithm
+			delete signal_rois;
+			list<ROI> *rois_R = new list<ROI>();
+			rois_R->insert(rois_R->end(), rois_R_1->begin(), rois_R_1->end());
+			rois_R->insert(rois_R->end(), rois_R_0->begin(), rois_R_0->end());
+			list<ROI> *rois_G = new list<ROI>();
+			rois_G->insert(rois_G->end(), rois_G_1->begin(), rois_G_1->end());
+			rois_G->insert(rois_G->end(), rois_G_0->begin(), rois_G_0->end());
+			signal_rois = create_field_signals(rois_R, rois_G);
+		}
 
-    if (signal_rois->size() == 0) {
-      // No signals found with laser, try vanilla algorithm
-      delete signal_rois;
-      list<ROI> *rois_R = new list<ROI>();
-      rois_R->insert(rois_R->end(), rois_R_1->begin(), rois_R_1->end());
-      rois_R->insert(rois_R->end(), rois_R_0->begin(), rois_R_0->end());
-      list<ROI> *rois_G = new list<ROI>();
-      rois_G->insert(rois_G->end(), rois_G_1->begin(), rois_G_1->end());
-      rois_G->insert(rois_G->end(), rois_G_0->begin(), rois_G_0->end());
-      signal_rois = create_field_signals(rois_R, rois_G);
-    }
+		// Lock mutex since now we start updating the data that is synced
+		// to the blackboard by the MachineSignalSensorThread.
+		data_mutex_.lock();
 
-    // Lock mutex since now we start updating the data that is synced
-    // to the blackboard by the MachineSignalSensorThread.
-    data_mutex_.lock();
+		for (SignalState &known_signal : known_signals_) {
+			// Decrease visibility history if signal hasn't been seen for
+			// a while or it's not inside a laser ROI anymore
+			known_signal.inc_unseen(*cluster_rois_);
+		}
 
-    for (SignalState &known_signal : known_signals_) {
-      // Decrease visibility history if signal hasn't been seen for
-      // a while or it's not inside a laser ROI anymore
-      known_signal.inc_unseen(*cluster_rois_);
-    }
+		// Go through all signals from this frame...
+		{
+			std::list<SignalState::signal_rois_t_>::iterator signal_it = signal_rois->begin();
+			for (uint i = 0; i < MAX_SIGNALS && signal_it != signal_rois->end(); ++i) {
+				try {
+					// ... and match them to known signals based on the max_jitter tunable
+					float                            dist_min   = FLT_MAX;
+					std::list<SignalState>::iterator best_match = known_signals_.begin();
+					for (std::list<SignalState>::iterator known_signal = known_signals_.begin();
+					     known_signal != known_signals_.end();
+					     ++known_signal) {
+						float dist = known_signal->distance(signal_it);
+						if (dist < dist_min) {
+							best_match = known_signal;
+							dist_min   = dist;
+						}
+					}
 
-    // Go through all signals from this frame...
-    {
-      std::list<SignalState::signal_rois_t_>::iterator signal_it =
-          signal_rois->begin();
-      for (uint i = 0; i < MAX_SIGNALS && signal_it != signal_rois->end();
-           ++i) {
-        try {
-          // ... and match them to known signals based on the max_jitter tunable
-          float dist_min = FLT_MAX;
-          std::list<SignalState>::iterator best_match = known_signals_.begin();
-          for (std::list<SignalState>::iterator known_signal =
-                   known_signals_.begin();
-               known_signal != known_signals_.end(); ++known_signal) {
-            float dist = known_signal->distance(signal_it);
-            if (dist < dist_min) {
-              best_match = known_signal;
-              dist_min = dist;
-            }
-          }
+					if (dist_min < cfg_max_jitter_) {
+						best_match->update_geometry(signal_it);
+					} else { // No historic match was found for the current signal
+						SignalState::historic_signal_rois_t_ new_signal;
+						logger->log_debug(name(), "new signal: dist=%f, history_len=%d", dist_min, 0);
+						new_signal.red_roi =
+						  shared_ptr<HistoricSmoothROI>(new HistoricSmoothROI(*(signal_it->red_roi), 0));
+						new_signal.yellow_roi =
+						  shared_ptr<HistoricSmoothROI>(new HistoricSmoothROI(*(signal_it->yellow_roi), 0));
+						new_signal.green_roi =
+						  shared_ptr<HistoricSmoothROI>(new HistoricSmoothROI(*(signal_it->green_roi), 0));
+						SignalState *cur_state = new SignalState(buflen_, logger, new_signal);
 
-          if (dist_min < cfg_max_jitter_) {
-            best_match->update_geometry(signal_it);
-          } else { // No historic match was found for the current signal
-            SignalState::historic_signal_rois_t_ new_signal;
-            logger->log_debug(name(), "new signal: dist=%f, history_len=%d",
-                              dist_min, 0);
-            new_signal.red_roi = shared_ptr<HistoricSmoothROI>(
-                new HistoricSmoothROI(*(signal_it->red_roi), 0));
-            new_signal.yellow_roi = shared_ptr<HistoricSmoothROI>(
-                new HistoricSmoothROI(*(signal_it->yellow_roi), 0));
-            new_signal.green_roi = shared_ptr<HistoricSmoothROI>(
-                new HistoricSmoothROI(*(signal_it->green_roi), 0));
-            SignalState *cur_state =
-                new SignalState(buflen_, logger, new_signal);
+						known_signals_.push_front(*cur_state);
+						best_match = known_signals_.begin();
+						delete cur_state;
+					}
 
-            known_signals_.push_front(*cur_state);
-            best_match = known_signals_.begin();
-            delete cur_state;
-          }
+					SignalState::frame_state_t_ frame_state({
+					  get_light_state(best_match->signal_rois_history_.red_roi.get()),
+					  get_light_state(best_match->signal_rois_history_.yellow_roi.get()),
+					  get_light_state(best_match->signal_rois_history_.green_roi.get()),
+					});
 
-          SignalState::frame_state_t_ frame_state({
-              get_light_state(best_match->signal_rois_history_.red_roi.get()),
-              get_light_state(
-                  best_match->signal_rois_history_.yellow_roi.get()),
-              get_light_state(best_match->signal_rois_history_.green_roi.get()),
-          });
+					best_match->update_state(frame_state);
 
-          best_match->update_state(frame_state);
+					// Classifiers sometimes do strange things to the image width/height,
+					// so reset them here...
+					best_match->signal_rois_history_.red_roi->set_image_width(cam_width_);
+					best_match->signal_rois_history_.red_roi->set_image_height(cam_height_);
+					best_match->signal_rois_history_.yellow_roi->set_image_width(cam_width_);
+					best_match->signal_rois_history_.yellow_roi->set_image_height(cam_height_);
+					best_match->signal_rois_history_.green_roi->set_image_width(cam_width_);
+					best_match->signal_rois_history_.green_roi->set_image_height(cam_height_);
 
-          // Classifiers sometimes do strange things to the image width/height,
-          // so reset them here...
-          best_match->signal_rois_history_.red_roi->set_image_width(cam_width_);
-          best_match->signal_rois_history_.red_roi->set_image_height(
-              cam_height_);
-          best_match->signal_rois_history_.yellow_roi->set_image_width(
-              cam_width_);
-          best_match->signal_rois_history_.yellow_roi->set_image_height(
-              cam_height_);
-          best_match->signal_rois_history_.green_roi->set_image_width(
-              cam_width_);
-          best_match->signal_rois_history_.green_roi->set_image_height(
-              cam_height_);
+					if (unlikely(cfg_tuning_mode_ && cfg_draw_processed_rois_)) {
+						drawn_rois_.push_back(*(best_match->signal_rois_history_.red_roi));
+						drawn_rois_.push_back(*(best_match->signal_rois_history_.yellow_roi));
+						drawn_rois_.push_back(*(best_match->signal_rois_history_.green_roi));
+					}
+				} catch (OutOfBoundsException &e) {
+					// logger->log_debug(name(), "Signal at %d,%d: Invalid ROI: %s",
+					//  signal_it->red_roi->start.x, signal_it->red_roi->start.y,
+					//  e.what());
+				}
+				signal_it++;
+			}
+		}
 
-          if (unlikely(cfg_tuning_mode_ && cfg_draw_processed_rois_)) {
-            drawn_rois_.push_back(*(best_match->signal_rois_history_.red_roi));
-            drawn_rois_.push_back(
-                *(best_match->signal_rois_history_.yellow_roi));
-            drawn_rois_.push_back(
-                *(best_match->signal_rois_history_.green_roi));
-          }
-        } catch (OutOfBoundsException &e) {
-          // logger->log_debug(name(), "Signal at %d,%d: Invalid ROI: %s",
-          //  signal_it->red_roi->start.x, signal_it->red_roi->start.y,
-          //  e.what());
-        }
-        signal_it++;
-      }
-    }
+		delete signal_rois;
+		signal_rois = NULL;
 
-    delete signal_rois;
-    signal_rois = NULL;
+		if (unlikely(cfg_tuning_mode_)) { // Draw a representation of what we see
+			                                // into SHM buffer(s)
+			shmbuf_cam_->lock_for_write();
+			shmbuf_->lock_for_write();
 
-    if (unlikely(cfg_tuning_mode_)) { // Draw a representation of what we see
-                                      // into SHM buffer(s)
-      shmbuf_cam_->lock_for_write();
-      shmbuf_->lock_for_write();
+			// Untreated copy of the cam image
+			memcpy(shmbuf_cam_->buffer(), camera_->buffer(), shmbuf_cam_->data_size());
 
-      // Untreated copy of the cam image
-      memcpy(shmbuf_cam_->buffer(), camera_->buffer(),
-             shmbuf_cam_->data_size());
+			// Visualize color similarities in tuning buffer
+			color_filter_->set_src_buffer(camera_->buffer(), ROI::full_image(cam_width_, cam_height_));
+			color_filter_->set_dst_buffer(shmbuf_->buffer(),
+			                              ROI::full_image(shmbuf_->width(), shmbuf_->height()));
+			color_filter_->apply();
 
-      // Visualize color similarities in tuning buffer
-      color_filter_->set_src_buffer(camera_->buffer(),
-                                    ROI::full_image(cam_width_, cam_height_));
-      color_filter_->set_dst_buffer(
-          shmbuf_->buffer(),
-          ROI::full_image(shmbuf_->width(), shmbuf_->height()));
-      color_filter_->apply();
+			if (cluster_rois_) {
+				drawn_rois_.insert(drawn_rois_.end(), cluster_rois_->begin(), cluster_rois_->end());
+			}
 
-      if (cluster_rois_) {
-        drawn_rois_.insert(drawn_rois_.end(), cluster_rois_->begin(),
-                           cluster_rois_->end());
-      }
+			// Visualize the signals and bright spots we found
+			roi_drawer_->set_rois(&drawn_rois_);
+			roi_drawer_->set_src_buffer(shmbuf_->buffer(), ROI::full_image(cam_width_, cam_height_), 0);
+			roi_drawer_->set_dst_buffer(shmbuf_->buffer(), NULL);
+			roi_drawer_->apply();
 
-      // Visualize the signals and bright spots we found
-      roi_drawer_->set_rois(&drawn_rois_);
-      roi_drawer_->set_src_buffer(shmbuf_->buffer(),
-                                  ROI::full_image(cam_width_, cam_height_), 0);
-      roi_drawer_->set_dst_buffer(shmbuf_->buffer(), NULL);
-      roi_drawer_->apply();
+			shmbuf_cam_->unlock();
+			shmbuf_->unlock();
+		}
 
-      shmbuf_cam_->unlock();
-      shmbuf_->unlock();
-    }
+		// Throw out the signals with the worst visibility histories
+		known_signals_.sort(SignalState::compare_signal_states_by_visibility());
+		while (known_signals_.size() > MAX_SIGNALS)
+			known_signals_.pop_back();
 
-    // Throw out the signals with the worst visibility histories
-    known_signals_.sort(SignalState::compare_signal_states_by_visibility());
-    while (known_signals_.size() > MAX_SIGNALS)
-      known_signals_.pop_back();
+		// Then sort geometrically
+		known_signals_.sort(SignalState::compare_signal_states_by_area());
+		best_signal_ = known_signals_.begin();
 
-    // Then sort geometrically
-    known_signals_.sort(SignalState::compare_signal_states_by_area());
-    best_signal_ = known_signals_.begin();
+		if (unlikely(best_signal_ != known_signals_.end() && cfg_debug_blink_)) {
+			logger->log_info(name(), best_signal_->get_debug_R());
+			logger->log_info(name(), best_signal_->get_debug_Y());
+			logger->log_info(name(), best_signal_->get_debug_G());
+			logger->log_info(name(), "================="); //*/
+		}
+		new_data_ = true;
+		data_mutex_.unlock();
 
-    if (unlikely(best_signal_ != known_signals_.end() && cfg_debug_blink_)) {
-      logger->log_info(name(), best_signal_->get_debug_R());
-      logger->log_info(name(), best_signal_->get_debug_Y());
-      logger->log_info(name(), best_signal_->get_debug_G());
-      logger->log_info(name(), "================="); //*/
-    }
-    new_data_ = true;
-    data_mutex_.unlock();
+		delete rois_R_1;
+		delete rois_R_0;
+		delete rois_G_1;
+		delete rois_G_0;
 
-    delete rois_R_1;
-    delete rois_R_0;
-    delete rois_G_1;
-    delete rois_G_0;
-
-    camera_->dispose_buffer();
-  } /* if (cfg_enable_switch_) */
-  else {
-    known_signals_.clear();
-  }
-  time_wait_->wait();
+		camera_->dispose_buffer();
+	} /* if (cfg_enable_switch_) */
+	else {
+		known_signals_.clear();
+	}
+	time_wait_->wait();
 }
 
 /**
@@ -1092,42 +1086,49 @@ void MachineSignalPipelineThread::loop() {
  * @param light the ROI to be considered
  * @return true if "lit" according to our criteria, false otherwise.
  */
-bool MachineSignalPipelineThread::get_light_state(firevision::ROI *light) {
-  light_scangrid_->set_roi(light);
-  light_scangrid_->reset();
-  std::list<ROI> *bright_rois = light_classifier_->classify();
+bool
+MachineSignalPipelineThread::get_light_state(firevision::ROI *light)
+{
+	light_scangrid_->set_roi(light);
+	light_scangrid_->reset();
+	std::list<ROI> *bright_rois = light_classifier_->classify();
 
-  for (std::list<ROI>::iterator roi_it = bright_rois->begin();
-       roi_it != bright_rois->end(); ++roi_it) {
-    float area_ratio = (float)(roi_it->width * roi_it->height) /
-                       (float)(light->width * light->height);
-    if (roi_aspect_ok(*roi_it) && area_ratio > cfg_light_on_min_area_cover_) {
-      if (unlikely(cfg_tuning_mode_))
-        drawn_rois_.push_back(*roi_it);
-      delete bright_rois;
-      return true;
-    }
-  }
-  delete bright_rois;
-  return false;
+	for (std::list<ROI>::iterator roi_it = bright_rois->begin(); roi_it != bright_rois->end();
+	     ++roi_it) {
+		float area_ratio =
+		  (float)(roi_it->width * roi_it->height) / (float)(light->width * light->height);
+		if (roi_aspect_ok(*roi_it) && area_ratio > cfg_light_on_min_area_cover_) {
+			if (unlikely(cfg_tuning_mode_))
+				drawn_rois_.push_back(*roi_it);
+			delete bright_rois;
+			return true;
+		}
+	}
+	delete bright_rois;
+	return false;
 }
 
-bool MachineSignalPipelineThread::roi1_x_overlaps_below(ROI &r1, ROI &r2) {
-  return (r1.start.y > r2.start.y) &&
-         ((r1.start.x <= r2.start.x && r1.start.x + r1.width > r2.start.x) ||
-          (r1.start.x > r2.start.x && r1.start.x < r2.start.x + r2.width &&
-           r1.start.x + r1.width > r2.start.x + r2.width));
+bool
+MachineSignalPipelineThread::roi1_x_overlaps_below(ROI &r1, ROI &r2)
+{
+	return (r1.start.y > r2.start.y)
+	       && ((r1.start.x <= r2.start.x && r1.start.x + r1.width > r2.start.x)
+	           || (r1.start.x > r2.start.x && r1.start.x < r2.start.x + r2.width
+	               && r1.start.x + r1.width > r2.start.x + r2.width));
 }
 
-bool MachineSignalPipelineThread::roi1_x_intersects(ROI &r1, ROI &r2) {
-  return !(r1.start.x + r1.width <= r2.start.x ||
-           r2.start.x + r2.width <= r1.start.x);
+bool
+MachineSignalPipelineThread::roi1_x_intersects(ROI &r1, ROI &r2)
+{
+	return !(r1.start.x + r1.width <= r2.start.x || r2.start.x + r2.width <= r1.start.x);
 }
 
-bool MachineSignalPipelineThread::roi1_oversize(ROI &r1, ROI &r2) {
-  return !rois_similar_width(r1, r2) && roi_aspect_ok(r2) &&
-         (r2.start.x + r2.width / 10) - r1.start.x > 0 &&
-         (r1.start.x + r1.width * 1.1) - (r2.start.x + r2.width) > 0;
+bool
+MachineSignalPipelineThread::roi1_oversize(ROI &r1, ROI &r2)
+{
+	return !rois_similar_width(r1, r2) && roi_aspect_ok(r2)
+	       && (r2.start.x + r2.width / 10) - r1.start.x > 0
+	       && (r1.start.x + r1.width * 1.1) - (r2.start.x + r2.width) > 0;
 }
 
 /**
@@ -1136,133 +1137,126 @@ bool MachineSignalPipelineThread::roi1_oversize(ROI &r1, ROI &r2) {
  * @return a yellow ROI that fits between roi_R and roi_G iff they match all
  * configured constraints
  */
-ROI *MachineSignalPipelineThread::red_green_match(ROI *r, ROI *g) {
-  if (!r || !g)
-    return nullptr;
+ROI *
+MachineSignalPipelineThread::red_green_match(ROI *r, ROI *g)
+{
+	if (!r || !g)
+		return nullptr;
 
-  shared_ptr<ROI> roi_R = make_shared<ROI>(*r);
-  shared_ptr<ROI> roi_G = make_shared<ROI>(*g);
+	shared_ptr<ROI> roi_R = make_shared<ROI>(*r);
+	shared_ptr<ROI> roi_G = make_shared<ROI>(*g);
 
-  int vspace = roi_G->start.y - (roi_R->start.y + roi_R->height);
-  try {
-    if (roi_G->height > cfg_roi_max_height_ &&
-        roi1_x_overlaps_below(*roi_G, *roi_R)) {
-      ROI *recheck_G = new ROI(*roi_G);
-      recheck_G->height = cfg_roi_max_height_;
-      cfy_ctxt_green_1_.scanline_grid->set_roi(recheck_G);
-      list<ROI> *rechecked_G = cfy_ctxt_green_1_.classifier->classify();
-      if (!rechecked_G->empty()) {
-        ROI &new_G = rechecked_G->front();
-        if (roi_width_ok(new_G) && rois_x_aligned(*roi_R, new_G) &&
-            !roi1_oversize(new_G, *roi_R) && rois_vspace_ok(*roi_R, new_G) &&
-            rois_similar_width(*roi_R, new_G)) {
-          *roi_G = new_G;
-        }
-      }
-      cfy_ctxt_green_1_.scanline_grid->set_roi(
-          recheck_G->full_image(cam_width_, cam_height_));
-      delete recheck_G;
-      delete rechecked_G;
-    }
+	int vspace = roi_G->start.y - (roi_R->start.y + roi_R->height);
+	try {
+		if (roi_G->height > cfg_roi_max_height_ && roi1_x_overlaps_below(*roi_G, *roi_R)) {
+			ROI *recheck_G    = new ROI(*roi_G);
+			recheck_G->height = cfg_roi_max_height_;
+			cfy_ctxt_green_1_.scanline_grid->set_roi(recheck_G);
+			list<ROI> *rechecked_G = cfy_ctxt_green_1_.classifier->classify();
+			if (!rechecked_G->empty()) {
+				ROI &new_G = rechecked_G->front();
+				if (roi_width_ok(new_G) && rois_x_aligned(*roi_R, new_G) && !roi1_oversize(new_G, *roi_R)
+				    && rois_vspace_ok(*roi_R, new_G) && rois_similar_width(*roi_R, new_G)) {
+					*roi_G = new_G;
+				}
+			}
+			cfy_ctxt_green_1_.scanline_grid->set_roi(recheck_G->full_image(cam_width_, cam_height_));
+			delete recheck_G;
+			delete rechecked_G;
+		}
 
-    if (roi_R->width > cfg_roi_max_width_ &&
-        roi_R->height > cfg_roi_max_height_ &&
-        roi_G->start.y > roi_R->start.y && roi1_x_intersects(*roi_G, *roi_R)) {
-      ROI *recheck_R = new ROI(*roi_R);
-      recheck_R->start.y += roi_R->height - cfg_roi_max_height_;
-      recheck_R->height -= roi_R->height - cfg_roi_max_height_;
-      cfy_ctxt_red_1_.scanline_grid->set_roi(recheck_R);
-      list<ROI> *rechecked_R = cfy_ctxt_red_1_.classifier->classify();
-      if (!rechecked_R->empty()) {
-        ROI &new_R = rechecked_R->front();
-        if (roi_width_ok(new_R) && rois_x_aligned(new_R, *roi_G) &&
-            !roi1_oversize(new_R, *roi_G) && rois_vspace_ok(new_R, *roi_G) &&
-            rois_similar_width(new_R, *roi_G)) {
-          *roi_R = new_R;
-        }
-      }
-      cfy_ctxt_red_1_.scanline_grid->set_roi(
-          recheck_R->full_image(cam_width_, cam_height_));
-      delete recheck_R;
-      delete rechecked_R;
-    }
+		if (roi_R->width > cfg_roi_max_width_ && roi_R->height > cfg_roi_max_height_
+		    && roi_G->start.y > roi_R->start.y && roi1_x_intersects(*roi_G, *roi_R)) {
+			ROI *recheck_R = new ROI(*roi_R);
+			recheck_R->start.y += roi_R->height - cfg_roi_max_height_;
+			recheck_R->height -= roi_R->height - cfg_roi_max_height_;
+			cfy_ctxt_red_1_.scanline_grid->set_roi(recheck_R);
+			list<ROI> *rechecked_R = cfy_ctxt_red_1_.classifier->classify();
+			if (!rechecked_R->empty()) {
+				ROI &new_R = rechecked_R->front();
+				if (roi_width_ok(new_R) && rois_x_aligned(new_R, *roi_G) && !roi1_oversize(new_R, *roi_G)
+				    && rois_vspace_ok(new_R, *roi_G) && rois_similar_width(new_R, *roi_G)) {
+					*roi_R = new_R;
+				}
+			}
+			cfy_ctxt_red_1_.scanline_grid->set_roi(recheck_R->full_image(cam_width_, cam_height_));
+			delete recheck_R;
+			delete rechecked_R;
+		}
 
-    if (roi_width_ok(*roi_G) && rois_x_aligned(*roi_R, *roi_G) &&
-        roi_G->start.y > cfg_roi_green_horizon) {
+		if (roi_width_ok(*roi_G) && rois_x_aligned(*roi_R, *roi_G)
+		    && roi_G->start.y > cfg_roi_green_horizon) {
+			if (cfg_debug_processing_)
+				debug_proc_string_ += " | g:W rg:A";
 
-      if (cfg_debug_processing_)
-        debug_proc_string_ += " | g:W rg:A";
+			if (roi1_oversize(*roi_R, *roi_G) && vspace > 0 && vspace < roi_G->height * 1.5) {
+				roi_R->start.x = roi_G->start.x;
+				roi_R->width   = roi_G->width;
+				if (roi_R->width > cam_width_)
+					roi_R->width = cam_width_ - roi_R->start.x;
+				int r_end     = roi_G->start.y - roi_G->height;
+				roi_R->height = r_end - roi_R->start.y;
+				if (roi_R->start.y + roi_R->height > cam_height_)
+					roi_R->height = cam_height_ - roi_R->start.y;
 
-      if (roi1_oversize(*roi_R, *roi_G) && vspace > 0 &&
-          vspace < roi_G->height * 1.5) {
-        roi_R->start.x = roi_G->start.x;
-        roi_R->width = roi_G->width;
-        if (roi_R->width > cam_width_)
-          roi_R->width = cam_width_ - roi_R->start.x;
-        int r_end = roi_G->start.y - roi_G->height;
-        roi_R->height = r_end - roi_R->start.y;
-        if (roi_R->start.y + roi_R->height > cam_height_)
-          roi_R->height = cam_height_ - roi_R->start.y;
+				if (cfg_debug_processing_)
+					debug_proc_string_ += " r:O";
+			}
 
-        if (cfg_debug_processing_)
-          debug_proc_string_ += " r:O";
-      }
+			if (roi1_oversize(*roi_G, *roi_R) && vspace > 0 && vspace < roi_R->height * 1.5) {
+				roi_G->start.x = roi_R->start.x;
+				roi_G->width   = roi_R->width;
+				if (roi_G->width > cam_width_)
+					roi_G->width = cam_width_ - roi_G->start.x;
+				roi_G->height = roi_R->height;
+				if (roi_G->start.y + roi_G->height > cam_height_)
+					roi_G->height = cam_height_ - roi_G->start.y;
 
-      if (roi1_oversize(*roi_G, *roi_R) && vspace > 0 &&
-          vspace < roi_R->height * 1.5) {
-        roi_G->start.x = roi_R->start.x;
-        roi_G->width = roi_R->width;
-        if (roi_G->width > cam_width_)
-          roi_G->width = cam_width_ - roi_G->start.x;
-        roi_G->height = roi_R->height;
-        if (roi_G->start.y + roi_G->height > cam_height_)
-          roi_G->height = cam_height_ - roi_G->start.y;
+				if (cfg_debug_processing_)
+					debug_proc_string_ += " g:O";
+			}
 
-        if (cfg_debug_processing_)
-          debug_proc_string_ += " g:O";
-      }
+			if (rois_vspace_ok(*roi_R, *roi_G)) {
+				if (cfg_debug_processing_)
+					debug_proc_string_ += " V";
 
-      if (rois_vspace_ok(*roi_R, *roi_G)) {
-        if (cfg_debug_processing_)
-          debug_proc_string_ += " V";
+				if (!rois_similar_width(*roi_R, *roi_G)) {
+					int wdiff   = roi_G->width - roi_R->width;
+					int start_x = roi_G->start.x + wdiff / 2;
+					if (start_x < 0)
+						start_x = 0;
+					roi_G->start.x = start_x;
+					int width      = roi_G->width - wdiff / 2;
+					if ((unsigned int)(start_x + width) > cam_width_)
+						width = cam_width_ - start_x;
+					roi_G->width = width;
+					if (cfg_debug_processing_)
+						debug_proc_string_ += " !W";
+				}
 
-        if (!rois_similar_width(*roi_R, *roi_G)) {
-          int wdiff = roi_G->width - roi_R->width;
-          int start_x = roi_G->start.x + wdiff / 2;
-          if (start_x < 0)
-            start_x = 0;
-          roi_G->start.x = start_x;
-          int width = roi_G->width - wdiff / 2;
-          if ((unsigned int)(start_x + width) > cam_width_)
-            width = cam_width_ - start_x;
-          roi_G->width = width;
-          if (cfg_debug_processing_)
-            debug_proc_string_ += " !W";
-        }
+				// Once we got through here it_G should have a pretty sensible green
+				// ROI.
+				roi_G->height = roi_G->width;
+				uint start_x  = (roi_R->start.x + roi_G->start.x) / 2;
+				uint height   = (roi_R->height + roi_G->height) / 2;
+				uint width    = (roi_R->width + roi_G->width) / 2;
+				uint r_end_y  = roi_R->start.y + roi_G->height;
+				uint start_y  = r_end_y + (int)(roi_G->start.y - r_end_y - height) / 2;
+				if (start_y < 0)
+					start_y = 0;
+				ROI *roi_Y =
+				  new ROI(start_x, start_y, width, height, roi_R->image_width, roi_R->image_height);
+				roi_Y->color = C_YELLOW;
 
-        // Once we got through here it_G should have a pretty sensible green
-        // ROI.
-        roi_G->height = roi_G->width;
-        uint start_x = (roi_R->start.x + roi_G->start.x) / 2;
-        uint height = (roi_R->height + roi_G->height) / 2;
-        uint width = (roi_R->width + roi_G->width) / 2;
-        uint r_end_y = roi_R->start.y + roi_G->height;
-        uint start_y = r_end_y + (int)(roi_G->start.y - r_end_y - height) / 2;
-        if (start_y < 0)
-          start_y = 0;
-        ROI *roi_Y = new ROI(start_x, start_y, width, height,
-                             roi_R->image_width, roi_R->image_height);
-        roi_Y->color = C_YELLOW;
-
-        *r = *roi_R;
-        *g = *roi_G;
-        return roi_Y;
-      }
-    }
-  } catch (Exception &e) {
-    logger->log_error(name(), e.what());
-  }
-  return nullptr;
+				*r = *roi_R;
+				*g = *roi_G;
+				return roi_Y;
+			}
+		}
+	} catch (Exception &e) {
+		logger->log_error(name(), e.what());
+	}
+	return nullptr;
 }
 
 /**
@@ -1276,449 +1270,456 @@ ROI *MachineSignalPipelineThread::red_green_match(ROI *r, ROI *g) {
  * green ROIs
  */
 std::list<SignalState::signal_rois_t_> *
-MachineSignalPipelineThread::create_field_signals(std::list<ROI> *rois_R,
-                                                  std::list<ROI> *rois_G) {
-  std::list<SignalState::signal_rois_t_> *rv =
-      new std::list<SignalState::signal_rois_t_>();
+MachineSignalPipelineThread::create_field_signals(std::list<ROI> *rois_R, std::list<ROI> *rois_G)
+{
+	std::list<SignalState::signal_rois_t_> *rv = new std::list<SignalState::signal_rois_t_>();
 
-  /*if (unlikely(cfg_tuning_mode_ && !cfg_draw_processed_rois_)) {
+	/*if (unlikely(cfg_tuning_mode_ && !cfg_draw_processed_rois_)) {
     drawn_rois_.insert(drawn_rois_.end(), rois_R->begin(), rois_R->end());
     drawn_rois_.insert(drawn_rois_.end(), rois_G->begin(), rois_G->end());
   }*/
 
-  std::list<ROI>::iterator it_R = rois_R->begin();
-  uint i = 0;
-  while (it_R != rois_R->end()) {
-    if (!(roi_width_ok(*it_R)) || (it_R->start.y > cam_height_ / 2)) {
-      it_R = rois_R->erase(it_R);
-      continue;
-    }
+	std::list<ROI>::iterator it_R = rois_R->begin();
+	uint                     i    = 0;
+	while (it_R != rois_R->end()) {
+		if (!(roi_width_ok(*it_R)) || (it_R->start.y > cam_height_ / 2)) {
+			it_R = rois_R->erase(it_R);
+			continue;
+		}
 
-    if (it_R->height > it_R->width) {
-      it_R->height = it_R->width;
-    }
+		if (it_R->height > it_R->width) {
+			it_R->height = it_R->width;
+		}
 
-    ROI *roi_Y = nullptr;
-    std::list<ROI>::iterator it_G = rois_G->begin();
-    while (it_G != rois_G->end()) {
-      if ((roi_Y = red_green_match(&*it_R, &*it_G))) {
-        auto roi_G = shared_ptr<ROI>(new ROI(*it_G));
-        auto roi_R = shared_ptr<ROI>(new ROI(*it_R));
-        rv->push_back({roi_R, shared_ptr<ROI>(roi_Y), roi_G, nullptr, 1.0});
-        it_G = rois_G->erase(it_G);
-      } else {
-        ++it_G;
-      }
-    }
+		ROI *                    roi_Y = nullptr;
+		std::list<ROI>::iterator it_G  = rois_G->begin();
+		while (it_G != rois_G->end()) {
+			if ((roi_Y = red_green_match(&*it_R, &*it_G))) {
+				auto roi_G = shared_ptr<ROI>(new ROI(*it_G));
+				auto roi_R = shared_ptr<ROI>(new ROI(*it_R));
+				rv->push_back({roi_R, shared_ptr<ROI>(roi_Y), roi_G, nullptr, 1.0});
+				it_G = rois_G->erase(it_G);
+			} else {
+				++it_G;
+			}
+		}
 
-    if (roi_Y)
-      it_R = rois_R->erase(it_R);
-    else
-      ++it_R;
+		if (roi_Y)
+			it_R = rois_R->erase(it_R);
+		else
+			++it_R;
 
-    if (unlikely(!roi_Y && cfg_debug_processing_))
-      logger->log_debug(name(), "field proc red %d: %s", ++i,
-                        debug_proc_string_.c_str());
-  }
-  return rv;
+		if (unlikely(!roi_Y && cfg_debug_processing_))
+			logger->log_debug(name(), "field proc red %d: %s", ++i, debug_proc_string_.c_str());
+	}
+	return rv;
 }
 
-ROI *MachineSignalPipelineThread::merge_rois_in_roi(const ROI &outer_roi,
-                                                    list<ROI> *rois) {
-  ROI *rv = nullptr;
-  list<ROI>::iterator it_roi = rois->begin();
-  while (it_roi != rois->end()) {
-    ROI intersection = it_roi->intersect(outer_roi);
-    unsigned int area_R = it_roi->width * it_roi->height;
-    unsigned int area_intrsct = intersection.width * intersection.height;
-    if (area_R && (float(area_intrsct) / float(area_R) >= 0.3)) {
-      if (rv != nullptr) {
-        rv->extend(intersection.start.x, intersection.start.y);
-        rv->extend(intersection.start.x + intersection.width,
-                   intersection.start.y + intersection.height);
-      } else {
-        rv = new ROI(intersection);
-      }
+ROI *
+MachineSignalPipelineThread::merge_rois_in_roi(const ROI &outer_roi, list<ROI> *rois)
+{
+	ROI *               rv     = nullptr;
+	list<ROI>::iterator it_roi = rois->begin();
+	while (it_roi != rois->end()) {
+		ROI          intersection = it_roi->intersect(outer_roi);
+		unsigned int area_R       = it_roi->width * it_roi->height;
+		unsigned int area_intrsct = intersection.width * intersection.height;
+		if (area_R && (float(area_intrsct) / float(area_R) >= 0.3)) {
+			if (rv != nullptr) {
+				rv->extend(intersection.start.x, intersection.start.y);
+				rv->extend(intersection.start.x + intersection.width,
+				           intersection.start.y + intersection.height);
+			} else {
+				rv = new ROI(intersection);
+			}
 
-      // Erase ROIs that have been processed here
-      it_roi = rois->erase(it_roi);
-    } else {
-      ++it_roi;
-    }
-  }
-  if (rv)
-    rois->push_front(rv);
-  return rv;
+			// Erase ROIs that have been processed here
+			it_roi = rois->erase(it_roi);
+		} else {
+			++it_roi;
+		}
+	}
+	if (rv)
+		rois->push_front(rv);
+	return rv;
 }
 
-SignalState::signal_rois_t_ *MachineSignalPipelineThread::create_laser_signals(
-    const ROI &laser_roi, std::list<ROI> *rois_R, std::list<ROI> *rois_G) {
-  SignalState::signal_rois_t_ *rv = nullptr;
+SignalState::signal_rois_t_ *
+MachineSignalPipelineThread::create_laser_signals(const ROI &     laser_roi,
+                                                  std::list<ROI> *rois_R,
+                                                  std::list<ROI> *rois_G)
+{
+	SignalState::signal_rois_t_ *rv = nullptr;
 
-  { // Used to be a loop, kept block to simplify diffs
-    try {
-      shared_ptr<ROI> roi_R(merge_rois_in_roi(laser_roi, rois_R));
-      shared_ptr<ROI> roi_G(merge_rois_in_roi(laser_roi, rois_G));
+	{ // Used to be a loop, kept block to simplify diffs
+		try {
+			shared_ptr<ROI> roi_R(merge_rois_in_roi(laser_roi, rois_R));
+			shared_ptr<ROI> roi_G(merge_rois_in_roi(laser_roi, rois_G));
 
-      // Look for the black cap on top
-      ROI roi_black_top(laser_roi);
-      roi_black_top.height = laser_roi.height / 4;
-      roi_black_top.color = C_BACKGROUND;
-      if (roi_R) {
-        roi_black_top.start.x = roi_R->start.x;
-        roi_black_top.width = roi_R->width;
-      } else if (roi_G) {
-        roi_black_top.start.x = roi_G->start.x;
-        roi_black_top.width = roi_G->width;
-      }
-      black_scangrid_->set_roi(&roi_black_top);
-      list<ROI> *black_stuff_top = black_classifier_->classify();
+			// Look for the black cap on top
+			ROI roi_black_top(laser_roi);
+			roi_black_top.height = laser_roi.height / 4;
+			roi_black_top.color  = C_BACKGROUND;
+			if (roi_R) {
+				roi_black_top.start.x = roi_R->start.x;
+				roi_black_top.width   = roi_R->width;
+			} else if (roi_G) {
+				roi_black_top.start.x = roi_G->start.x;
+				roi_black_top.width   = roi_G->width;
+			}
+			black_scangrid_->set_roi(&roi_black_top);
+			list<ROI> *black_stuff_top = black_classifier_->classify();
 
-      // Look for the black socket
-      ROI roi_black_bottom(laser_roi);
-      roi_black_bottom.color = C_BACKGROUND;
-      roi_black_bottom.start.y = laser_roi.start.y + laser_roi.height * 0.75;
-      roi_black_bottom.height = laser_roi.height / 4;
-      if (roi_G) {
-        roi_black_bottom.start.x = roi_G->start.x;
-        roi_black_bottom.width = roi_G->width;
-      } else if (roi_R) {
-        roi_black_bottom.start.x = roi_R->start.x;
-        roi_black_bottom.width = roi_R->width;
-      }
-      roi_black_bottom.set_image_height(cam_width_);
-      roi_black_bottom.set_image_height(cam_height_);
-      black_scangrid_->set_roi(&roi_black_bottom);
-      list<ROI> *black_stuff_bottom = black_classifier_->classify();
+			// Look for the black socket
+			ROI roi_black_bottom(laser_roi);
+			roi_black_bottom.color   = C_BACKGROUND;
+			roi_black_bottom.start.y = laser_roi.start.y + laser_roi.height * 0.75;
+			roi_black_bottom.height  = laser_roi.height / 4;
+			if (roi_G) {
+				roi_black_bottom.start.x = roi_G->start.x;
+				roi_black_bottom.width   = roi_G->width;
+			} else if (roi_R) {
+				roi_black_bottom.start.x = roi_R->start.x;
+				roi_black_bottom.width   = roi_R->width;
+			}
+			roi_black_bottom.set_image_height(cam_width_);
+			roi_black_bottom.set_image_height(cam_height_);
+			black_scangrid_->set_roi(&roi_black_bottom);
+			list<ROI> *black_stuff_bottom = black_classifier_->classify();
 
-      if (unlikely(cfg_tuning_mode_)) {
-        drawn_rois_.insert(drawn_rois_.end(), black_stuff_top->begin(),
-                           black_stuff_top->end());
-        drawn_rois_.insert(drawn_rois_.end(), black_stuff_bottom->begin(),
-                           black_stuff_bottom->end());
-      }
+			if (unlikely(cfg_tuning_mode_)) {
+				drawn_rois_.insert(drawn_rois_.end(), black_stuff_top->begin(), black_stuff_top->end());
+				drawn_rois_.insert(drawn_rois_.end(),
+				                   black_stuff_bottom->begin(),
+				                   black_stuff_bottom->end());
+			}
 
-      if (roi_R) {
-        if (!black_stuff_top->empty()) {
-          // Extend red ROI up to the black cap
-          ROI &black = black_stuff_top->front();
-          unsigned int black_end_y = black.start.y + black.height;
-          int hdiff = roi_R->start.y - black_end_y;
-          roi_R->start.y = black_end_y;
-          if (-hdiff > long(roi_R->height))
-            hdiff = -roi_R->height;
-          if (roi_R->height + hdiff > cam_height_)
-            hdiff = cam_height_ - roi_R->height;
-          roi_R->height += hdiff;
-        }
+			if (roi_R) {
+				if (!black_stuff_top->empty()) {
+					// Extend red ROI up to the black cap
+					ROI &        black       = black_stuff_top->front();
+					unsigned int black_end_y = black.start.y + black.height;
+					int          hdiff       = roi_R->start.y - black_end_y;
+					roi_R->start.y           = black_end_y;
+					if (-hdiff > long(roi_R->height))
+						hdiff = -roi_R->height;
+					if (roi_R->height + hdiff > cam_height_)
+						hdiff = cam_height_ - roi_R->height;
+					roi_R->height += hdiff;
+				}
 
-        if (!roi_aspect_ok(*roi_R)) {
-          roi_R->height = roi_R->width;
-        }
-      }
-      ///*
-      if (roi_G) {
-        // Improve green ROI with black socket
-        if (!black_stuff_bottom->empty()) {
-          ROI &black = black_stuff_bottom->front();
-          int hdiff = black.start.y - (roi_G->start.y + roi_G->height);
-          if (hdiff > 0) {
-            roi_G->height += hdiff;
-          }
-        }
-      } //*/
+				if (!roi_aspect_ok(*roi_R)) {
+					roi_R->height = roi_R->width;
+				}
+			}
+			///*
+			if (roi_G) {
+				// Improve green ROI with black socket
+				if (!black_stuff_bottom->empty()) {
+					ROI &black = black_stuff_bottom->front();
+					int  hdiff = black.start.y - (roi_G->start.y + roi_G->height);
+					if (hdiff > 0) {
+						roi_G->height += hdiff;
+					}
+				}
+			} //*/
 
-      ROI *roi_Y = red_green_match(roi_R.get(), roi_G.get());
+			ROI *roi_Y = red_green_match(roi_R.get(), roi_G.get());
 
-      if (roi_Y) {
-        rv = new SignalState::signal_rois_t_(
-            {shared_ptr<ROI>(roi_R), shared_ptr<ROI>(roi_Y),
-             shared_ptr<ROI>(roi_G), nullptr, 1.0});
-      } else {
-        SignalState::signal_rois_t_ signal;
+			if (roi_Y) {
+				rv = new SignalState::signal_rois_t_(
+				  {shared_ptr<ROI>(roi_R), shared_ptr<ROI>(roi_Y), shared_ptr<ROI>(roi_G), nullptr, 1.0});
+			} else {
+				SignalState::signal_rois_t_ signal;
 
-        if (roi_R && roi_G) {
-          float badness_R =
-              abs(1 - (float(roi_R->height) / float(laser_roi.width)));
-          float badness_G =
-              abs(1 - (float(roi_G->height) / float(laser_roi.width)));
-          if (cfg_debug_processing_) {
-            drawn_rois_.push_back(*roi_R);
-            drawn_rois_.push_back(*roi_G);
-          }
-          if (roi_G->height > laser_roi.width && badness_G > badness_R) {
-            // Height of roi_R is closer to the width of the laser ROI than
-            // roi_G
-            uint hdiff = roi_G->height - roi_R->height;
-            if (hdiff < roi_G->height) {
-              roi_G->start.y += hdiff / 2;
-              roi_G->height -= hdiff;
-              if (cfg_debug_processing_)
-                logger->log_info(name(), "laser adapt red: %d", hdiff);
-            }
-          } else if (roi_R->height > laser_roi.width && badness_R > badness_G) {
-            uint hdiff = roi_R->height - roi_G->height;
-            if (hdiff < roi_R->height) {
-              roi_R->start.y += hdiff / 2;
-              roi_R->height -= hdiff;
-              if (cfg_debug_processing_)
-                logger->log_info(name(), "laser adapt green: %d", hdiff);
-            }
-          }
+				if (roi_R && roi_G) {
+					float badness_R = abs(1 - (float(roi_R->height) / float(laser_roi.width)));
+					float badness_G = abs(1 - (float(roi_G->height) / float(laser_roi.width)));
+					if (cfg_debug_processing_) {
+						drawn_rois_.push_back(*roi_R);
+						drawn_rois_.push_back(*roi_G);
+					}
+					if (roi_G->height > laser_roi.width && badness_G > badness_R) {
+						// Height of roi_R is closer to the width of the laser ROI than
+						// roi_G
+						uint hdiff = roi_G->height - roi_R->height;
+						if (hdiff < roi_G->height) {
+							roi_G->start.y += hdiff / 2;
+							roi_G->height -= hdiff;
+							if (cfg_debug_processing_)
+								logger->log_info(name(), "laser adapt red: %d", hdiff);
+						}
+					} else if (roi_R->height > laser_roi.width && badness_R > badness_G) {
+						uint hdiff = roi_R->height - roi_G->height;
+						if (hdiff < roi_R->height) {
+							roi_R->start.y += hdiff / 2;
+							roi_R->height -= hdiff;
+							if (cfg_debug_processing_)
+								logger->log_info(name(), "laser adapt green: %d", hdiff);
+						}
+					}
 
-          ROI *roi_Y = red_green_match(roi_R.get(), roi_G.get());
-          if (roi_Y) {
-            rv = new SignalState::signal_rois_t_(
-                {shared_ptr<ROI>(roi_R), shared_ptr<ROI>(roi_Y),
-                 shared_ptr<ROI>(roi_G), nullptr, 1.0});
-          } else {
-            if (cfg_debug_processing_)
-              logger->log_info(name(), "threw out r+g");
-          }
-        } else if (roi_R && !roi_G) {
-          if (black_stuff_bottom->size() > 0) {
-            roi_R->height =
-                (black_stuff_bottom->front().start.y - roi_R->start.y) / 3;
-          } else if (roi_R->start.y + roi_R->height * 3 > cam_height_) {
-            roi_R->height = (cam_height_ - roi_R->start.y) / 3;
-          }
+					ROI *roi_Y = red_green_match(roi_R.get(), roi_G.get());
+					if (roi_Y) {
+						rv = new SignalState::signal_rois_t_({shared_ptr<ROI>(roi_R),
+						                                      shared_ptr<ROI>(roi_Y),
+						                                      shared_ptr<ROI>(roi_G),
+						                                      nullptr,
+						                                      1.0});
+					} else {
+						if (cfg_debug_processing_)
+							logger->log_info(name(), "threw out r+g");
+					}
+				} else if (roi_R && !roi_G) {
+					if (black_stuff_bottom->size() > 0) {
+						roi_R->height = (black_stuff_bottom->front().start.y - roi_R->start.y) / 3;
+					} else if (roi_R->start.y + roi_R->height * 3 > cam_height_) {
+						roi_R->height = (cam_height_ - roi_R->start.y) / 3;
+					}
 
-          signal.red_roi = roi_R;
+					signal.red_roi = roi_R;
 
-          // Put equally sized yellow & green ROIs below the red one
-          signal.yellow_roi = shared_ptr<ROI>(new ROI());
-          signal.yellow_roi->color = C_YELLOW;
-          signal.yellow_roi->start.x = roi_R->start.x;
-          signal.yellow_roi->start.y = roi_R->start.y + roi_R->height;
-          signal.yellow_roi->width = roi_R->width;
-          signal.yellow_roi->height = roi_R->height;
+					// Put equally sized yellow & green ROIs below the red one
+					signal.yellow_roi          = shared_ptr<ROI>(new ROI());
+					signal.yellow_roi->color   = C_YELLOW;
+					signal.yellow_roi->start.x = roi_R->start.x;
+					signal.yellow_roi->start.y = roi_R->start.y + roi_R->height;
+					signal.yellow_roi->width   = roi_R->width;
+					signal.yellow_roi->height  = roi_R->height;
 
-          signal.green_roi = shared_ptr<ROI>(new ROI());
-          signal.green_roi->color = C_GREEN;
-          signal.green_roi->start.x = signal.yellow_roi->start.x;
-          signal.green_roi->start.y =
-              signal.yellow_roi->start.y + signal.yellow_roi->height;
-          signal.green_roi->width = signal.yellow_roi->width;
-          signal.green_roi->height = signal.yellow_roi->height;
+					signal.green_roi          = shared_ptr<ROI>(new ROI());
+					signal.green_roi->color   = C_GREEN;
+					signal.green_roi->start.x = signal.yellow_roi->start.x;
+					signal.green_roi->start.y = signal.yellow_roi->start.y + signal.yellow_roi->height;
+					signal.green_roi->width   = signal.yellow_roi->width;
+					signal.green_roi->height  = signal.yellow_roi->height;
 
-          signal.truth = 0.001;
+					signal.truth = 0.001;
 
-          rv = new SignalState::signal_rois_t_(signal);
-        } else if (!roi_R && roi_G) {
-          if (black_stuff_top->size() > 0) {
-            ROI &black = black_stuff_top->front();
-            roi_G->height = (roi_G->start.y + roi_G->height -
-                             (black.start.y + black.height)) /
-                            3;
-          } else if (long(roi_G->start.y) - long(roi_G->height) * 2 < 0) {
-            unsigned int hnew = (roi_G->start.y + roi_G->height) / 3;
-            roi_G->start.y += roi_G->height - hnew;
-            roi_G->height = hnew;
-          }
+					rv = new SignalState::signal_rois_t_(signal);
+				} else if (!roi_R && roi_G) {
+					if (black_stuff_top->size() > 0) {
+						ROI &black    = black_stuff_top->front();
+						roi_G->height = (roi_G->start.y + roi_G->height - (black.start.y + black.height)) / 3;
+					} else if (long(roi_G->start.y) - long(roi_G->height) * 2 < 0) {
+						unsigned int hnew = (roi_G->start.y + roi_G->height) / 3;
+						roi_G->start.y += roi_G->height - hnew;
+						roi_G->height = hnew;
+					}
 
-          signal.green_roi = roi_G;
+					signal.green_roi = roi_G;
 
-          signal.yellow_roi = shared_ptr<ROI>(new ROI());
-          signal.yellow_roi->color = C_YELLOW;
-          signal.yellow_roi->start.x = roi_G->start.x;
-          int start_y = roi_G->start.y - roi_G->height;
-          if (start_y < 0)
-            start_y = 0;
-          signal.yellow_roi->start.y = start_y;
-          signal.yellow_roi->width = roi_G->width;
-          signal.yellow_roi->height = roi_G->height;
+					signal.yellow_roi          = shared_ptr<ROI>(new ROI());
+					signal.yellow_roi->color   = C_YELLOW;
+					signal.yellow_roi->start.x = roi_G->start.x;
+					int start_y                = roi_G->start.y - roi_G->height;
+					if (start_y < 0)
+						start_y = 0;
+					signal.yellow_roi->start.y = start_y;
+					signal.yellow_roi->width   = roi_G->width;
+					signal.yellow_roi->height  = roi_G->height;
 
-          signal.red_roi = shared_ptr<ROI>(new ROI());
-          signal.red_roi->color = C_RED;
-          signal.red_roi->start.x = signal.yellow_roi->start.x;
-          start_y = signal.yellow_roi->start.y - signal.yellow_roi->height;
-          if (start_y < 0)
-            start_y = 0;
-          signal.red_roi->start.y = start_y;
-          signal.red_roi->width = signal.yellow_roi->width;
-          signal.red_roi->height = signal.yellow_roi->height;
+					signal.red_roi          = shared_ptr<ROI>(new ROI());
+					signal.red_roi->color   = C_RED;
+					signal.red_roi->start.x = signal.yellow_roi->start.x;
+					start_y                 = signal.yellow_roi->start.y - signal.yellow_roi->height;
+					if (start_y < 0)
+						start_y = 0;
+					signal.red_roi->start.y = start_y;
+					signal.red_roi->width   = signal.yellow_roi->width;
+					signal.red_roi->height  = signal.yellow_roi->height;
 
-          signal.truth = 0.001;
+					signal.truth = 0.001;
 
-          rv = new SignalState::signal_rois_t_(signal);
-        }
-      }
-      delete black_stuff_top;
-      delete black_stuff_bottom;
-    } catch (OutOfBoundsException &e) {
-      logger->log_error(name(), e);
-    }
-  }
-  if (unlikely(cfg_debug_processing_))
-    logger->log_info(name(), "laser proc: %s", debug_proc_string_.c_str());
-  return rv;
+					rv = new SignalState::signal_rois_t_(signal);
+				}
+			}
+			delete black_stuff_top;
+			delete black_stuff_bottom;
+		} catch (OutOfBoundsException &e) {
+			logger->log_error(name(), e);
+		}
+	}
+	if (unlikely(cfg_debug_processing_))
+		logger->log_info(name(), "laser proc: %s", debug_proc_string_.c_str());
+	return rv;
 }
 
-bool MachineSignalPipelineThread::roi_width_ok(ROI &r) {
-  return r.width < cam_width_ / 3;
+bool
+MachineSignalPipelineThread::roi_width_ok(ROI &r)
+{
+	return r.width < cam_width_ / 3;
 }
 
-bool MachineSignalPipelineThread::rois_similar_width(ROI &r1, ROI &r2) {
-  float width_ratio = (float)r1.width / (float)r2.width;
-  return width_ratio >= 1 / cfg_roi_max_width_ratio_ &&
-         width_ratio <= cfg_roi_max_width_ratio_;
+bool
+MachineSignalPipelineThread::rois_similar_width(ROI &r1, ROI &r2)
+{
+	float width_ratio = (float)r1.width / (float)r2.width;
+	return width_ratio >= 1 / cfg_roi_max_width_ratio_ && width_ratio <= cfg_roi_max_width_ratio_;
 }
 
-bool MachineSignalPipelineThread::rois_x_aligned(ROI &r1, ROI &r2) {
-  float avg_width = (r1.width + r2.width) / 2.0f;
-  int mid1 = r1.start.x + r1.width / 2;
-  int mid2 = r2.start.x + r2.width / 2;
-  return abs(mid1 - mid2) / avg_width < cfg_roi_xalign_;
+bool
+MachineSignalPipelineThread::rois_x_aligned(ROI &r1, ROI &r2)
+{
+	float avg_width = (r1.width + r2.width) / 2.0f;
+	int   mid1      = r1.start.x + r1.width / 2;
+	int   mid2      = r2.start.x + r2.width / 2;
+	return abs(mid1 - mid2) / avg_width < cfg_roi_xalign_;
 }
 
-bool MachineSignalPipelineThread::roi_aspect_ok(ROI &r) {
-  float aspect_ratio = (float)r.width / (float)r.height;
-  return aspect_ratio > 1 / cfg_roi_max_aspect_ratio_ &&
-         aspect_ratio < cfg_roi_max_aspect_ratio_;
+bool
+MachineSignalPipelineThread::roi_aspect_ok(ROI &r)
+{
+	float aspect_ratio = (float)r.width / (float)r.height;
+	return aspect_ratio > 1 / cfg_roi_max_aspect_ratio_ && aspect_ratio < cfg_roi_max_aspect_ratio_;
 }
 
-bool MachineSignalPipelineThread::rois_vspace_ok(ROI &r1, ROI &r2) {
-  float avg_height = (r1.height + r2.height) / 2.0f;
-  int dist = r2.start.y - (r1.start.y + r1.height);
-  return dist > 0.6 * avg_height && dist < 1.7 * avg_height;
+bool
+MachineSignalPipelineThread::rois_vspace_ok(ROI &r1, ROI &r2)
+{
+	float avg_height = (r1.height + r2.height) / 2.0f;
+	int   dist       = r2.start.y - (r1.start.y + r1.height);
+	return dist > 0.6 * avg_height && dist < 1.7 * avg_height;
 }
 
-void MachineSignalPipelineThread::config_value_erased(const char *path) {}
-void MachineSignalPipelineThread::config_tag_changed(const char *new_tag) {}
-void MachineSignalPipelineThread::config_comment_changed(
-    const Configuration::ValueIterator *v) {}
+void
+MachineSignalPipelineThread::config_value_erased(const char *path)
+{
+}
+void
+MachineSignalPipelineThread::config_tag_changed(const char *new_tag)
+{
+}
+void
+MachineSignalPipelineThread::config_comment_changed(const Configuration::ValueIterator *v)
+{
+}
 
-void MachineSignalPipelineThread::config_value_changed(
-    const Configuration::ValueIterator *v) {
-  if (v->valid()) {
-    std::string path = v->path();
-    std::string sufx = path.substr(strlen(CFG_PREFIX));
-    std::string sub_prefix = sufx.substr(0, sufx.substr(1).find("/") + 1);
-    std::string full_pfx = CFG_PREFIX + sub_prefix;
-    std::string opt = path.substr(full_pfx.length());
+void
+MachineSignalPipelineThread::config_value_changed(const Configuration::ValueIterator *v)
+{
+	if (v->valid()) {
+		std::string path       = v->path();
+		std::string sufx       = path.substr(strlen(CFG_PREFIX));
+		std::string sub_prefix = sufx.substr(0, sufx.substr(1).find("/") + 1);
+		std::string full_pfx   = CFG_PREFIX + sub_prefix;
+		std::string opt        = path.substr(full_pfx.length());
 
-    MutexLocker lock(&cfg_mutex_);
-    bool chg = false;
+		MutexLocker lock(&cfg_mutex_);
+		bool        chg = false;
 
-    if (sub_prefix == "/red_on" || sub_prefix == "/green_on" ||
-        sub_prefix == "/red_off" || sub_prefix == "/green_off") {
-      color_classifier_context_t_ *classifier = NULL;
-      if (sub_prefix == "/red_on")
-        classifier = &cfy_ctxt_red_1_;
-      else if (sub_prefix == "/green_on")
-        classifier = &cfy_ctxt_green_1_;
-      else if (sub_prefix == "/red_off")
-        classifier = &cfy_ctxt_red_0_;
-      else if (sub_prefix == "/green_off")
-        classifier = &cfy_ctxt_green_0_;
+		if (sub_prefix == "/red_on" || sub_prefix == "/green_on" || sub_prefix == "/red_off"
+		    || sub_prefix == "/green_off") {
+			color_classifier_context_t_ *classifier = NULL;
+			if (sub_prefix == "/red_on")
+				classifier = &cfy_ctxt_red_1_;
+			else if (sub_prefix == "/green_on")
+				classifier = &cfy_ctxt_green_1_;
+			else if (sub_prefix == "/red_off")
+				classifier = &cfy_ctxt_red_0_;
+			else if (sub_prefix == "/green_off")
+				classifier = &cfy_ctxt_green_0_;
 
-      std::string opt = path.substr(full_pfx.length());
+			std::string opt = path.substr(full_pfx.length());
 
-      if (opt == "/reference_color")
-        chg = test_set_cfg_value(&(classifier->cfg_ref_col), v->get_uints());
-      else if (opt == "/saturation_thresh")
-        chg = test_set_cfg_value(&(classifier->cfg_sat_thresh), v->get_ints());
-      else if (opt == "/chroma_thresh")
-        chg =
-            test_set_cfg_value(&(classifier->cfg_chroma_thresh), v->get_ints());
-      else if (opt == "/luma_thresh")
-        chg = test_set_cfg_value(&(classifier->cfg_luma_thresh), v->get_ints());
-      else if (opt == "/min_points")
-        chg = test_set_cfg_value(&(classifier->cfg_roi_min_points),
-                                 v->get_uint());
-      else if (opt == "/basic_roi_size")
-        chg = test_set_cfg_value(&(classifier->cfg_roi_basic_size),
-                                 v->get_uint());
-      else if (opt == "/neighborhood_min_match")
-        chg = test_set_cfg_value(&(classifier->cfg_roi_neighborhood_min_match),
-                                 v->get_uint());
-      else if (opt == "/scangrid_x_offset")
-        chg = test_set_cfg_value(&(classifier->cfg_scangrid_x_offset),
-                                 v->get_uint());
-      else if (opt == "/scangrid_y_offset")
-        chg = test_set_cfg_value(&(classifier->cfg_scangrid_y_offset),
-                                 v->get_uint());
-      else if (opt == "/visualize")
-        chg = test_set_cfg_value(&(classifier->visualize), v->get_bool());
-    } else if (sub_prefix == "/bright_light") {
-      if (opt == "/min_brightness")
-        chg = test_set_cfg_value(&(cfg_light_on_threshold_), v->get_uint());
-      else if (opt == "/min_points")
-        chg = test_set_cfg_value(&(cfg_light_on_min_points_), v->get_uint());
-      else if (opt == "/neighborhood_min_match")
-        chg = test_set_cfg_value(&(cfg_light_on_min_neighborhood_),
-                                 v->get_uint());
-      else if (opt == "/min_area_cover")
-        cfg_light_on_min_area_cover_ = v->get_float();
-    } else if (sub_prefix == "/black") {
-      if (opt == "/y_threshold")
-        chg = test_set_cfg_value(&(cfg_black_y_thresh_), v->get_uint());
-      else if (opt == "/u_threshold")
-        chg = test_set_cfg_value(&(cfg_black_u_thresh_), v->get_uint());
-      else if (opt == "/v_threshold")
-        chg = test_set_cfg_value(&(cfg_black_v_thresh_), v->get_uint());
-      else if (opt == "/u_reference")
-        chg = test_set_cfg_value(&(cfg_black_u_ref_), v->get_uint());
-      else if (opt == "/v_reference")
-        chg = test_set_cfg_value(&(cfg_black_v_ref_), v->get_uint());
-      else if (opt == "/min_points")
-        chg = test_set_cfg_value(&(cfg_black_min_points_), v->get_uint());
-      else if (opt == "/neighborhood_min_match")
-        chg = test_set_cfg_value(&(cfg_black_min_neighborhood_), v->get_uint());
-    } else if (sub_prefix == "/lasercluster") {
-      if (opt == "/min_visibility_history")
-        cfg_lasercluster_min_vis_hist_ = v->get_uint();
-      else if (opt == "/enable")
-        cfg_lasercluster_enabled_ = v->get_bool();
-    } else if (sub_prefix == "/laser-lines") {
-      if (opt == "/min_visibility_history")
-        cfg_laser_lines_min_vis_hist_ = v->get_uint();
-      else if (opt == "/enable")
-        cfg_laser_lines_enabled_ = v->get_bool();
-      else if (opt == "/moving_avg")
-        cfg_laser_lines_moving_avg_ = v->get_bool();
-    } else if (sub_prefix == "") {
-      if (opt == "/roi_max_aspect_ratio")
-        cfg_roi_max_aspect_ratio_ = v->get_float();
-      else if (opt == "/roi_max_width")
-        cfg_roi_max_width_ = v->get_uint();
-      else if (opt == "/roi_max_height")
-        cfg_roi_max_height_ = v->get_uint();
-      else if (opt == "/roi_max_r2g_width_ratio")
-        cfg_roi_max_width_ratio_ = v->get_float();
-      else if (opt == "/roi_xalign_by_width")
-        cfg_roi_xalign_ = v->get_float();
-      else if (opt == "/tuning_mode")
-        cfg_tuning_mode_ = v->get_bool();
-      else if (opt == "/max_jitter")
-        cfg_max_jitter_ = v->get_float();
-      else if (opt == "/draw_processed_rois")
-        cfg_draw_processed_rois_ = v->get_bool();
-      else if (opt == "/roi_green_horizon")
-        cfg_roi_green_horizon = v->get_uint();
-      else if (opt == "/debug_blink")
-        cfg_debug_blink_ = v->get_bool();
-      else if (opt == "/debug_processing")
-        cfg_debug_processing_ = v->get_bool();
-      else if (opt == "/laser_frame")
-        chg = test_set_cfg_value(&(cfg_lasercluster_frame_), v->get_string());
-      else if (opt == "/cam_frame")
-        chg = test_set_cfg_value(&(cfg_cam_frame_), v->get_string());
-      else if (opt == "/cam_aperture_x")
-        chg = test_set_cfg_value(&(cfg_cam_aperture_x_), v->get_float());
-      else if (opt == "/cam_aperture_y")
-        chg = test_set_cfg_value(&(cfg_cam_aperture_y_), v->get_float());
-      else if (opt == "/cam_angle")
-        chg = test_set_cfg_value(&(cfg_cam_angle_y_), v->get_float());
-      else if (opt == "/signal_width")
-        cfg_lasercluster_signal_radius_ = 0.5 * v->get_float();
-      else if (opt == "/signal_top")
-        cfg_lasercluster_signal_top_ = v->get_float();
-      else if (opt == "/signal_bottom")
-        cfg_lasercluster_signal_bottom_ = v->get_float();
-      else if (opt == "/debug_tf")
-        cfg_debug_tf_ = v->get_bool();
-    }
-    cfg_changed_ = cfg_changed_ || chg;
-  }
+			if (opt == "/reference_color")
+				chg = test_set_cfg_value(&(classifier->cfg_ref_col), v->get_uints());
+			else if (opt == "/saturation_thresh")
+				chg = test_set_cfg_value(&(classifier->cfg_sat_thresh), v->get_ints());
+			else if (opt == "/chroma_thresh")
+				chg = test_set_cfg_value(&(classifier->cfg_chroma_thresh), v->get_ints());
+			else if (opt == "/luma_thresh")
+				chg = test_set_cfg_value(&(classifier->cfg_luma_thresh), v->get_ints());
+			else if (opt == "/min_points")
+				chg = test_set_cfg_value(&(classifier->cfg_roi_min_points), v->get_uint());
+			else if (opt == "/basic_roi_size")
+				chg = test_set_cfg_value(&(classifier->cfg_roi_basic_size), v->get_uint());
+			else if (opt == "/neighborhood_min_match")
+				chg = test_set_cfg_value(&(classifier->cfg_roi_neighborhood_min_match), v->get_uint());
+			else if (opt == "/scangrid_x_offset")
+				chg = test_set_cfg_value(&(classifier->cfg_scangrid_x_offset), v->get_uint());
+			else if (opt == "/scangrid_y_offset")
+				chg = test_set_cfg_value(&(classifier->cfg_scangrid_y_offset), v->get_uint());
+			else if (opt == "/visualize")
+				chg = test_set_cfg_value(&(classifier->visualize), v->get_bool());
+		} else if (sub_prefix == "/bright_light") {
+			if (opt == "/min_brightness")
+				chg = test_set_cfg_value(&(cfg_light_on_threshold_), v->get_uint());
+			else if (opt == "/min_points")
+				chg = test_set_cfg_value(&(cfg_light_on_min_points_), v->get_uint());
+			else if (opt == "/neighborhood_min_match")
+				chg = test_set_cfg_value(&(cfg_light_on_min_neighborhood_), v->get_uint());
+			else if (opt == "/min_area_cover")
+				cfg_light_on_min_area_cover_ = v->get_float();
+		} else if (sub_prefix == "/black") {
+			if (opt == "/y_threshold")
+				chg = test_set_cfg_value(&(cfg_black_y_thresh_), v->get_uint());
+			else if (opt == "/u_threshold")
+				chg = test_set_cfg_value(&(cfg_black_u_thresh_), v->get_uint());
+			else if (opt == "/v_threshold")
+				chg = test_set_cfg_value(&(cfg_black_v_thresh_), v->get_uint());
+			else if (opt == "/u_reference")
+				chg = test_set_cfg_value(&(cfg_black_u_ref_), v->get_uint());
+			else if (opt == "/v_reference")
+				chg = test_set_cfg_value(&(cfg_black_v_ref_), v->get_uint());
+			else if (opt == "/min_points")
+				chg = test_set_cfg_value(&(cfg_black_min_points_), v->get_uint());
+			else if (opt == "/neighborhood_min_match")
+				chg = test_set_cfg_value(&(cfg_black_min_neighborhood_), v->get_uint());
+		} else if (sub_prefix == "/lasercluster") {
+			if (opt == "/min_visibility_history")
+				cfg_lasercluster_min_vis_hist_ = v->get_uint();
+			else if (opt == "/enable")
+				cfg_lasercluster_enabled_ = v->get_bool();
+		} else if (sub_prefix == "/laser-lines") {
+			if (opt == "/min_visibility_history")
+				cfg_laser_lines_min_vis_hist_ = v->get_uint();
+			else if (opt == "/enable")
+				cfg_laser_lines_enabled_ = v->get_bool();
+			else if (opt == "/moving_avg")
+				cfg_laser_lines_moving_avg_ = v->get_bool();
+		} else if (sub_prefix == "") {
+			if (opt == "/roi_max_aspect_ratio")
+				cfg_roi_max_aspect_ratio_ = v->get_float();
+			else if (opt == "/roi_max_width")
+				cfg_roi_max_width_ = v->get_uint();
+			else if (opt == "/roi_max_height")
+				cfg_roi_max_height_ = v->get_uint();
+			else if (opt == "/roi_max_r2g_width_ratio")
+				cfg_roi_max_width_ratio_ = v->get_float();
+			else if (opt == "/roi_xalign_by_width")
+				cfg_roi_xalign_ = v->get_float();
+			else if (opt == "/tuning_mode")
+				cfg_tuning_mode_ = v->get_bool();
+			else if (opt == "/max_jitter")
+				cfg_max_jitter_ = v->get_float();
+			else if (opt == "/draw_processed_rois")
+				cfg_draw_processed_rois_ = v->get_bool();
+			else if (opt == "/roi_green_horizon")
+				cfg_roi_green_horizon = v->get_uint();
+			else if (opt == "/debug_blink")
+				cfg_debug_blink_ = v->get_bool();
+			else if (opt == "/debug_processing")
+				cfg_debug_processing_ = v->get_bool();
+			else if (opt == "/laser_frame")
+				chg = test_set_cfg_value(&(cfg_lasercluster_frame_), v->get_string());
+			else if (opt == "/cam_frame")
+				chg = test_set_cfg_value(&(cfg_cam_frame_), v->get_string());
+			else if (opt == "/cam_aperture_x")
+				chg = test_set_cfg_value(&(cfg_cam_aperture_x_), v->get_float());
+			else if (opt == "/cam_aperture_y")
+				chg = test_set_cfg_value(&(cfg_cam_aperture_y_), v->get_float());
+			else if (opt == "/cam_angle")
+				chg = test_set_cfg_value(&(cfg_cam_angle_y_), v->get_float());
+			else if (opt == "/signal_width")
+				cfg_lasercluster_signal_radius_ = 0.5 * v->get_float();
+			else if (opt == "/signal_top")
+				cfg_lasercluster_signal_top_ = v->get_float();
+			else if (opt == "/signal_bottom")
+				cfg_lasercluster_signal_bottom_ = v->get_float();
+			else if (opt == "/debug_tf")
+				cfg_debug_tf_ = v->get_bool();
+		}
+		cfg_changed_ = cfg_changed_ || chg;
+	}
 }

--- a/src/plugins/attic/machine-signal/pipeline_thread.h
+++ b/src/plugins/attic/machine-signal/pipeline_thread.h
@@ -32,7 +32,9 @@
 #include <core/threading/thread.h>
 
 // Members
-#include <atomic>
+#include "custom_rois.h"
+#include "state.h"
+
 #include <core/threading/mutex.h>
 #include <fvcams/v4l2.h>
 #include <fvclassifiers/simple.h>
@@ -48,12 +50,11 @@
 #include <interfaces/Position3DInterface.h>
 #include <interfaces/SignalHintInterface.h>
 #include <interfaces/SwitchInterface.h>
-#include <set>
-#include <string>
 #include <utils/time/wait.h>
 
-#include "custom_rois.h"
-#include "state.h"
+#include <atomic>
+#include <set>
+#include <string>
 
 #define likely(x) __builtin_expect((x), 1)
 #define unlikely(x) __builtin_expect((x), 0)
@@ -78,233 +79,242 @@ class MachineSignalPipelineThread : public fawkes::Thread,
                                     public fawkes::VisionAspect,
                                     public fawkes::ConfigurationChangeHandler,
                                     public fawkes::ClockAspect,
-                                    public fawkes::TransformAspect {
+                                    public fawkes::TransformAspect
+{
 public:
-  MachineSignalPipelineThread();
-  ~MachineSignalPipelineThread();
+	MachineSignalPipelineThread();
+	~MachineSignalPipelineThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  bool lock_if_new_data();
+	bool lock_if_new_data();
 
-  void unlock();
+	void unlock();
 
-  std::list<SignalState> &get_known_signals();
-  std::list<SignalState>::iterator get_best_signal();
+	std::list<SignalState> &         get_known_signals();
+	std::list<SignalState>::iterator get_best_signal();
 
-  /** Check if pipeline thread is enabled.
+	/** Check if pipeline thread is enabled.
    * @return true if pipeline thread is enabled, false otherwise. */
-  bool is_enabled() const { return cfg_enable_switch_; }
+	bool
+	is_enabled() const
+	{
+		return cfg_enable_switch_;
+	}
 
 private:
-  float signal_beauty(const SignalState::signal_rois_t_ &signal,
-                      const firevision::ROI &laser_roi);
-  float compactness(const SignalState::signal_rois_t_ &s,
-                    const firevision::ROI &laser_roi);
+	float signal_beauty(const SignalState::signal_rois_t_ &signal, const firevision::ROI &laser_roi);
+	float compactness(const SignalState::signal_rois_t_ &s, const firevision::ROI &laser_roi);
 
-  bool bb_switch_is_enabled(fawkes::SwitchInterface *sw);
+	bool bb_switch_is_enabled(fawkes::SwitchInterface *sw);
 
-  bool cfg_enable_switch_;
+	bool cfg_enable_switch_;
 
-  fawkes::Mutex data_mutex_;
-  bool new_data_;
-  double desired_frametime_;
-  fawkes::TimeWait *time_wait_;
+	fawkes::Mutex     data_mutex_;
+	bool              new_data_;
+	double            desired_frametime_;
+	fawkes::TimeWait *time_wait_;
 
-  fawkes::SwitchInterface *bb_enable_switch_;
+	fawkes::SwitchInterface *bb_enable_switch_;
 
-  typedef struct {
-    firevision::ColorModelSimilarity *colormodel;
-    firevision::SimpleColorClassifier *classifier;
-    std::vector<firevision::ColorModelSimilarity::color_class_t *> color_class;
-    firevision::ScanlineGrid *scanline_grid;
-    std::vector<unsigned int> cfg_ref_col;
-    std::vector<int> cfg_chroma_thresh;
-    std::vector<int> cfg_sat_thresh;
-    std::vector<int> cfg_luma_thresh;
-    firevision::color_t color_expect;
-    unsigned int cfg_roi_min_points;
-    unsigned int cfg_roi_basic_size;
-    unsigned int cfg_roi_neighborhood_min_match;
-    unsigned int cfg_scangrid_x_offset;
-    unsigned int cfg_scangrid_y_offset;
-    bool visualize;
-  } color_classifier_context_t_;
+	typedef struct
+	{
+		firevision::ColorModelSimilarity *                             colormodel;
+		firevision::SimpleColorClassifier *                            classifier;
+		std::vector<firevision::ColorModelSimilarity::color_class_t *> color_class;
+		firevision::ScanlineGrid *                                     scanline_grid;
+		std::vector<unsigned int>                                      cfg_ref_col;
+		std::vector<int>                                               cfg_chroma_thresh;
+		std::vector<int>                                               cfg_sat_thresh;
+		std::vector<int>                                               cfg_luma_thresh;
+		firevision::color_t                                            color_expect;
+		unsigned int                                                   cfg_roi_min_points;
+		unsigned int                                                   cfg_roi_basic_size;
+		unsigned int                                                   cfg_roi_neighborhood_min_match;
+		unsigned int                                                   cfg_scangrid_x_offset;
+		unsigned int                                                   cfg_scangrid_y_offset;
+		bool                                                           visualize;
+	} color_classifier_context_t_;
 
-  color_classifier_context_t_ cfy_ctxt_red_1_;
-  color_classifier_context_t_ cfy_ctxt_red_0_;
-  color_classifier_context_t_ cfy_ctxt_green_1_;
-  color_classifier_context_t_ cfy_ctxt_green_0_;
+	color_classifier_context_t_ cfy_ctxt_red_1_;
+	color_classifier_context_t_ cfy_ctxt_red_0_;
+	color_classifier_context_t_ cfy_ctxt_green_1_;
+	color_classifier_context_t_ cfy_ctxt_green_0_;
 
-  std::string cfg_camera_;
-  firevision::Camera *camera_;
-  unsigned int cam_width_, cam_height_;
+	std::string         cfg_camera_;
+	firevision::Camera *camera_;
+	unsigned int        cam_width_, cam_height_;
 
-  unsigned int cfg_fps_;
+	unsigned int cfg_fps_;
 
-  fawkes::Position3DInterface *bb_laser_clusters_[3];
-  std::atomic<unsigned int> cfg_lasercluster_min_vis_hist_;
-  std::string cfg_lasercluster_frame_;
-  std::atomic<float> cfg_lasercluster_signal_radius_;
-  std::atomic<float> cfg_lasercluster_signal_top_;
-  std::atomic<float> cfg_lasercluster_signal_bottom_;
-  std::atomic_bool cfg_lasercluster_enabled_;
+	fawkes::Position3DInterface *bb_laser_clusters_[3];
+	std::atomic<unsigned int>    cfg_lasercluster_min_vis_hist_;
+	std::string                  cfg_lasercluster_frame_;
+	std::atomic<float>           cfg_lasercluster_signal_radius_;
+	std::atomic<float>           cfg_lasercluster_signal_top_;
+	std::atomic<float>           cfg_lasercluster_signal_bottom_;
+	std::atomic_bool             cfg_lasercluster_enabled_;
 
-  fawkes::LaserLineInterface *bb_laser_lines_[5];
-  std::atomic<unsigned int> cfg_laser_lines_min_vis_hist_;
-  std::atomic_bool cfg_laser_lines_enabled_;
-  std::atomic_bool cfg_laser_lines_moving_avg_;
-  void bb_open_laser_lines();
-  void bb_close_laser_lines();
+	fawkes::LaserLineInterface *bb_laser_lines_[5];
+	std::atomic<unsigned int>   cfg_laser_lines_min_vis_hist_;
+	std::atomic_bool            cfg_laser_lines_enabled_;
+	std::atomic_bool            cfg_laser_lines_moving_avg_;
+	void                        bb_open_laser_lines();
+	void                        bb_close_laser_lines();
 
-  float cfg_cam_aperture_x_;
-  float cfg_cam_aperture_y_;
-  float cfg_cam_angle_y_;
-  std::string cfg_cam_frame_;
-  firevision::PositionToPixel *pos2pixel_;
+	float                        cfg_cam_aperture_x_;
+	float                        cfg_cam_aperture_y_;
+	float                        cfg_cam_angle_y_;
+	std::string                  cfg_cam_frame_;
+	firevision::PositionToPixel *pos2pixel_;
 
-  std::atomic<unsigned int> cfg_roi_max_height_;
-  std::atomic<unsigned int> cfg_roi_max_width_;
-  std::atomic<float> cfg_roi_max_aspect_ratio_;
-  std::atomic<float> cfg_roi_max_width_ratio_;
-  std::atomic<float> cfg_roi_xalign_;
-  std::atomic<unsigned int> cfg_roi_green_horizon;
-  std::atomic_bool cfg_tuning_mode_;
-  std::atomic_bool cfg_draw_processed_rois_;
-  std::atomic<float> cfg_max_jitter_;
-  std::atomic_bool cfg_debug_processing_;
-  std::atomic_bool cfg_debug_blink_;
-  std::atomic_bool cfg_debug_tf_;
+	std::atomic<unsigned int> cfg_roi_max_height_;
+	std::atomic<unsigned int> cfg_roi_max_width_;
+	std::atomic<float>        cfg_roi_max_aspect_ratio_;
+	std::atomic<float>        cfg_roi_max_width_ratio_;
+	std::atomic<float>        cfg_roi_xalign_;
+	std::atomic<unsigned int> cfg_roi_green_horizon;
+	std::atomic_bool          cfg_tuning_mode_;
+	std::atomic_bool          cfg_draw_processed_rois_;
+	std::atomic<float>        cfg_max_jitter_;
+	std::atomic_bool          cfg_debug_processing_;
+	std::atomic_bool          cfg_debug_blink_;
+	std::atomic_bool          cfg_debug_tf_;
 
-  std::string debug_proc_string_;
+	std::string debug_proc_string_;
 
-  fawkes::Mutex cfg_mutex_;
-  std::atomic_bool cfg_changed_, cam_changed_;
+	fawkes::Mutex    cfg_mutex_;
+	std::atomic_bool cfg_changed_, cam_changed_;
 
-  fawkes::Time *last_second_;
-  unsigned int buflen_;
+	fawkes::Time *last_second_;
+	unsigned int  buflen_;
 
-  // Maybe we want to detect the black cap on top of the signal, too...?
-  /*firevision::SimpleColorClassifier *cls_black_cap_;
+	// Maybe we want to detect the black cap on top of the signal, too...?
+	/*firevision::SimpleColorClassifier *cls_black_cap_;
   unsigned int cfg_black_thresh_;*/
 
-  unsigned int cfg_light_on_threshold_;
-  unsigned int cfg_light_on_min_points_;
-  unsigned int cfg_light_on_min_neighborhood_;
-  std::atomic<float> cfg_light_on_min_area_cover_;
-  firevision::SimpleColorClassifier *light_classifier_;
-  firevision::ColorModelLuminance *light_colormodel_;
-  firevision::ScanlineGrid *light_scangrid_;
+	unsigned int                       cfg_light_on_threshold_;
+	unsigned int                       cfg_light_on_min_points_;
+	unsigned int                       cfg_light_on_min_neighborhood_;
+	std::atomic<float>                 cfg_light_on_min_area_cover_;
+	firevision::SimpleColorClassifier *light_classifier_;
+	firevision::ColorModelLuminance *  light_colormodel_;
+	firevision::ScanlineGrid *         light_scangrid_;
 
-  unsigned int cfg_black_y_thresh_;
-  unsigned int cfg_black_u_thresh_;
-  unsigned int cfg_black_v_thresh_;
-  unsigned int cfg_black_u_ref_;
-  unsigned int cfg_black_v_ref_;
-  unsigned int cfg_black_min_points_;
-  unsigned int cfg_black_min_neighborhood_;
-  firevision::SimpleColorClassifier *black_classifier_;
-  firevision::ColorModelBlack *black_colormodel_;
-  firevision::ScanlineGrid *black_scangrid_;
+	unsigned int                       cfg_black_y_thresh_;
+	unsigned int                       cfg_black_u_thresh_;
+	unsigned int                       cfg_black_v_thresh_;
+	unsigned int                       cfg_black_u_ref_;
+	unsigned int                       cfg_black_v_ref_;
+	unsigned int                       cfg_black_min_points_;
+	unsigned int                       cfg_black_min_neighborhood_;
+	firevision::SimpleColorClassifier *black_classifier_;
+	firevision::ColorModelBlack *      black_colormodel_;
+	firevision::ScanlineGrid *         black_scangrid_;
 
-  firevision::FilterROIDraw *roi_drawer_;
-  firevision::SharedMemoryImageBuffer *shmbuf_;
-  firevision::SharedMemoryImageBuffer *shmbuf_cam_;
-  firevision::FilterColorThreshold *color_filter_;
-  firevision::ColorModelSimilarity *combined_colormodel_;
+	firevision::FilterROIDraw *          roi_drawer_;
+	firevision::SharedMemoryImageBuffer *shmbuf_;
+	firevision::SharedMemoryImageBuffer *shmbuf_cam_;
+	firevision::FilterColorThreshold *   color_filter_;
+	firevision::ColorModelSimilarity *   combined_colormodel_;
 
-  void setup_color_classifier(color_classifier_context_t_ *classifier,
-                              firevision::ROI *roi = nullptr);
-  void setup_camera();
-  bool color_data_consistent(color_classifier_context_t_ *);
-  void reinit_color_config();
+	void setup_color_classifier(color_classifier_context_t_ *classifier,
+	                            firevision::ROI *            roi = nullptr);
+	void setup_camera();
+	bool color_data_consistent(color_classifier_context_t_ *);
+	void reinit_color_config();
 
-  //*/
-  struct compare_rois_by_x_ {
-    bool operator()(firevision::ROI const &r1, firevision::ROI const &r2) {
-      return r1.start.x <= r2.start.x;
-    }
-  }; // sort_rois_by_x_; //*/
+	//*/
+	struct compare_rois_by_x_
+	{
+		bool
+		operator()(firevision::ROI const &r1, firevision::ROI const &r2)
+		{
+			return r1.start.x <= r2.start.x;
+		}
+	}; // sort_rois_by_x_; //*/
 
-  struct compare_rois_by_y_ {
-    bool operator()(firevision::ROI const &r1, firevision::ROI const &r2) {
-      return r1.start.y <= r2.start.y;
-    }
-  } sort_rois_by_y_;
+	struct compare_rois_by_y_
+	{
+		bool
+		operator()(firevision::ROI const &r1, firevision::ROI const &r2)
+		{
+			return r1.start.y <= r2.start.y;
+		}
+	} sort_rois_by_y_;
 
-  /*struct compare_signal_rois_by_x_ {
+	/*struct compare_signal_rois_by_x_ {
       bool operator() (SignalState::signal_rois_t_ const &signal1,
   SignalState::signal_rois_t_ const &signal2) { return signal1.red_roi->start.x
   <= signal2.red_roi->start.x;
       }
   } sort_signal_rois_by_x_; //*/
 
-  // All ROIs we want to see painted in the tuning buffer
-  std::list<firevision::ROI> drawn_rois_;
+	// All ROIs we want to see painted in the tuning buffer
+	std::list<firevision::ROI> drawn_rois_;
 
-  firevision::ROI *red_green_match(firevision::ROI *roi_R,
-                                   firevision::ROI *roi_G);
-  std::list<SignalState::signal_rois_t_> *
-  create_field_signals(std::list<firevision::ROI> *rois_R,
-                       std::list<firevision::ROI> *rois_G);
-  SignalState::signal_rois_t_ *
-  create_laser_signals(const firevision::ROI &,
-                       std::list<firevision::ROI> *rois_R,
-                       std::list<firevision::ROI> *rois_G);
+	firevision::ROI *red_green_match(firevision::ROI *roi_R, firevision::ROI *roi_G);
+	std::list<SignalState::signal_rois_t_> *create_field_signals(std::list<firevision::ROI> *rois_R,
+	                                                             std::list<firevision::ROI> *rois_G);
+	SignalState::signal_rois_t_ *           create_laser_signals(const firevision::ROI &,
+	                                                             std::list<firevision::ROI> *rois_R,
+	                                                             std::list<firevision::ROI> *rois_G);
 
-  // Checks to weed out implausible ROIs
-  inline bool roi_width_ok(firevision::ROI &r);
-  inline bool rois_similar_width(firevision::ROI &r1, firevision::ROI &r2);
-  inline bool rois_x_aligned(firevision::ROI &r1, firevision::ROI &r2);
-  inline bool roi_aspect_ok(firevision::ROI &r);
-  inline bool rois_vspace_ok(firevision::ROI &r1, firevision::ROI &r2);
-  inline bool roi1_oversize(firevision::ROI &r1, firevision::ROI &r2);
-  inline bool roi1_x_overlaps_below(firevision::ROI &r1, firevision::ROI &r2);
-  inline bool roi1_x_intersects(firevision::ROI &r1, firevision::ROI &r2);
+	// Checks to weed out implausible ROIs
+	inline bool roi_width_ok(firevision::ROI &r);
+	inline bool rois_similar_width(firevision::ROI &r1, firevision::ROI &r2);
+	inline bool rois_x_aligned(firevision::ROI &r1, firevision::ROI &r2);
+	inline bool roi_aspect_ok(firevision::ROI &r);
+	inline bool rois_vspace_ok(firevision::ROI &r1, firevision::ROI &r2);
+	inline bool roi1_oversize(firevision::ROI &r1, firevision::ROI &r2);
+	inline bool roi1_x_overlaps_below(firevision::ROI &r1, firevision::ROI &r2);
+	inline bool roi1_x_intersects(firevision::ROI &r1, firevision::ROI &r2);
 
-  bool get_light_state(firevision::ROI *light);
+	bool get_light_state(firevision::ROI *light);
 
-  std::list<SignalState> known_signals_;
-  std::list<SignalState>::iterator best_signal_;
+	std::list<SignalState>           known_signals_;
+	std::list<SignalState>::iterator best_signal_;
 
-  std::set<firevision::WorldROI, SignalState::compare_rois_by_area> *
-  bb_get_laser_rois();
-  firevision::WorldROI
-  pos3d_to_roi(const fawkes::tf::Stamped<fawkes::tf::Point> &pos3d);
-  std::set<firevision::WorldROI, SignalState::compare_rois_by_area>
-      *cluster_rois_;
+	std::set<firevision::WorldROI, SignalState::compare_rois_by_area> *bb_get_laser_rois();
+	firevision::WorldROI pos3d_to_roi(const fawkes::tf::Stamped<fawkes::tf::Point> &pos3d);
+	std::set<firevision::WorldROI, SignalState::compare_rois_by_area> *cluster_rois_;
 
-  fawkes::SignalHintInterface *bb_signal_position_estimate_;
-  fawkes::tf::Stamped<fawkes::tf::Point> signal_hint_;
+	fawkes::SignalHintInterface *          bb_signal_position_estimate_;
+	fawkes::tf::Stamped<fawkes::tf::Point> signal_hint_;
 
-  /*std::map<firevision::ROI, SignalState::signal_rois_t_, compare_rois_by_x_>
+	/*std::map<firevision::ROI, SignalState::signal_rois_t_, compare_rois_by_x_>
     *merge_rois_in_laser( std::set<firevision::WorldROI,
     SignalState::compare_rois_by_area> *laser_rois, std::list<firevision::ROI>
     *rois_R, std::list<firevision::ROI> *rois_G); //*/
 
-  firevision::ROI *merge_rois_in_roi(const firevision::ROI &outer_roi,
-                                     std::list<firevision::ROI> *rois);
+	firevision::ROI *merge_rois_in_roi(const firevision::ROI &     outer_roi,
+	                                   std::list<firevision::ROI> *rois);
 
-  // Implemented abstracts inherited from ConfigurationChangeHandler
-  virtual void config_tag_changed(const char *new_tag);
-  virtual void
-  config_value_changed(const fawkes::Configuration::ValueIterator *v);
-  virtual void
-  config_comment_changed(const fawkes::Configuration::ValueIterator *v);
-  virtual void config_value_erased(const char *path);
+	// Implemented abstracts inherited from ConfigurationChangeHandler
+	virtual void config_tag_changed(const char *new_tag);
+	virtual void config_value_changed(const fawkes::Configuration::ValueIterator *v);
+	virtual void config_comment_changed(const fawkes::Configuration::ValueIterator *v);
+	virtual void config_value_erased(const char *path);
 
-  template <typename T> bool test_set_cfg_value(T *cfg, T val) {
-    if (*cfg == val)
-      return false;
-    *cfg = val;
-    return true;
-  }
+	template <typename T>
+	bool
+	test_set_cfg_value(T *cfg, T val)
+	{
+		if (*cfg == val)
+			return false;
+		*cfg = val;
+		return true;
+	}
 
 protected:
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
-  virtual void run() { Thread::run(); }
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 };
 
 #endif

--- a/src/plugins/attic/machine-signal/plugin.cpp
+++ b/src/plugins/attic/machine-signal/plugin.cpp
@@ -20,24 +20,25 @@
 
 #ifndef MACHINE_SIGNAL_PLUGIN_H_
 
-#include <core/plugin.h>
+#	include "pipeline_thread.h"
+#	include "sensor_thread.h"
 
-#include "pipeline_thread.h"
-#include "sensor_thread.h"
+#	include <core/plugin.h>
 
 using namespace fawkes;
 
-class MachineSignalPlugin : public fawkes::Plugin {
+class MachineSignalPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  MachineSignalPlugin(Configuration *config) : Plugin(config) {
-    MachineSignalPipelineThread *pipeline_thread =
-        new MachineSignalPipelineThread();
-    thread_list.push_back(pipeline_thread);
-    thread_list.push_back(new MachineSignalSensorThread(pipeline_thread));
-  }
+	MachineSignalPlugin(Configuration *config) : Plugin(config)
+	{
+		MachineSignalPipelineThread *pipeline_thread = new MachineSignalPipelineThread();
+		thread_list.push_back(pipeline_thread);
+		thread_list.push_back(new MachineSignalSensorThread(pipeline_thread));
+	}
 };
 
 PLUGIN_DESCRIPTION("Detect signals using color thresholds")

--- a/src/plugins/attic/machine-signal/sensor_thread.h
+++ b/src/plugins/attic/machine-signal/sensor_thread.h
@@ -24,13 +24,14 @@
 #ifndef __PLUGINS_MACHINE_SIGNAL_SENSOR_THREAD_H_
 #define __PLUGINS_MACHINE_SIGNAL_SENSOR_THREAD_H_
 
+#include "pipeline_thread.h"
+
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <core/threading/thread.h>
 
-#include "pipeline_thread.h"
 #include <string>
 
 namespace fawkes {
@@ -44,22 +45,27 @@ class MachineSignalSensorThread : public fawkes::Thread,
                                   public fawkes::BlockedTimingAspect,
                                   public fawkes::LoggingAspect,
                                   public fawkes::ConfigurableAspect,
-                                  public fawkes::BlackBoardAspect {
+                                  public fawkes::BlackBoardAspect
+{
 public:
-  MachineSignalSensorThread(MachineSignalPipelineThread *pipeline_thread);
+	MachineSignalSensorThread(MachineSignalPipelineThread *pipeline_thread);
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
 protected:
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
-  virtual void run() { Thread::run(); }
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  std::vector<fawkes::RobotinoLightInterface *> bb_signal_states_;
-  fawkes::RobotinoLightInterface *bb_signal_compat_;
-  MachineSignalPipelineThread *pipeline_thread_;
+	std::vector<fawkes::RobotinoLightInterface *> bb_signal_states_;
+	fawkes::RobotinoLightInterface *              bb_signal_compat_;
+	MachineSignalPipelineThread *                 pipeline_thread_;
 };
 
 #endif /* __PLUGINS_MACHINE_SIGNAL_SENSOR_THREAD_H_ */

--- a/src/plugins/attic/machine-signal/state.cpp
+++ b/src/plugins/attic/machine-signal/state.cpp
@@ -20,177 +20,188 @@
 
 #include "state.h"
 
-SignalState::SignalState(unsigned int buflen, fawkes::Logger *logger,
+SignalState::SignalState(unsigned int             buflen,
+                         fawkes::Logger *         logger,
                          historic_signal_rois_t_ &signal)
-    : world_pos(nullptr), signal_rois_history_(signal) {
-  logger_ = logger;
-  buflen_ = buflen;
-  state_buflen_ = buflen * 2;
-  history_R_.frames.set_capacity(buflen);
-  history_Y_.frames.set_capacity(buflen);
-  history_G_.frames.set_capacity(buflen);
-  history_R_.state.set_capacity(state_buflen_);
-  history_Y_.state.set_capacity(state_buflen_);
-  history_G_.state.set_capacity(state_buflen_);
-  area = 0;
-  visibility = -1;
-  ready = false;
-  unseen = 0;
-  red = fawkes::RobotinoLightInterface::UNKNOWN;
-  yellow = fawkes::RobotinoLightInterface::UNKNOWN;
-  green = fawkes::RobotinoLightInterface::UNKNOWN;
-  pos.x = signal.yellow_roi->start.x + signal.yellow_roi->width / 2;
-  pos.y = signal.yellow_roi->start.y + signal.yellow_roi->height / 2;
+: world_pos(nullptr), signal_rois_history_(signal)
+{
+	logger_       = logger;
+	buflen_       = buflen;
+	state_buflen_ = buflen * 2;
+	history_R_.frames.set_capacity(buflen);
+	history_Y_.frames.set_capacity(buflen);
+	history_G_.frames.set_capacity(buflen);
+	history_R_.state.set_capacity(state_buflen_);
+	history_Y_.state.set_capacity(state_buflen_);
+	history_G_.state.set_capacity(state_buflen_);
+	area       = 0;
+	visibility = -1;
+	ready      = false;
+	unseen     = 0;
+	red        = fawkes::RobotinoLightInterface::UNKNOWN;
+	yellow     = fawkes::RobotinoLightInterface::UNKNOWN;
+	green      = fawkes::RobotinoLightInterface::UNKNOWN;
+	pos.x      = signal.yellow_roi->start.x + signal.yellow_roi->width / 2;
+	pos.y      = signal.yellow_roi->start.y + signal.yellow_roi->height / 2;
 }
 
-void SignalState::inc_unseen(
-    std::set<firevision::WorldROI, compare_rois_by_area> &laser_rois) {
-  bool in_laser = false;
-  firevision::ROI full(*(signal_rois_history_.red_roi));
-  full += *(signal_rois_history_.yellow_roi);
-  full += *(signal_rois_history_.green_roi);
-  for (firevision::WorldROI cluster : laser_rois) {
-    firevision::ROI intersection = cluster.intersect(full);
-    unsigned int laser_area = cluster.get_width() * cluster.get_height();
-    if (laser_area &&
-        float(intersection.get_width() * intersection.get_height()) /
-                float(laser_area) >
-            0.3) {
-      in_laser = true;
-    }
-  }
+void
+SignalState::inc_unseen(std::set<firevision::WorldROI, compare_rois_by_area> &laser_rois)
+{
+	bool            in_laser = false;
+	firevision::ROI full(*(signal_rois_history_.red_roi));
+	full += *(signal_rois_history_.yellow_roi);
+	full += *(signal_rois_history_.green_roi);
+	for (firevision::WorldROI cluster : laser_rois) {
+		firevision::ROI intersection = cluster.intersect(full);
+		unsigned int    laser_area   = cluster.get_width() * cluster.get_height();
+		if (laser_area
+		    && float(intersection.get_width() * intersection.get_height()) / float(laser_area) > 0.3) {
+			in_laser = true;
+		}
+	}
 
-  ++unseen;
-  if (unseen > 17 || (!in_laser && unseen > 2)) {
-    if (visibility >= 0)
-      visibility = -1;
-    else
-      visibility--;
-    ready = false;
-  }
+	++unseen;
+	if (unseen > 17 || (!in_laser && unseen > 2)) {
+		if (visibility >= 0)
+			visibility = -1;
+		else
+			visibility--;
+		ready = false;
+	}
 }
 
-char const *SignalState::get_debug_R() { return debug_R_.c_str(); }
+char const *
+SignalState::get_debug_R()
+{
+	return debug_R_.c_str();
+}
 
-char const *SignalState::get_debug_Y() { return debug_Y_.c_str(); }
+char const *
+SignalState::get_debug_Y()
+{
+	return debug_Y_.c_str();
+}
 
-char const *SignalState::get_debug_G() { return debug_G_.c_str(); }
+char const *
+SignalState::get_debug_G()
+{
+	return debug_G_.c_str();
+}
 
-float SignalState::distance(std::list<signal_rois_t_>::iterator const &s) {
-  int dx = s->yellow_roi->start.x + s->yellow_roi->width / 2 - pos.x;
-  int dy = s->yellow_roi->start.y + s->yellow_roi->height / 2 - pos.y;
-  return sqrtf(float(dx * dx + dy * dy));
+float
+SignalState::distance(std::list<signal_rois_t_>::iterator const &s)
+{
+	int dx = s->yellow_roi->start.x + s->yellow_roi->width / 2 - pos.x;
+	int dy = s->yellow_roi->start.y + s->yellow_roi->height / 2 - pos.y;
+	return sqrtf(float(dx * dx + dy * dy));
 }
 
 fawkes::RobotinoLightInterface::LightState
-SignalState::eval_history(light_history_t_ &history,
-                          std::string &debug_string) {
-  int count = 0;
-  debug_string = "";
-  for (boost::circular_buffer<bool>::const_iterator it = history.frames.begin();
-       it != history.frames.end(); it++) {
-    debug_string += *it ? "#" : ".";
-    count += *it ? 1 : -1;
-  }
+SignalState::eval_history(light_history_t_ &history, std::string &debug_string)
+{
+	int count    = 0;
+	debug_string = "";
+	for (boost::circular_buffer<bool>::const_iterator it = history.frames.begin();
+	     it != history.frames.end();
+	     it++) {
+		debug_string += *it ? "#" : ".";
+		count += *it ? 1 : -1;
+	}
 
-  if (count < 0) {
-    history.state.push_front(false);
-  } else if (count > 0) {
-    history.state.push_front(true);
-  } else {
-    history.state.push_front(history.state.front());
-  }
+	if (count < 0) {
+		history.state.push_front(false);
+	} else if (count > 0) {
+		history.state.push_front(true);
+	} else {
+		history.state.push_front(history.state.front());
+	}
 
-  debug_string += " -> ";
+	debug_string += " -> ";
 
-  unsigned int num_changes = 0;
-  if (!history.state.empty()) {
-    boost::circular_buffer<bool>::const_iterator it = history.state.begin();
-    bool last_state = *it;
-    while (it != history.state.end()) {
-      debug_string += *it ? "#" : ".";
-      if (*it != last_state) {
-        num_changes++;
-      }
-      last_state = *it;
-      ++it;
-    }
-  }
+	unsigned int num_changes = 0;
+	if (!history.state.empty()) {
+		boost::circular_buffer<bool>::const_iterator it         = history.state.begin();
+		bool                                         last_state = *it;
+		while (it != history.state.end()) {
+			debug_string += *it ? "#" : ".";
+			if (*it != last_state) {
+				num_changes++;
+			}
+			last_state = *it;
+			++it;
+		}
+	}
 
-  if (history.state.size() < state_buflen_) {
-    return fawkes::RobotinoLightInterface::UNKNOWN;
-  }
-  if (num_changes >= 2)
-    return fawkes::RobotinoLightInterface::BLINKING;
-  else
-    return history.state.front() ? fawkes::RobotinoLightInterface::ON
-                                 : fawkes::RobotinoLightInterface::OFF;
+	if (history.state.size() < state_buflen_) {
+		return fawkes::RobotinoLightInterface::UNKNOWN;
+	}
+	if (num_changes >= 2)
+		return fawkes::RobotinoLightInterface::BLINKING;
+	else
+		return history.state.front() ? fawkes::RobotinoLightInterface::ON
+		                             : fawkes::RobotinoLightInterface::OFF;
 }
 
-void SignalState::update_geometry(
-    std::list<signal_rois_t_>::iterator const &new_signal_rois) {
-  signal_rois_history_.red_roi->update(*(new_signal_rois->red_roi));
-  signal_rois_history_.yellow_roi->update(*(new_signal_rois->yellow_roi));
-  signal_rois_history_.green_roi->update(*(new_signal_rois->green_roi));
+void
+SignalState::update_geometry(std::list<signal_rois_t_>::iterator const &new_signal_rois)
+{
+	signal_rois_history_.red_roi->update(*(new_signal_rois->red_roi));
+	signal_rois_history_.yellow_roi->update(*(new_signal_rois->yellow_roi));
+	signal_rois_history_.green_roi->update(*(new_signal_rois->green_roi));
 
-  area = signal_rois_history_.red_roi->width *
-             signal_rois_history_.red_roi->height +
-         signal_rois_history_.yellow_roi->width *
-             signal_rois_history_.yellow_roi->height +
-         signal_rois_history_.green_roi->width *
-             signal_rois_history_.green_roi->height;
+	area = signal_rois_history_.red_roi->width * signal_rois_history_.red_roi->height
+	       + signal_rois_history_.yellow_roi->width * signal_rois_history_.yellow_roi->height
+	       + signal_rois_history_.green_roi->width * signal_rois_history_.green_roi->height;
 
-  pos.x = signal_rois_history_.yellow_roi->start.x +
-          signal_rois_history_.yellow_roi->width / 2;
-  pos.y = signal_rois_history_.yellow_roi->start.y +
-          signal_rois_history_.yellow_roi->height / 2;
+	pos.x = signal_rois_history_.yellow_roi->start.x + signal_rois_history_.yellow_roi->width / 2;
+	pos.y = signal_rois_history_.yellow_roi->start.y + signal_rois_history_.yellow_roi->height / 2;
 
-  if (new_signal_rois->world_pos) {
-    world_pos = std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>>(
-        new_signal_rois->world_pos);
-  }
+	if (new_signal_rois->world_pos) {
+		world_pos = std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>>(new_signal_rois->world_pos);
+	}
 }
 
-void SignalState::update_state(frame_state_t_ const &cur_state) {
-  history_R_.frames.push_front(cur_state.red);
-  history_Y_.frames.push_front(cur_state.yellow);
-  history_G_.frames.push_front(cur_state.green);
+void
+SignalState::update_state(frame_state_t_ const &cur_state)
+{
+	history_R_.frames.push_front(cur_state.red);
+	history_Y_.frames.push_front(cur_state.yellow);
+	history_G_.frames.push_front(cur_state.green);
 
-  unseen = 0;
+	unseen = 0;
 
-  fawkes::RobotinoLightInterface::LightState new_red, new_yellow, new_green;
-  new_red = eval_history(history_R_, debug_R_);
-  new_yellow = eval_history(history_Y_, debug_Y_);
-  new_green = eval_history(history_G_, debug_G_);
+	fawkes::RobotinoLightInterface::LightState new_red, new_yellow, new_green;
+	new_red    = eval_history(history_R_, debug_R_);
+	new_yellow = eval_history(history_Y_, debug_Y_);
+	new_green  = eval_history(history_G_, debug_G_);
 
-  // decrease visibility history if:
-  // - All lights are off or
-  // - One is unknown or
-  // - A light changes from something other than unknown
-  if ((new_red == fawkes::RobotinoLightInterface::OFF &&
-       new_yellow == fawkes::RobotinoLightInterface::OFF &&
-       new_green == fawkes::RobotinoLightInterface::OFF) ||
-      new_red == fawkes::RobotinoLightInterface::UNKNOWN ||
-      new_yellow == fawkes::RobotinoLightInterface::UNKNOWN ||
-      new_green == fawkes::RobotinoLightInterface::UNKNOWN ||
-      (red != fawkes::RobotinoLightInterface::UNKNOWN && new_red != red) ||
-      (yellow != fawkes::RobotinoLightInterface::UNKNOWN &&
-       new_yellow != yellow) ||
-      (green != fawkes::RobotinoLightInterface::UNKNOWN &&
-       new_green != green)) {
-    if (visibility >= 0)
-      visibility = -1;
-    else
-      visibility--;
-  } else {
-    if (unlikely(visibility < 0))
-      visibility = 1;
-    else
-      visibility++;
-  }
-  red = new_red;
-  yellow = new_yellow;
-  green = new_green;
+	// decrease visibility history if:
+	// - All lights are off or
+	// - One is unknown or
+	// - A light changes from something other than unknown
+	if ((new_red == fawkes::RobotinoLightInterface::OFF
+	     && new_yellow == fawkes::RobotinoLightInterface::OFF
+	     && new_green == fawkes::RobotinoLightInterface::OFF)
+	    || new_red == fawkes::RobotinoLightInterface::UNKNOWN
+	    || new_yellow == fawkes::RobotinoLightInterface::UNKNOWN
+	    || new_green == fawkes::RobotinoLightInterface::UNKNOWN
+	    || (red != fawkes::RobotinoLightInterface::UNKNOWN && new_red != red)
+	    || (yellow != fawkes::RobotinoLightInterface::UNKNOWN && new_yellow != yellow)
+	    || (green != fawkes::RobotinoLightInterface::UNKNOWN && new_green != green)) {
+		if (visibility >= 0)
+			visibility = -1;
+		else
+			visibility--;
+	} else {
+		if (unlikely(visibility < 0))
+			visibility = 1;
+		else
+			visibility++;
+	}
+	red    = new_red;
+	yellow = new_yellow;
+	green  = new_green;
 
-  ready = (visibility >= (long int)state_buflen_);
+	ready = (visibility >= (long int)state_buflen_);
 }

--- a/src/plugins/attic/machine-signal/state.h
+++ b/src/plugins/attic/machine-signal/state.h
@@ -21,117 +21,133 @@
 #ifndef __PLUGINS_MACHINE_SIGNAL_STATE_H_
 #define __PLUGINS_MACHINE_SIGNAL_STATE_H_
 
-#include <boost/circular_buffer.hpp>
+#include "custom_rois.h"
+
 #include <fvutils/base/roi.h>
 #include <interfaces/RobotinoLightInterface.h>
 #include <logging/logger.h>
-#include <set>
 #include <tf/transformer.h>
 
-#include "custom_rois.h"
+#include <boost/circular_buffer.hpp>
+#include <set>
 
 #define likely(x) __builtin_expect((x), 1)
 #define unlikely(x) __builtin_expect((x), 0)
 
-class SignalState {
+class SignalState
+{
 public:
-  typedef struct {
-    std::shared_ptr<firevision::ROI> red_roi;
-    std::shared_ptr<firevision::ROI> yellow_roi;
-    std::shared_ptr<firevision::ROI> green_roi;
-    std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>> world_pos;
-    float truth;
-  } signal_rois_t_;
+	typedef struct
+	{
+		std::shared_ptr<firevision::ROI>                        red_roi;
+		std::shared_ptr<firevision::ROI>                        yellow_roi;
+		std::shared_ptr<firevision::ROI>                        green_roi;
+		std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>> world_pos;
+		float                                                   truth;
+	} signal_rois_t_;
 
-  typedef struct {
-    std::shared_ptr<firevision::HistoricSmoothROI> red_roi;
-    std::shared_ptr<firevision::HistoricSmoothROI> yellow_roi;
-    std::shared_ptr<firevision::HistoricSmoothROI> green_roi;
-    std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>> world_pos;
-    float truth;
-  } historic_signal_rois_t_;
+	typedef struct
+	{
+		std::shared_ptr<firevision::HistoricSmoothROI>          red_roi;
+		std::shared_ptr<firevision::HistoricSmoothROI>          yellow_roi;
+		std::shared_ptr<firevision::HistoricSmoothROI>          green_roi;
+		std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>> world_pos;
+		float                                                   truth;
+	} historic_signal_rois_t_;
 
-  SignalState(unsigned int buflen, fawkes::Logger *logger,
-              historic_signal_rois_t_ &signal);
+	SignalState(unsigned int buflen, fawkes::Logger *logger, historic_signal_rois_t_ &signal);
 
-  typedef struct {
-    bool red;
-    bool yellow;
-    bool green;
-  } frame_state_t_;
+	typedef struct
+	{
+		bool red;
+		bool yellow;
+		bool green;
+	} frame_state_t_;
 
-  struct compare_rois_by_area {
-    bool operator()(firevision::ROI const &r1, firevision::ROI const &r2) {
-      unsigned int a1 = r1.width * r1.height;
-      unsigned int a2 = r2.width * r2.height;
-      return a1 >= a2;
-    }
-  }; // sort_rois_by_area_;
+	struct compare_rois_by_area
+	{
+		bool
+		operator()(firevision::ROI const &r1, firevision::ROI const &r2)
+		{
+			unsigned int a1 = r1.width * r1.height;
+			unsigned int a2 = r2.width * r2.height;
+			return a1 >= a2;
+		}
+	}; // sort_rois_by_area_;
 
-  struct compare_signal_states_by_visibility {
-    bool operator()(SignalState const &s1, SignalState const &s2) {
-      return s1.visibility > s2.visibility;
-    }
-  }; // sort_signal_states_by_visibility_;
+	struct compare_signal_states_by_visibility
+	{
+		bool
+		operator()(SignalState const &s1, SignalState const &s2)
+		{
+			return s1.visibility > s2.visibility;
+		}
+	}; // sort_signal_states_by_visibility_;
 
-  struct compare_signal_states_by_x {
-    bool operator()(SignalState const &s1, SignalState const &s2) {
-      return s1.pos.x <= s2.pos.x;
-    }
-  }; // sort_signal_states_by_x_;
+	struct compare_signal_states_by_x
+	{
+		bool
+		operator()(SignalState const &s1, SignalState const &s2)
+		{
+			return s1.pos.x <= s2.pos.x;
+		}
+	}; // sort_signal_states_by_x_;
 
-  struct compare_signal_states_by_area {
-    bool operator()(SignalState const &s1, SignalState const &s2) {
-      if ((s1.visibility < 0) == (s2.visibility < 0)) {
-        float size_ratio = (float)s1.area / (float)s2.area;
-        if (size_ratio < 1.5 && size_ratio > 0.67)
-          return s1.pos.x <= s2.pos.x;
-        else
-          return s1.area > s2.area;
-      } else
-        return s1.visibility > 0;
-    }
-  }; // sort_signal_states_by_area_;
+	struct compare_signal_states_by_area
+	{
+		bool
+		operator()(SignalState const &s1, SignalState const &s2)
+		{
+			if ((s1.visibility < 0) == (s2.visibility < 0)) {
+				float size_ratio = (float)s1.area / (float)s2.area;
+				if (size_ratio < 1.5 && size_ratio > 0.67)
+					return s1.pos.x <= s2.pos.x;
+				else
+					return s1.area > s2.area;
+			} else
+				return s1.visibility > 0;
+		}
+	}; // sort_signal_states_by_area_;
 
 private:
-  typedef struct {
-    boost::circular_buffer<bool> frames;
-    boost::circular_buffer<bool> state;
-  } light_history_t_;
+	typedef struct
+	{
+		boost::circular_buffer<bool> frames;
+		boost::circular_buffer<bool> state;
+	} light_history_t_;
 
-  light_history_t_ history_R_;
-  light_history_t_ history_Y_;
-  light_history_t_ history_G_;
-  unsigned int buflen_;
-  unsigned int state_buflen_;
-  std::string debug_R_;
-  std::string debug_Y_;
-  std::string debug_G_;
-  fawkes::Logger *logger_;
+	light_history_t_ history_R_;
+	light_history_t_ history_Y_;
+	light_history_t_ history_G_;
+	unsigned int     buflen_;
+	unsigned int     state_buflen_;
+	std::string      debug_R_;
+	std::string      debug_Y_;
+	std::string      debug_G_;
+	fawkes::Logger * logger_;
 
-  fawkes::RobotinoLightInterface::LightState
-  eval_history(light_history_t_ &history, std::string &debug_str);
+	fawkes::RobotinoLightInterface::LightState eval_history(light_history_t_ &history,
+	                                                        std::string &     debug_str);
 
 public:
-  fawkes::RobotinoLightInterface::LightState red;
-  fawkes::RobotinoLightInterface::LightState yellow;
-  fawkes::RobotinoLightInterface::LightState green;
-  fawkes::upoint_t pos;
-  int visibility;
-  bool ready;
-  int unseen;
-  unsigned int area;
-  std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>> world_pos;
-  historic_signal_rois_t_ signal_rois_history_;
+	fawkes::RobotinoLightInterface::LightState              red;
+	fawkes::RobotinoLightInterface::LightState              yellow;
+	fawkes::RobotinoLightInterface::LightState              green;
+	fawkes::upoint_t                                        pos;
+	int                                                     visibility;
+	bool                                                    ready;
+	int                                                     unseen;
+	unsigned int                                            area;
+	std::shared_ptr<fawkes::tf::Stamped<fawkes::tf::Point>> world_pos;
+	historic_signal_rois_t_                                 signal_rois_history_;
 
-  char const *get_debug_R();
-  char const *get_debug_Y();
-  char const *get_debug_G();
-  void
-  inc_unseen(std::set<firevision::WorldROI, compare_rois_by_area> &laser_rois);
-  void update_geometry(std::list<signal_rois_t_>::iterator const &rois);
-  void update_state(frame_state_t_ const &s);
-  float distance(std::list<signal_rois_t_>::iterator const &s);
+	char const *get_debug_R();
+	char const *get_debug_Y();
+	char const *get_debug_G();
+	void        inc_unseen(std::set<firevision::WorldROI, compare_rois_by_area> &laser_rois);
+	void        update_geometry(std::list<signal_rois_t_>::iterator const &rois);
+	void        update_state(frame_state_t_ const &s);
+	float       distance(std::list<signal_rois_t_>::iterator const &s);
 };
 
 #endif /* __PLUGINS_MACHINE_SIGNAL_STATE_H_ */

--- a/src/plugins/attic/machinedetection/Blob.cpp
+++ b/src/plugins/attic/machinedetection/Blob.cpp
@@ -19,104 +19,157 @@
  */
 
 #include "Blob.h"
+
 #include <algorithm>
 
-Blob::Blob(unsigned char *buffer, int buffer_width, int buffer_height,
-           int threshold, int x, int y)
-    : buffer_(buffer), buffer_width_(buffer_width),
-      buffer_height_(buffer_height), threshold_(threshold), center_x_(x),
-      center_y_(y) {
-  lower_y_ = center_y_;
-  upper_y_ = center_y_;
+Blob::Blob(unsigned char *buffer, int buffer_width, int buffer_height, int threshold, int x, int y)
+: buffer_(buffer),
+  buffer_width_(buffer_width),
+  buffer_height_(buffer_height),
+  threshold_(threshold),
+  center_x_(x),
+  center_y_(y)
+{
+	lower_y_ = center_y_;
+	upper_y_ = center_y_;
 
-  left_x_ = center_x_;
-  right_x_ = center_x_;
+	left_x_  = center_x_;
+	right_x_ = center_x_;
 }
 
-Blob::~Blob() {
-  // TODO Auto-generated destructor stub
+Blob::~Blob()
+{
+	// TODO Auto-generated destructor stub
 }
 
-int Blob::getDiameter() const {
-  return (std::min(right_x_ - left_x_, lower_y_ - upper_y_));
+int
+Blob::getDiameter() const
+{
+	return (std::min(right_x_ - left_x_, lower_y_ - upper_y_));
 }
 
 /**
  * expands the blob in all directions.
  */
-void Blob::grow() {
-  grow_left();
-  grow_right();
-  grow_up();
-  grow_down();
+void
+Blob::grow()
+{
+	grow_left();
+	grow_right();
+	grow_up();
+	grow_down();
 }
 
-void Blob::grow_left() {
-  while (buffer_[center_y_ * buffer_width_ + left_x_] == 255) {
-    if (left_x_ > 0) {
-      left_x_--;
-    } else {
-      return;
-    }
-    return;
-  }
+void
+Blob::grow_left()
+{
+	while (buffer_[center_y_ * buffer_width_ + left_x_] == 255) {
+		if (left_x_ > 0) {
+			left_x_--;
+		} else {
+			return;
+		}
+		return;
+	}
 }
 
-void Blob::grow_right() {
-  while (buffer_[center_y_ * buffer_width_ + right_x_] == 255) {
-    if (right_x_ < buffer_width_) {
-      right_x_++;
-    } else {
-      return;
-    }
-    return;
-  }
+void
+Blob::grow_right()
+{
+	while (buffer_[center_y_ * buffer_width_ + right_x_] == 255) {
+		if (right_x_ < buffer_width_) {
+			right_x_++;
+		} else {
+			return;
+		}
+		return;
+	}
 }
 
-void Blob::grow_up() {
-  while (buffer_[upper_y_ * buffer_width_ + center_x_] == 255) {
-    if (upper_y_ > 0) {
-      upper_y_--;
-    } else {
-      return;
-    }
-    return;
-  }
+void
+Blob::grow_up()
+{
+	while (buffer_[upper_y_ * buffer_width_ + center_x_] == 255) {
+		if (upper_y_ > 0) {
+			upper_y_--;
+		} else {
+			return;
+		}
+		return;
+	}
 }
 
-int Blob::getCenterX() {
-  center_x_ = left_x_ + (right_x_ - left_x_ / 2);
-  return center_x_;
+int
+Blob::getCenterX()
+{
+	center_x_ = left_x_ + (right_x_ - left_x_ / 2);
+	return center_x_;
 }
 
-int Blob::getCenterY() {
-  center_y_ = upper_y_ + (lower_y_ - upper_y_ / 2);
-  return center_y_;
+int
+Blob::getCenterY()
+{
+	center_y_ = upper_y_ + (lower_y_ - upper_y_ / 2);
+	return center_y_;
 }
 
-int Blob::getLeftX() const { return left_x_; }
+int
+Blob::getLeftX() const
+{
+	return left_x_;
+}
 
-int Blob::getLowerY() const { return lower_y_; }
+int
+Blob::getLowerY() const
+{
+	return lower_y_;
+}
 
-int Blob::getRightX() const { return right_x_; }
+int
+Blob::getRightX() const
+{
+	return right_x_;
+}
 
-int Blob::getUpperY() const { return upper_y_; }
+int
+Blob::getUpperY() const
+{
+	return upper_y_;
+}
 
-void Blob::setLeftX(int leftX) { left_x_ = leftX; }
+void
+Blob::setLeftX(int leftX)
+{
+	left_x_ = leftX;
+}
 
-void Blob::setLowerY(int lowerY) { lower_y_ = lowerY; }
+void
+Blob::setLowerY(int lowerY)
+{
+	lower_y_ = lowerY;
+}
 
-void Blob::setRightX(int rightX) { right_x_ = rightX; }
+void
+Blob::setRightX(int rightX)
+{
+	right_x_ = rightX;
+}
 
-void Blob::setUpperY(int upperY) { upper_y_ = upperY; }
+void
+Blob::setUpperY(int upperY)
+{
+	upper_y_ = upperY;
+}
 
-void Blob::grow_down() {
-  while (buffer_[lower_y_ * buffer_width_ + center_x_] == 255) {
-    if (lower_y_ < buffer_height_) {
-      lower_y_++;
-    } else {
-      return;
-    }
-    return;
-  }
+void
+Blob::grow_down()
+{
+	while (buffer_[lower_y_ * buffer_width_ + center_x_] == 255) {
+		if (lower_y_ < buffer_height_) {
+			lower_y_++;
+		} else {
+			return;
+		}
+		return;
+	}
 }

--- a/src/plugins/attic/machinedetection/Blob.h
+++ b/src/plugins/attic/machinedetection/Blob.h
@@ -23,39 +23,39 @@
 
 #include <string>
 
-class Blob {
+class Blob
+{
 public:
-  Blob(unsigned char *buffer, int buffer_width, int buffer_height,
-       int threshold, int x, int y);
-  virtual ~Blob();
-  void grow();
-  int getCenterX();
-  int getCenterY();
-  int getLeftX() const;
-  int getLowerY() const;
-  int getRightX() const;
-  int getUpperY() const;
-  int getDiameter() const;
-  void setLeftX(int leftX);
-  void setLowerY(int lowerY);
-  void setRightX(int rightX);
-  void setUpperY(int upperY);
+	Blob(unsigned char *buffer, int buffer_width, int buffer_height, int threshold, int x, int y);
+	virtual ~Blob();
+	void grow();
+	int  getCenterX();
+	int  getCenterY();
+	int  getLeftX() const;
+	int  getLowerY() const;
+	int  getRightX() const;
+	int  getUpperY() const;
+	int  getDiameter() const;
+	void setLeftX(int leftX);
+	void setLowerY(int lowerY);
+	void setRightX(int rightX);
+	void setUpperY(int upperY);
 
 private:
-  unsigned char *buffer_;
-  int buffer_width_;
-  int buffer_height_;
-  int threshold_;
-  int center_x_;
-  int center_y_;
-  int left_x_;
-  int right_x_;
-  int upper_y_;
-  int lower_y_;
-  void grow_left();
-  void grow_right();
-  void grow_up();
-  void grow_down();
+	unsigned char *buffer_;
+	int            buffer_width_;
+	int            buffer_height_;
+	int            threshold_;
+	int            center_x_;
+	int            center_y_;
+	int            left_x_;
+	int            right_x_;
+	int            upper_y_;
+	int            lower_y_;
+	void           grow_left();
+	void           grow_right();
+	void           grow_up();
+	void           grow_down();
 };
 
 #endif /* BLOB_H_ */

--- a/src/plugins/attic/machinedetection/BlobFarm.cpp
+++ b/src/plugins/attic/machinedetection/BlobFarm.cpp
@@ -19,91 +19,116 @@
  */
 
 #include "BlobFarm.h"
+
 #include <cmath>
 #include <cstdlib>
 
 using namespace std;
 
-BlobFarm::BlobFarm(unsigned char *buffer, int buffer_width, int buffer_height,
-                   int min_diam, int max_diam, int merge_distance,
-                   int threshold)
-    : buffer_(buffer), buffer_width_(buffer_width),
-      buffer_height_(buffer_width), min_diam_(min_diam), max_diam_(max_diam),
-      merge_distance_(merge_distance), threshold_(threshold) {
-  // TODO Auto-generated constructor stub
+BlobFarm::BlobFarm(unsigned char *buffer,
+                   int            buffer_width,
+                   int            buffer_height,
+                   int            min_diam,
+                   int            max_diam,
+                   int            merge_distance,
+                   int            threshold)
+: buffer_(buffer),
+  buffer_width_(buffer_width),
+  buffer_height_(buffer_width),
+  min_diam_(min_diam),
+  max_diam_(max_diam),
+  merge_distance_(merge_distance),
+  threshold_(threshold)
+{
+	// TODO Auto-generated constructor stub
 }
 
-void BlobFarm::add_Blob(Blob *blob) { blobs.push_back(blob); }
-
-void BlobFarm::add_Blob(int x, int y) {
-  Blob *blob =
-      new Blob(buffer_, buffer_width_, buffer_height_, threshold_, x, y);
-  blobs.push_back(blob);
+void
+BlobFarm::add_Blob(Blob *blob)
+{
+	blobs.push_back(blob);
 }
 
-void BlobFarm::grow_blobs() {
-  for (list<Blob *>::iterator it = blobs.begin(); it != blobs.end(); ++it) {
-    (*it)->grow();
-  }
+void
+BlobFarm::add_Blob(int x, int y)
+{
+	Blob *blob = new Blob(buffer_, buffer_width_, buffer_height_, threshold_, x, y);
+	blobs.push_back(blob);
 }
 
-list<Blob *> BlobFarm::get_valid_blobs() {
-  grow_blobs();
-  merge_blobs();
-  filter_blobs();
-  list<Blob *> blobcopy(blobs);
-  return blobcopy;
+void
+BlobFarm::grow_blobs()
+{
+	for (list<Blob *>::iterator it = blobs.begin(); it != blobs.end(); ++it) {
+		(*it)->grow();
+	}
 }
 
-void BlobFarm::filter_blobs() {
-  list<Blob *>::iterator it = blobs.begin();
-  while (it != blobs.end()) {
-    int diameter = (*it)->getDiameter();
-    if (diameter < min_diam_ || diameter > max_diam_) {
-      blobs.erase(it);
-    } else {
-      it++;
-    }
-  }
+list<Blob *>
+BlobFarm::get_valid_blobs()
+{
+	grow_blobs();
+	merge_blobs();
+	filter_blobs();
+	list<Blob *> blobcopy(blobs);
+	return blobcopy;
 }
 
-void BlobFarm::merge_blobs() {
-  list<Blob *>::iterator it1, it2;
-  for (it1 = blobs.begin(); it1 != blobs.end(); ++it1) {
-    it2 = it1;
-    it2++; // we don't want to compare it with itsself
-    while (it2 != blobs.end()) {
-      if (it1 != it2) {
-        double first_radius = (*it1)->getDiameter() / 2.0;
-        double sec_radius = (*it2)->getDiameter() / 2.0;
-        if ((abs((*it1)->getCenterX() - (*it2)->getCenterX()) <
-             first_radius + sec_radius + merge_distance_) &&
-            (abs((*it1)->getCenterY() - (*it2)->getCenterY()) <
-             first_radius + sec_radius + merge_distance_)) {
-          blobs.push_back(merge_blob(*it1, *it2));
-          blobs.erase(it1);
-          blobs.erase(it2);
-          it2 = blobs.begin();
-        } else {
-          it2++;
-        }
-      }
-    }
-  }
+void
+BlobFarm::filter_blobs()
+{
+	list<Blob *>::iterator it = blobs.begin();
+	while (it != blobs.end()) {
+		int diameter = (*it)->getDiameter();
+		if (diameter < min_diam_ || diameter > max_diam_) {
+			blobs.erase(it);
+		} else {
+			it++;
+		}
+	}
 }
 
-Blob *BlobFarm::merge_blob(Blob *first, Blob *second) {
-  int x = round(abs(first->getCenterX() - second->getCenterX()) / 2.0);
-  int y = round(abs(first->getCenterY() - second->getCenterY()) / 2.0);
-  Blob *merged =
-      new Blob(buffer_, buffer_width_, buffer_height_, threshold_, x, y);
-  merged->setLeftX(min(first->getLeftX(), second->getLeftX()));
-  merged->setRightX(max(first->getRightX(), second->getRightX()));
-  merged->setUpperY(min(first->getUpperY(), second->getUpperY()));
-  merged->setLowerY(max(first->getLowerY(), second->getLowerY()));
-  return merged;
+void
+BlobFarm::merge_blobs()
+{
+	list<Blob *>::iterator it1, it2;
+	for (it1 = blobs.begin(); it1 != blobs.end(); ++it1) {
+		it2 = it1;
+		it2++; // we don't want to compare it with itsself
+		while (it2 != blobs.end()) {
+			if (it1 != it2) {
+				double first_radius = (*it1)->getDiameter() / 2.0;
+				double sec_radius   = (*it2)->getDiameter() / 2.0;
+				if ((abs((*it1)->getCenterX() - (*it2)->getCenterX())
+				     < first_radius + sec_radius + merge_distance_)
+				    && (abs((*it1)->getCenterY() - (*it2)->getCenterY())
+				        < first_radius + sec_radius + merge_distance_)) {
+					blobs.push_back(merge_blob(*it1, *it2));
+					blobs.erase(it1);
+					blobs.erase(it2);
+					it2 = blobs.begin();
+				} else {
+					it2++;
+				}
+			}
+		}
+	}
 }
 
-BlobFarm::~BlobFarm() {
-  // TODO Auto-generated destructor stub
+Blob *
+BlobFarm::merge_blob(Blob *first, Blob *second)
+{
+	int   x      = round(abs(first->getCenterX() - second->getCenterX()) / 2.0);
+	int   y      = round(abs(first->getCenterY() - second->getCenterY()) / 2.0);
+	Blob *merged = new Blob(buffer_, buffer_width_, buffer_height_, threshold_, x, y);
+	merged->setLeftX(min(first->getLeftX(), second->getLeftX()));
+	merged->setRightX(max(first->getRightX(), second->getRightX()));
+	merged->setUpperY(min(first->getUpperY(), second->getUpperY()));
+	merged->setLowerY(max(first->getLowerY(), second->getLowerY()));
+	return merged;
+}
+
+BlobFarm::~BlobFarm()
+{
+	// TODO Auto-generated destructor stub
 }

--- a/src/plugins/attic/machinedetection/BlobFarm.h
+++ b/src/plugins/attic/machinedetection/BlobFarm.h
@@ -22,31 +22,38 @@
 #define BLOBFARM_H_
 
 #include "Blob.h"
+
 #include <list>
 
-class BlobFarm {
+class BlobFarm
+{
 public:
-  BlobFarm(unsigned char *buffer, int buffer_width, int buffer_height,
-           int min_diam, int max_diam, int merge_distance, int threshold);
-  virtual ~BlobFarm();
-  void add_Blob(Blob *blob);
-  void add_Blob(int x, int y);
-  std::list<Blob *> get_valid_blobs();
+	BlobFarm(unsigned char *buffer,
+	         int            buffer_width,
+	         int            buffer_height,
+	         int            min_diam,
+	         int            max_diam,
+	         int            merge_distance,
+	         int            threshold);
+	virtual ~BlobFarm();
+	void              add_Blob(Blob *blob);
+	void              add_Blob(int x, int y);
+	std::list<Blob *> get_valid_blobs();
 
 private:
-  void grow_blobs();
-  void merge_blobs();
-  void filter_blobs();
-  Blob *merge_blob(Blob *first, Blob *second);
-  unsigned char *buffer_;
+	void           grow_blobs();
+	void           merge_blobs();
+	void           filter_blobs();
+	Blob *         merge_blob(Blob *first, Blob *second);
+	unsigned char *buffer_;
 
-  int buffer_width_;
-  int buffer_height_;
-  int min_diam_;
-  int max_diam_;
-  int merge_distance_;
-  int threshold_;
-  std::list<Blob *> blobs;
+	int               buffer_width_;
+	int               buffer_height_;
+	int               min_diam_;
+	int               max_diam_;
+	int               merge_distance_;
+	int               threshold_;
+	std::list<Blob *> blobs;
 };
 
 #endif /* BLOBFARM_H_ */

--- a/src/plugins/attic/machinedetection/machinedetection_plugin.cpp
+++ b/src/plugins/attic/machinedetection/machinedetection_plugin.cpp
@@ -33,14 +33,16 @@ using namespace fawkes;
  * brightest spot!
  * @author Daniel Ewert
  */
-class RobotinoMachineDetectionPlugin : public fawkes::Plugin {
+class RobotinoMachineDetectionPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  RobotinoMachineDetectionPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new RobotinoMachineDetectionThread());
-  }
+	RobotinoMachineDetectionPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new RobotinoMachineDetectionThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Robotino Machine detection image processing")

--- a/src/plugins/attic/machinedetection/machinedetection_thread.cpp
+++ b/src/plugins/attic/machinedetection/machinedetection_thread.cpp
@@ -22,23 +22,20 @@
 
 #include "machinedetection_thread.h"
 
+#include <fvcams/camera.h>
+#include <fvmodels/scanlines/grid.h>
 #include <fvutils/color/conversions.h>
 #include <fvutils/draw/drawer.h>
 #include <fvutils/ipc/shm_image.h>
-
-#include <fvmodels/scanlines/grid.h>
-
-#include <fvcams/camera.h>
 #include <interfaces/Position3DInterface.h>
 #include <interfaces/SwitchInterface.h>
-
-#include <cmath>
-#include <cstdio>
-#include <stdlib.h>
 #include <utils/math/angle.h> //diff angle
 #include <utils/math/coord.h> //cart2polar2d
 #include <utils/system/hostinfo.h>
 
+#include <cmath>
+#include <cstdio>
+#include <stdlib.h>
 #include <string>
 
 using namespace std;
@@ -53,78 +50,87 @@ using namespace firevision;
 
 /** Constructor. */
 RobotinoMachineDetectionThread::RobotinoMachineDetectionThread()
-    : Thread("RobotinoMachineDetectionThread", Thread::OPMODE_WAITFORWAKEUP),
-      VisionAspect(VisionAspect::CYCLIC) {}
+: Thread("RobotinoMachineDetectionThread", Thread::OPMODE_WAITFORWAKEUP),
+  VisionAspect(VisionAspect::CYCLIC)
+{
+}
 
 /** Destructor. */
-RobotinoMachineDetectionThread::~RobotinoMachineDetectionThread() {}
+RobotinoMachineDetectionThread::~RobotinoMachineDetectionThread()
+{
+}
 
 /** Initialize the pipeline thread.
  * Camera is requested, config parameters are set.
  */
-void RobotinoMachineDetectionThread::init() {
-  // receive a camera
-  logger->log_debug(name(), "starting up");
-  cam_ = vision_master->register_for_camera(
-      "v4l2:front:device=/dev/"
-      "video0:format=YUYV:size=160x120:white_balance_temperature_auto=0:"
-      "exposure_auto=1:exposure_absolute=305",
-      this);
-  pic_width_ = cam_->pixel_width();
-  pic_height_ = cam_->pixel_height();
-  // pic_colorspace_ = YUV422_PLANAR;
-  pic_colorspace_ = cam_->colorspace();
+void
+RobotinoMachineDetectionThread::init()
+{
+	// receive a camera
+	logger->log_debug(name(), "starting up");
+	cam_ = vision_master->register_for_camera(
+	  "v4l2:front:device=/dev/"
+	  "video0:format=YUYV:size=160x120:white_balance_temperature_auto=0:"
+	  "exposure_auto=1:exposure_absolute=305",
+	  this);
+	pic_width_  = cam_->pixel_width();
+	pic_height_ = cam_->pixel_height();
+	// pic_colorspace_ = YUV422_PLANAR;
+	pic_colorspace_ = cam_->colorspace();
 
-  full_image_roi_ = ROI::full_image(pic_width_, pic_height_);
+	full_image_roi_ = ROI::full_image(pic_width_, pic_height_);
 
-  shm_buffer_ = new SharedMemoryImageBuffer("machinedetection", pic_colorspace_,
-                                            pic_width_, pic_height_);
-  buffer_ = shm_buffer_->buffer();
+	shm_buffer_ =
+	  new SharedMemoryImageBuffer("machinedetection", pic_colorspace_, pic_width_, pic_height_);
+	buffer_ = shm_buffer_->buffer();
 
-  scanlinegrid_ =
-      new ScanlineGrid(pic_width_, pic_height_, 5, 5, full_image_roi_);
+	scanlinegrid_ = new ScanlineGrid(pic_width_, pic_height_, 5, 5, full_image_roi_);
 
-  blobFarm = new BlobFarm(buffer_, pic_width_, pic_height_, 3, 20, 2, 200);
-  logger->log_debug(name(), "init complete");
+	blobFarm = new BlobFarm(buffer_, pic_width_, pic_height_, 3, 20, 2, 200);
+	logger->log_debug(name(), "init complete");
 }
 
 /** Thread finalization. */
-void RobotinoMachineDetectionThread::finalize() {}
+void
+RobotinoMachineDetectionThread::finalize()
+{
+}
 
 /** Process image to detect objects.
  * Retrieves a new image from the camera and uses the classifier
  * determine objects according to the colormap. Publish the
  * position of the closest such object as puck position.
  */
-void RobotinoMachineDetectionThread::loop() {
-  cam_->capture();
-  buffer_ = cam_->buffer();
+void
+RobotinoMachineDetectionThread::loop()
+{
+	cam_->capture();
+	buffer_ = cam_->buffer();
 
-  // Filtered
-  logger->log_debug(name(), "Filtering done");
-  scanlinegrid_->reset();
-  while (!scanlinegrid_->finished()) {
-    unsigned char pix =
-        buffer_[(*scanlinegrid_)->y * pic_width_ + (*scanlinegrid_)->x];
-    if (pix > 200) {
-      logger->log_debug(name(), "pix(%d,%d):%d", (*scanlinegrid_)->x,
-                        (*scanlinegrid_)->y, pix);
-    }
-    if (pix > 200)
-      blobFarm->add_Blob((*scanlinegrid_)->x, (*scanlinegrid_)->y);
-    ++(*scanlinegrid_);
-  }
-  logger->log_debug(name(), "Scanning done");
-  std::list<Blob *> blobs = blobFarm->get_valid_blobs();
-  for (std::list<Blob *>::iterator it = blobs.begin(); it != blobs.end();
-       ++it) {
-    logger->log_debug(name(), "Blob:(%d|%d)/(%d|%d)", (*it)->getLeftX(),
-                      (*it)->getUpperY(), (*it)->getRightX(),
-                      (*it)->getLowerY());
-  }
+	// Filtered
+	logger->log_debug(name(), "Filtering done");
+	scanlinegrid_->reset();
+	while (!scanlinegrid_->finished()) {
+		unsigned char pix = buffer_[(*scanlinegrid_)->y * pic_width_ + (*scanlinegrid_)->x];
+		if (pix > 200) {
+			logger->log_debug(name(), "pix(%d,%d):%d", (*scanlinegrid_)->x, (*scanlinegrid_)->y, pix);
+		}
+		if (pix > 200)
+			blobFarm->add_Blob((*scanlinegrid_)->x, (*scanlinegrid_)->y);
+		++(*scanlinegrid_);
+	}
+	logger->log_debug(name(), "Scanning done");
+	std::list<Blob *> blobs = blobFarm->get_valid_blobs();
+	for (std::list<Blob *>::iterator it = blobs.begin(); it != blobs.end(); ++it) {
+		logger->log_debug(name(),
+		                  "Blob:(%d|%d)/(%d|%d)",
+		                  (*it)->getLeftX(),
+		                  (*it)->getUpperY(),
+		                  (*it)->getRightX(),
+		                  (*it)->getLowerY());
+	}
 
-  ImageDisplay *dis =
-      new ImageDisplay(pic_width_, pic_height_, "buffer_filtered");
-  dis->show(pic_colorspace_, buffer_);
-  dis->loop_until_quit();
+	ImageDisplay *dis = new ImageDisplay(pic_width_, pic_height_, "buffer_filtered");
+	dis->show(pic_colorspace_, buffer_);
+	dis->loop_until_quit();
 }

--- a/src/plugins/attic/machinedetection/machinedetection_thread.h
+++ b/src/plugins/attic/machinedetection/machinedetection_thread.h
@@ -23,12 +23,14 @@
 #ifndef __PLUGINS_ROBOTINO_AMPELVAR_PIPELINE_THREAD_H_
 #define __PLUGINS_ROBOTINO_AMPELVAR_PIPELINE_THREAD_H_
 
-#include <core/threading/thread.h>
+#include "BlobFarm.h"
 
 #include <aspect/blackboard.h>
+#include <aspect/clock.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <aspect/vision.h>
+#include <core/threading/thread.h>
 #include <fvfilters/threshold.h>
 #include <fvmodels/scanlines/grid.h>
 #include <fvutils/base/roi.h>
@@ -38,9 +40,6 @@
 #include <fvwidgets/image_display.h>
 #include <utils/math/types.h>
 
-#include <aspect/clock.h>
-
-#include "BlobFarm.h"
 #include <string>
 
 namespace firevision {
@@ -56,35 +55,36 @@ class RobotinoMachineDetectionThread : public fawkes::Thread,
                                        public fawkes::VisionAspect,
                                        public fawkes::ConfigurableAspect,
                                        public fawkes::BlackBoardAspect,
-                                       public fawkes::ClockAspect {
+                                       public fawkes::ClockAspect
+{
 public:
-  RobotinoMachineDetectionThread();
-  virtual ~RobotinoMachineDetectionThread();
+	RobotinoMachineDetectionThread();
+	virtual ~RobotinoMachineDetectionThread();
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
 private:
-  void detect_white_blobs();
+	void detect_white_blobs();
 
-  BlobFarm *blobFarm;
-  firevision::Camera *cam_;
-  firevision::SharedMemoryImageBuffer *shm_buffer_;
-  unsigned char *buffer_;
-  int pic_width_;
-  int pic_height_;
+	BlobFarm *                           blobFarm;
+	firevision::Camera *                 cam_;
+	firevision::SharedMemoryImageBuffer *shm_buffer_;
+	unsigned char *                      buffer_;
+	int                                  pic_width_;
+	int                                  pic_height_;
 
-  firevision::ROI *full_image_roi_;
+	firevision::ROI *full_image_roi_;
 
-  firevision::colorspace_t pic_colorspace_;
+	firevision::colorspace_t pic_colorspace_;
 
-  firevision::Filter *thresholdFilter_;
+	firevision::Filter *thresholdFilter_;
 
-  firevision::ScanlineModel *scanlinegrid_;
+	firevision::ScanlineModel *scanlinegrid_;
 
-  // for debugging
-  firevision::Reader *reader_;
+	// for debugging
+	firevision::Reader *reader_;
 };
 
 #endif

--- a/src/plugins/attic/navgraph-generator-llsf2014/navgraph_generator_llsf2014_plugin.cpp
+++ b/src/plugins/attic/navgraph-generator-llsf2014/navgraph_generator_llsf2014_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "navgraph_generator_llsf2014_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Automatically generate navgraph for LLSF2014
  * @author Tim Niemueller
  */
-class NavGraphGenerator2014Plugin : public fawkes::Plugin {
+class NavGraphGenerator2014Plugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  NavGraphGenerator2014Plugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new NavGraphGenerator2014Thread());
-  }
+	NavGraphGenerator2014Plugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new NavGraphGenerator2014Thread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Generate navgraph for LLSF2014 game")

--- a/src/plugins/attic/navgraph-generator-llsf2014/navgraph_generator_llsf2014_thread.cpp
+++ b/src/plugins/attic/navgraph-generator-llsf2014/navgraph_generator_llsf2014_thread.cpp
@@ -23,10 +23,11 @@
 
 #include <core/threading/mutex_locker.h>
 #include <interfaces/NavGraphGeneratorInterface.h>
-#include <limits>
-#include <memory>
 #include <navgraph/navgraph.h>
 #include <navgraph/yaml_navgraph.h>
+
+#include <limits>
+#include <memory>
 
 using namespace fawkes;
 
@@ -37,119 +38,102 @@ using namespace fawkes;
 
 /** Constructor. */
 NavGraphGenerator2014Thread::NavGraphGenerator2014Thread()
-    : Thread("NavGraphGenerator2014Thread", Thread::OPMODE_WAITFORWAKEUP) {}
+: Thread("NavGraphGenerator2014Thread", Thread::OPMODE_WAITFORWAKEUP)
+{
+}
 
 /** Destructor. */
-NavGraphGenerator2014Thread::~NavGraphGenerator2014Thread() {}
+NavGraphGenerator2014Thread::~NavGraphGenerator2014Thread()
+{
+}
 
-void NavGraphGenerator2014Thread::init() {
-  last_id_ = 0;
+void
+NavGraphGenerator2014Thread::init()
+{
+	last_id_ = 0;
 
-  navgen_if_ = blackboard->open_for_reading<NavGraphGeneratorInterface>(
-      "/navgraph-generator");
+	navgen_if_ = blackboard->open_for_reading<NavGraphGeneratorInterface>("/navgraph-generator");
 
-  navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::ClearMessage());
-  navgen_if_->msgq_enqueue(
-      new NavGraphGeneratorInterface::SetBoundingBoxMessage(-5.6, 0, 5.6, 5.6));
+	navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::ClearMessage());
+	navgen_if_->msgq_enqueue(
+	  new NavGraphGeneratorInterface::SetBoundingBoxMessage(-5.6, 0, 5.6, 5.6));
 
-  navgen_if_->msgq_enqueue(
-      new NavGraphGeneratorInterface::AddMapObstaclesMessage(0.5));
+	navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddMapObstaclesMessage(0.5));
 
-  logger->log_info(name(), "Copying");
-  std::string cfg_graph_file = config->get_string("/navgraph/graph_file");
-  if (cfg_graph_file[0] != '/') {
-    cfg_graph_file = std::string(CONFDIR) + "/" + cfg_graph_file;
-  }
-  std::shared_ptr<NavGraph> file_graph(load_yaml_navgraph(cfg_graph_file));
+	logger->log_info(name(), "Copying");
+	std::string cfg_graph_file = config->get_string("/navgraph/graph_file");
+	if (cfg_graph_file[0] != '/') {
+		cfg_graph_file = std::string(CONFDIR) + "/" + cfg_graph_file;
+	}
+	std::shared_ptr<NavGraph> file_graph(load_yaml_navgraph(cfg_graph_file));
 
-  for (unsigned int i = 1; i <= 24; ++i) {
-    NavGraphNode n = file_graph->node(NavGraph::format_name("M%u", i));
-    if (n) {
-      navgen_if_->msgq_enqueue(
-          new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-              n.name().c_str(), n.x(), n.y(),
-              NavGraphGeneratorInterface::CLOSEST_EDGE));
-    }
-  }
+	for (unsigned int i = 1; i <= 24; ++i) {
+		NavGraphNode n = file_graph->node(NavGraph::format_name("M%u", i));
+		if (n) {
+			navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+			  n.name().c_str(), n.x(), n.y(), NavGraphGeneratorInterface::CLOSEST_EDGE));
+		}
+	}
 
-  for (unsigned int i = 1; i <= 24; ++i) {
-    NavGraphNode n = file_graph->node(NavGraph::format_name("ExpM%u", i));
-    if (n) {
-      navgen_if_->msgq_enqueue(
-          new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-              n.name().c_str(), n.x(), n.y(),
-              NavGraphGeneratorInterface::CLOSEST_EDGE));
-    }
-  }
+	for (unsigned int i = 1; i <= 24; ++i) {
+		NavGraphNode n = file_graph->node(NavGraph::format_name("ExpM%u", i));
+		if (n) {
+			navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+			  n.name().c_str(), n.x(), n.y(), NavGraphGeneratorInterface::CLOSEST_EDGE));
+		}
+	}
 
-  for (unsigned int i = 1; i <= 2; ++i) {
-    for (unsigned int j = 1; i <= 2; ++i) {
-      NavGraphNode n =
-          file_graph->node(NavGraph::format_name("D%u_PUCK_STORAGE_%u", i, j));
-      if (n) {
-        navgen_if_->msgq_enqueue(
-            new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-                n.name().c_str(), n.x(), n.y(),
-                NavGraphGeneratorInterface::CLOSEST_EDGE));
-      }
-    }
-  }
+	for (unsigned int i = 1; i <= 2; ++i) {
+		for (unsigned int j = 1; i <= 2; ++i) {
+			NavGraphNode n = file_graph->node(NavGraph::format_name("D%u_PUCK_STORAGE_%u", i, j));
+			if (n) {
+				navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+				  n.name().c_str(), n.x(), n.y(), NavGraphGeneratorInterface::CLOSEST_EDGE));
+			}
+		}
+	}
 
-  for (unsigned int i = 1; i <= 2; ++i) {
-    for (unsigned int j = 1; i <= 3; ++i) {
-      NavGraphNode n = file_graph->node(
-          NavGraph::format_name("WAIT_FOR_INS_%u_ROBOTINO_%u", i, j));
-      if (n) {
-        navgen_if_->msgq_enqueue(
-            new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-                n.name().c_str(), n.x(), n.y(),
-                NavGraphGeneratorInterface::CLOSEST_EDGE));
-      }
-    }
-  }
+	for (unsigned int i = 1; i <= 2; ++i) {
+		for (unsigned int j = 1; i <= 3; ++i) {
+			NavGraphNode n = file_graph->node(NavGraph::format_name("WAIT_FOR_INS_%u_ROBOTINO_%u", i, j));
+			if (n) {
+				navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+				  n.name().c_str(), n.x(), n.y(), NavGraphGeneratorInterface::CLOSEST_EDGE));
+			}
+		}
+	}
 
-  for (unsigned int i = 1; i <= 2; ++i) {
-    NavGraphNode n = file_graph->node(NavGraph::format_name("deliver%u", i));
-    NavGraphNode n2 = file_graph->node(NavGraph::format_name("deliver%ua", i));
-    NavGraphNode n3 =
-        file_graph->node(NavGraph::format_name("WAIT_FOR_DELIVER_%u", i));
-    if (n) {
-      navgen_if_->msgq_enqueue(
-          new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-              n.name().c_str(), n.x(), n.y(),
-              NavGraphGeneratorInterface::CLOSEST_NODE));
-    }
-    if (n2) {
-      navgen_if_->msgq_enqueue(
-          new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-              n2.name().c_str(), n2.x(), n2.y(),
-              NavGraphGeneratorInterface::CLOSEST_NODE));
-    }
-    if (n3) {
-      navgen_if_->msgq_enqueue(
-          new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-              n3.name().c_str(), n3.x(), n3.y(),
-              NavGraphGeneratorInterface::CLOSEST_EDGE));
-    }
-  }
-  for (unsigned int i = 1; i <= 2; ++i) {
-    NavGraphNode n = file_graph->node(NavGraph::format_name("Ins%u", i));
-    NavGraphNode n2 = file_graph->node(NavGraph::format_name("Ins%uSec", i));
-    if (n) {
-      navgen_if_->msgq_enqueue(
-          new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-              n.name().c_str(), n.x(), n.y(),
-              NavGraphGeneratorInterface::CLOSEST_EDGE));
-    }
-    if (n2) {
-      navgen_if_->msgq_enqueue(
-          new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-              n2.name().c_str(), n2.x(), n2.y(),
-              NavGraphGeneratorInterface::CLOSEST_EDGE));
-    }
-  }
+	for (unsigned int i = 1; i <= 2; ++i) {
+		NavGraphNode n  = file_graph->node(NavGraph::format_name("deliver%u", i));
+		NavGraphNode n2 = file_graph->node(NavGraph::format_name("deliver%ua", i));
+		NavGraphNode n3 = file_graph->node(NavGraph::format_name("WAIT_FOR_DELIVER_%u", i));
+		if (n) {
+			navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+			  n.name().c_str(), n.x(), n.y(), NavGraphGeneratorInterface::CLOSEST_NODE));
+		}
+		if (n2) {
+			navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+			  n2.name().c_str(), n2.x(), n2.y(), NavGraphGeneratorInterface::CLOSEST_NODE));
+		}
+		if (n3) {
+			navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+			  n3.name().c_str(), n3.x(), n3.y(), NavGraphGeneratorInterface::CLOSEST_EDGE));
+		}
+	}
+	for (unsigned int i = 1; i <= 2; ++i) {
+		NavGraphNode n  = file_graph->node(NavGraph::format_name("Ins%u", i));
+		NavGraphNode n2 = file_graph->node(NavGraph::format_name("Ins%uSec", i));
+		if (n) {
+			navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+			  n.name().c_str(), n.x(), n.y(), NavGraphGeneratorInterface::CLOSEST_EDGE));
+		}
+		if (n2) {
+			navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+			  n2.name().c_str(), n2.x(), n2.y(), NavGraphGeneratorInterface::CLOSEST_EDGE));
+		}
+	}
 
-  /* We rely on navgraph-generator to copy the properties
+	/* We rely on navgraph-generator to copy the properties
   const std::map<std::string, std::string> &graph_props =
   file_graph->default_properties(); for (auto &p : graph_props) {
     navgen_if_->msgq_enqueue
@@ -157,18 +141,19 @@ void NavGraphGenerator2014Thread::init() {
        (p.first.c_str(), p.second.c_str()));
   }
   */
-  navgen_if_->msgq_enqueue(
-      new NavGraphGeneratorInterface::SetCopyGraphDefaultPropertiesMessage(
-          true));
+	navgen_if_->msgq_enqueue(
+	  new NavGraphGeneratorInterface::SetCopyGraphDefaultPropertiesMessage(true));
 
-  navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::ComputeMessage());
+	navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::ComputeMessage());
 }
 
 /** Add node, connect to closest edge.
  * @param n node to add
  */
-void NavGraphGenerator2014Thread::add_node_edge(const NavGraphNode &n) {
-  /*
+void
+NavGraphGenerator2014Thread::add_node_edge(const NavGraphNode &n)
+{
+	/*
   NavGraphEdge closest = navgraph->closest_edge(n.x(), n.y());
   cart_coord_2d_t p = closest.closest_point_on_edge(n.x(), n.y());
 
@@ -222,8 +207,10 @@ void NavGraphGenerator2014Thread::add_node_edge(const NavGraphNode &n) {
 /** Add node, connect to closest node.
  * @param n node to add
  */
-void NavGraphGenerator2014Thread::add_node_node(const NavGraphNode &n) {
-  /*
+void
+NavGraphGenerator2014Thread::add_node_node(const NavGraphNode &n)
+{
+	/*
   NavGraphNode closest = navgraph->closest_node(n.x(), n.y());
   closest.set_property("highway_exit", true);
   navgraph->update_node(closest);
@@ -232,10 +219,19 @@ void NavGraphGenerator2014Thread::add_node_node(const NavGraphNode &n) {
   */
 }
 
-std::string NavGraphGenerator2014Thread::gen_id() {
-  return "O" + std::to_string(++last_id_);
+std::string
+NavGraphGenerator2014Thread::gen_id()
+{
+	return "O" + std::to_string(++last_id_);
 }
 
-void NavGraphGenerator2014Thread::finalize() { blackboard->close(navgen_if_); }
+void
+NavGraphGenerator2014Thread::finalize()
+{
+	blackboard->close(navgen_if_);
+}
 
-void NavGraphGenerator2014Thread::loop() {}
+void
+NavGraphGenerator2014Thread::loop()
+{
+}

--- a/src/plugins/attic/navgraph-generator-llsf2014/navgraph_generator_llsf2014_thread.h
+++ b/src/plugins/attic/navgraph-generator-llsf2014/navgraph_generator_llsf2014_thread.h
@@ -29,7 +29,6 @@
 #include <blackboard/interface_observer.h>
 #include <core/threading/thread.h>
 #include <core/utils/lock_list.h>
-
 #include <navgraph/navgraph_node.h>
 
 #include <list>
@@ -48,27 +47,32 @@ class NavGraphGenerator2014Thread : public fawkes::Thread,
                                     public fawkes::ClockAspect,
                                     public fawkes::LoggingAspect,
                                     public fawkes::ConfigurableAspect,
-                                    public fawkes::BlackBoardAspect {
+                                    public fawkes::BlackBoardAspect
+{
 public:
-  NavGraphGenerator2014Thread();
-  virtual ~NavGraphGenerator2014Thread();
+	NavGraphGenerator2014Thread();
+	virtual ~NavGraphGenerator2014Thread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  void add_node_edge(const fawkes::NavGraphNode &n);
-  void add_node_node(const fawkes::NavGraphNode &n);
-  std::string gen_id();
+	void        add_node_edge(const fawkes::NavGraphNode &n);
+	void        add_node_node(const fawkes::NavGraphNode &n);
+	std::string gen_id();
 
 private:
-  unsigned int last_id_;
-  fawkes::NavGraphGeneratorInterface *navgen_if_;
+	unsigned int                        last_id_;
+	fawkes::NavGraphGeneratorInterface *navgen_if_;
 };
 
 #endif

--- a/src/plugins/attic/omnivision_activator/omnivision_activator_plugin.cpp
+++ b/src/plugins/attic/omnivision_activator/omnivision_activator_plugin.cpp
@@ -20,9 +20,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "omnivision_activator_thread.h"
+
+#include <core/plugin.h>
 #include <interfaces/SwitchInterface.h>
 
 using namespace fawkes;
@@ -30,14 +30,16 @@ using namespace fawkes;
 /** Activates the Omnivison
  * @author Johannes Rothe
  */
-class OmnivisionActivatorPlugin : public fawkes::Plugin {
+class OmnivisionActivatorPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  OmnivisionActivatorPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new OmnivisionActivatorThread());
-  }
+	OmnivisionActivatorPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new OmnivisionActivatorThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Activates the Omnivision Thread")

--- a/src/plugins/attic/omnivision_activator/omnivision_activator_thread.cpp
+++ b/src/plugins/attic/omnivision_activator/omnivision_activator_thread.cpp
@@ -32,24 +32,30 @@ using namespace fawkes;
 
 /** Constructor. */
 OmnivisionActivatorThread::OmnivisionActivatorThread()
-    : Thread("OmnivisionActivatorThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL) {}
-
-void OmnivisionActivatorThread::init() {
-  switch_if_ =
-      blackboard->open_for_reading<SwitchInterface>("omnivisionSwitch");
-  SwitchInterface::EnableSwitchMessage *msg =
-      new SwitchInterface::EnableSwitchMessage();
-  switch_if_->msgq_enqueue(msg);
-  logger->log_info(name(), "Activating Omnivision");
+: Thread("OmnivisionActivatorThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
 }
 
-void OmnivisionActivatorThread::finalize() {
-  SwitchInterface::DisableSwitchMessage *msg =
-      new SwitchInterface::DisableSwitchMessage();
-  switch_if_->msgq_enqueue(msg);
-
-  blackboard->close(switch_if_);
+void
+OmnivisionActivatorThread::init()
+{
+	switch_if_ = blackboard->open_for_reading<SwitchInterface>("omnivisionSwitch");
+	SwitchInterface::EnableSwitchMessage *msg = new SwitchInterface::EnableSwitchMessage();
+	switch_if_->msgq_enqueue(msg);
+	logger->log_info(name(), "Activating Omnivision");
 }
 
-void OmnivisionActivatorThread::loop() {}
+void
+OmnivisionActivatorThread::finalize()
+{
+	SwitchInterface::DisableSwitchMessage *msg = new SwitchInterface::DisableSwitchMessage();
+	switch_if_->msgq_enqueue(msg);
+
+	blackboard->close(switch_if_);
+}
+
+void
+OmnivisionActivatorThread::loop()
+{
+}

--- a/src/plugins/attic/omnivision_activator/omnivision_activator_thread.h
+++ b/src/plugins/attic/omnivision_activator/omnivision_activator_thread.h
@@ -40,21 +40,25 @@ class OmnivisionActivatorThread : public fawkes::Thread,
                                   public fawkes::BlockedTimingAspect,
                                   public fawkes::LoggingAspect,
                                   public fawkes::ConfigurableAspect,
-                                  public fawkes::BlackBoardAspect {
-
+                                  public fawkes::BlackBoardAspect
+{
 public:
-  OmnivisionActivatorThread();
+	OmnivisionActivatorThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  fawkes::SwitchInterface *switch_if_;
+	fawkes::SwitchInterface *switch_if_;
 };
 
 #endif

--- a/src/plugins/attic/omnivision_pucks/omnivision_pucks_plugin.cpp
+++ b/src/plugins/attic/omnivision_pucks/omnivision_pucks_plugin.cpp
@@ -33,16 +33,18 @@ using namespace fawkes;
  * puck and colored field positions relative to the robot.
  * @author Tim Niemueller
  */
-class OmniVisionPucksPlugin : public fawkes::Plugin {
+class OmniVisionPucksPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  OmniVisionPucksPlugin(Configuration *config) : Plugin(config) {
-    OmniVisionPucksPipelineThread *t = new OmniVisionPucksPipelineThread();
-    thread_list.push_back(t);
-    thread_list.push_back(new OmniVisionPucksSensorThread(t));
-  }
+	OmniVisionPucksPlugin(Configuration *config) : Plugin(config)
+	{
+		OmniVisionPucksPipelineThread *t = new OmniVisionPucksPipelineThread();
+		thread_list.push_back(t);
+		thread_list.push_back(new OmniVisionPucksSensorThread(t));
+	}
 };
 
 PLUGIN_DESCRIPTION("Detect LLSF pucks through omni-vision")

--- a/src/plugins/attic/omnivision_pucks/pipeline_thread.cpp
+++ b/src/plugins/attic/omnivision_pucks/pipeline_thread.cpp
@@ -24,35 +24,29 @@
 
 #include "pipeline_thread.h"
 
-#include <fvutils/color/conversions.h>
-#include <fvutils/draw/drawer.h>
-#include <fvutils/ipc/shm_image.h>
-
+#include <fvcams/camera.h>
+#include <fvclassifiers/simple.h>
+#include <fvfilters/roidraw.h>
 #include <fvmodels/color/lookuptable.h>
 #include <fvmodels/global_position/omni_global.h>
 #include <fvmodels/mirror/bulb.h>
 #include <fvmodels/mirror/mirrormodel.h>
 #include <fvmodels/relative_position/omni_relative.h>
 #include <fvmodels/scanlines/grid.h>
-
-#include <fvcams/camera.h>
-#include <fvclassifiers/simple.h>
-#include <fvfilters/roidraw.h>
+#include <fvutils/color/conversions.h>
+#include <fvutils/draw/drawer.h>
+#include <fvutils/ipc/shm_image.h>
 #include <interfaces/Position3DInterface.h>
-#include <utils/system/hostinfo.h>
-
 #include <interfaces/SwitchInterface.h>
-
-#include <utils/misc/string_conversions.h>
-
 #include <utils/hungarian_method/hungarian.h>
+#include <utils/misc/string_conversions.h>
+#include <utils/system/hostinfo.h>
 
 #include <cmath>
 #include <cstdio>
 #include <stdlib.h>
-#include <unistd.h>
-
 #include <string>
+#include <unistd.h>
 
 using namespace std;
 using namespace fawkes;
@@ -71,123 +65,125 @@ using namespace firevision;
 
 /** Constructor. */
 OmniVisionPucksPipelineThread::OmniVisionPucksPipelineThread()
-    : Thread("RobotinoOmniVisionThread", Thread::OPMODE_CONTINUOUS),
-      VisionAspect(VisionAspect::CONTINUOUS) {
-  scanline_ = NULL;
-  cm_ = NULL;
-  mirror_ = NULL;
-  rel_pos_ = NULL;
-  classifier_ = NULL;
-  shm_buffer_ = NULL;
-  _new_data = false;
+: Thread("RobotinoOmniVisionThread", Thread::OPMODE_CONTINUOUS),
+  VisionAspect(VisionAspect::CONTINUOUS)
+{
+	scanline_   = NULL;
+	cm_         = NULL;
+	mirror_     = NULL;
+	rel_pos_    = NULL;
+	classifier_ = NULL;
+	shm_buffer_ = NULL;
+	_new_data   = false;
 
-  _data_mutex = new Mutex();
-  if_puck_map_ = new PuckIfMap();
+	_data_mutex  = new Mutex();
+	if_puck_map_ = new PuckIfMap();
 
-  cspace_to_ = YUV422_PLANAR;
-  drawer_ = 0;
+	cspace_to_ = YUV422_PLANAR;
+	drawer_    = 0;
 }
 
 /** Destructor. */
-OmniVisionPucksPipelineThread::~OmniVisionPucksPipelineThread() {}
+OmniVisionPucksPipelineThread::~OmniVisionPucksPipelineThread()
+{
+}
 
 /** Initialize the pipeline thread.
  * Camera is requested, config parameters are obtained from the config db, and
  * other miscellaneous init stuff is done here.
  */
-void OmniVisionPucksPipelineThread::init() {
-  cfg_prefix_ = "/hardware/robotino/omnivision/";
-  cfg_camera_ = config->get_string((cfg_prefix_ + "camera").c_str());
-  cfg_frame_ = config->get_string((cfg_prefix_ + "frame").c_str());
-  cfg_cam_height_ = config->get_float((cfg_prefix_ + "camera_height").c_str());
-  cfg_puck_radius_ = config->get_float((cfg_prefix_ + "puck_radius").c_str());
-  cfg_mirror_file_ = std::string(CONFDIR) + "/" +
-                     config->get_string((cfg_prefix_ + "mirror_file").c_str());
-  cfg_colormap_file_ =
-      std::string(CONFDIR) + "/" +
-      config->get_string((cfg_prefix_ + "colormap_file").c_str());
-  cfg_neighbors = config->get_float((cfg_prefix_ + "neighbors").c_str());
-  cfg_basic_roi_size =
-      config->get_float((cfg_prefix_ + "basic_roi_size").c_str());
+void
+OmniVisionPucksPipelineThread::init()
+{
+	cfg_prefix_      = "/hardware/robotino/omnivision/";
+	cfg_camera_      = config->get_string((cfg_prefix_ + "camera").c_str());
+	cfg_frame_       = config->get_string((cfg_prefix_ + "frame").c_str());
+	cfg_cam_height_  = config->get_float((cfg_prefix_ + "camera_height").c_str());
+	cfg_puck_radius_ = config->get_float((cfg_prefix_ + "puck_radius").c_str());
+	cfg_mirror_file_ =
+	  std::string(CONFDIR) + "/" + config->get_string((cfg_prefix_ + "mirror_file").c_str());
+	cfg_colormap_file_ =
+	  std::string(CONFDIR) + "/" + config->get_string((cfg_prefix_ + "colormap_file").c_str());
+	cfg_neighbors      = config->get_float((cfg_prefix_ + "neighbors").c_str());
+	cfg_basic_roi_size = config->get_float((cfg_prefix_ + "basic_roi_size").c_str());
 
-  // camera
-  cam_ = vision_master->register_for_camera(cfg_camera_.c_str(), this);
+	// camera
+	cam_ = vision_master->register_for_camera(cfg_camera_.c_str(), this);
 
-  // init puck interfaces
+	// init puck interfaces
 
-  try {
-    int i;
-    for (i = 1; i <= PUCK_AMOUNT; i++) {
-      Position3DInterface *puckif;
-      char *omni_name;
-      if (asprintf(&omni_name, "OmniPuck%d", i) != -1) {
-        puckif = blackboard->open_for_writing<Position3DInterface>(omni_name);
-        puckif->set_frame(cfg_frame_.c_str());
-        puckif->set_visibility_history(-1);
-        puckif->write();
-        free(omni_name);
-        puck_ifs_.push_back(puckif);
-      }
-    }
-  } catch (Exception &e) {
-    e.append("Opening puck interfaces for writing failed");
-    throw;
-  }
+	try {
+		int i;
+		for (i = 1; i <= PUCK_AMOUNT; i++) {
+			Position3DInterface *puckif;
+			char *               omni_name;
+			if (asprintf(&omni_name, "OmniPuck%d", i) != -1) {
+				puckif = blackboard->open_for_writing<Position3DInterface>(omni_name);
+				puckif->set_frame(cfg_frame_.c_str());
+				puckif->set_visibility_history(-1);
+				puckif->write();
+				free(omni_name);
+				puck_ifs_.push_back(puckif);
+			}
+		}
+	} catch (Exception &e) {
+		e.append("Opening puck interfaces for writing failed");
+		throw;
+	}
 
-  try {
-    switchInterface =
-        blackboard->open_for_writing<SwitchInterface>("omnivisionSwitch");
-  } catch (Exception &e) {
-    e.append("Opening switch interface for writing failed");
-    throw;
-  }
+	try {
+		switchInterface = blackboard->open_for_writing<SwitchInterface>("omnivisionSwitch");
+	} catch (Exception &e) {
+		e.append("Opening switch interface for writing failed");
+		throw;
+	}
 
-  // image properties
-  img_width_ = cam_->pixel_width();
-  img_height_ = cam_->pixel_height();
-  cspace_from_ = cam_->colorspace();
+	// image properties
+	img_width_   = cam_->pixel_width();
+	img_height_  = cam_->pixel_height();
+	cspace_from_ = cam_->colorspace();
 
-  // other stuff that might throw an exception
-  try {
-    // mirror calibration
-    mirror_ = new Bulb(cfg_mirror_file_.c_str(), "omni-mirror",
-                       true /* destroy on delete */);
+	// other stuff that might throw an exception
+	try {
+		// mirror calibration
+		mirror_ = new Bulb(cfg_mirror_file_.c_str(), "omni-mirror", true /* destroy on delete */);
 
-    // colormodel
-    cm_ = new ColorModelLookupTable(cfg_colormap_file_.c_str(), "omni-colormap",
-                                    true /* destroy on delete */);
+		// colormodel
+		cm_ = new ColorModelLookupTable(cfg_colormap_file_.c_str(),
+		                                "omni-colormap",
+		                                true /* destroy on delete */);
 
-    // SHM image buffer
-    shm_buffer_ = new SharedMemoryImageBuffer("omni-processed", cspace_to_,
-                                              img_width_, img_height_);
-    if (!shm_buffer_->is_valid()) {
-      throw Exception("Shared memory segment not valid");
-    }
-    shm_buffer_->set_frame_id(cfg_frame_.c_str());
-    buffer_ = shm_buffer_->buffer();
+		// SHM image buffer
+		shm_buffer_ =
+		  new SharedMemoryImageBuffer("omni-processed", cspace_to_, img_width_, img_height_);
+		if (!shm_buffer_->is_valid()) {
+			throw Exception("Shared memory segment not valid");
+		}
+		shm_buffer_->set_frame_id(cfg_frame_.c_str());
+		buffer_ = shm_buffer_->buffer();
 
-  } catch (Exception &e) {
-    delete mirror_;
-    mirror_ = NULL;
-    delete cm_;
-    cm_ = NULL;
-    delete shm_buffer_;
-    shm_buffer_ = NULL;
-    delete cam_;
-    cam_ = NULL;
-    throw;
-  }
+	} catch (Exception &e) {
+		delete mirror_;
+		mirror_ = NULL;
+		delete cm_;
+		cm_ = NULL;
+		delete shm_buffer_;
+		shm_buffer_ = NULL;
+		delete cam_;
+		cam_ = NULL;
+		throw;
+	}
 
-  // scanline_ model
-  scanline_ = new ScanlineGrid(img_width_, img_height_, 2, 2);
+	// scanline_ model
+	scanline_ = new ScanlineGrid(img_width_, img_height_, 2, 2);
 
-  // position model
-  rel_pos_ = new OmniRelative(mirror_);
+	// position model
+	rel_pos_ = new OmniRelative(mirror_);
 
-  // classifier
-  classifier_ = new SimpleColorClassifier(scanline_, cm_, 0, cfg_basic_roi_size,
-                                          false, cfg_neighbors, 4);
-  /** Constructor.
+	// classifier
+	classifier_ =
+	  new SimpleColorClassifier(scanline_, cm_, 0, cfg_basic_roi_size, false, cfg_neighbors, 4);
+	/** Constructor.
    * @param scanline_model scanline model
    * @param color_model color model
    * @param min_num_points minimum number of points in ROI to be considered
@@ -200,41 +196,43 @@ void OmniVisionPucksPipelineThread::init() {
    * @param grow_by grow region by that many pixels
    * @param color color to look for
    */
-  // drawer
-  drawer_ = new Drawer();
-  drawer_->set_buffer(buffer_, img_width_, img_height_);
-  drawer_->set_color(0, 127, 127);
+	// drawer
+	drawer_ = new Drawer();
+	drawer_->set_buffer(buffer_, img_width_, img_height_);
+	drawer_->set_color(0, 127, 127);
 }
 
 /** Thread finalization. */
-void OmniVisionPucksPipelineThread::finalize() {
-  delete drawer_;
-  delete classifier_;
-  delete rel_pos_;
-  delete scanline_;
-  delete shm_buffer_;
-  delete cm_;
-  delete mirror_;
+void
+OmniVisionPucksPipelineThread::finalize()
+{
+	delete drawer_;
+	delete classifier_;
+	delete rel_pos_;
+	delete scanline_;
+	delete shm_buffer_;
+	delete cm_;
+	delete mirror_;
 
-  logger->log_debug(name(), "Unregistering from vision master");
-  vision_master->unregister_thread(this);
-  delete cam_;
+	logger->log_debug(name(), "Unregistering from vision master");
+	vision_master->unregister_thread(this);
+	delete cam_;
 
-  try {
-    std::list<fawkes::Position3DInterface *>::iterator puck;
-    puck = puck_ifs_.begin();
-    for (puck = puck_ifs_.begin(); puck != puck_ifs_.end(); puck++) {
-      (*puck)->set_visibility_history(0);
-      blackboard->close(*puck);
-    }
+	try {
+		std::list<fawkes::Position3DInterface *>::iterator puck;
+		puck = puck_ifs_.begin();
+		for (puck = puck_ifs_.begin(); puck != puck_ifs_.end(); puck++) {
+			(*puck)->set_visibility_history(0);
+			blackboard->close(*puck);
+		}
 
-    blackboard->close(switchInterface);
+		blackboard->close(switchInterface);
 
-  } catch (Exception &e) {
-    logger->log_error(name(), "Closing interface failed!");
-    logger->log_error(name(), e);
-    throw;
-  }
+	} catch (Exception &e) {
+		logger->log_error(name(), "Closing interface failed!");
+		logger->log_error(name(), e);
+		throw;
+	}
 }
 
 /** Process image to detect objects.
@@ -242,275 +240,280 @@ void OmniVisionPucksPipelineThread::finalize() {
  * determine objects according to the colormap. Publish the
  * position of the closest such object as puck position.
  */
-void OmniVisionPucksPipelineThread::loop() {
-  old_pucks_ = current_pucks_;
-  // check if there is a msg in the msg-queue
-  while (!switchInterface->msgq_empty()) {
-    if (SwitchInterface::DisableSwitchMessage *msg =
-            switchInterface->msgq_first_safe(msg)) {
-      logger->log_info(name(), "Switch disable message received");
-      switchInterface->set_enabled(false);
-    } else if (SwitchInterface::EnableSwitchMessage *msg =
-                   switchInterface->msgq_first_safe(msg)) {
-      logger->log_info(name(), "Switch enable message received");
-      switchInterface->set_enabled(true);
-    }
-    switchInterface->msgq_pop();
-    switchInterface->write();
-  }
+void
+OmniVisionPucksPipelineThread::loop()
+{
+	old_pucks_ = current_pucks_;
+	// check if there is a msg in the msg-queue
+	while (!switchInterface->msgq_empty()) {
+		if (SwitchInterface::DisableSwitchMessage *msg = switchInterface->msgq_first_safe(msg)) {
+			logger->log_info(name(), "Switch disable message received");
+			switchInterface->set_enabled(false);
+		} else if (SwitchInterface::EnableSwitchMessage *msg = switchInterface->msgq_first_safe(msg)) {
+			logger->log_info(name(), "Switch enable message received");
+			switchInterface->set_enabled(true);
+		}
+		switchInterface->msgq_pop();
+		switchInterface->write();
+	}
 
-  if (!switchInterface->is_enabled()) {
-    std::list<fawkes::Position3DInterface *>::iterator puck;
-    puck = puck_ifs_.begin();
-    for (puck = puck_ifs_.begin(); puck != puck_ifs_.end(); puck++) {
-      (*puck)->set_visibility_history(0);
-      (*puck)->write();
-    }
-    usleep(500000);
-    return;
-  }
+	if (!switchInterface->is_enabled()) {
+		std::list<fawkes::Position3DInterface *>::iterator puck;
+		puck = puck_ifs_.begin();
+		for (puck = puck_ifs_.begin(); puck != puck_ifs_.end(); puck++) {
+			(*puck)->set_visibility_history(0);
+			(*puck)->write();
+		}
+		usleep(500000);
+		return;
+	}
 
-  cam_->capture();
-  convert(cspace_from_, cspace_to_, cam_->buffer(), buffer_, img_width_,
-          img_height_);
-  puck_visible_ = false;
+	cam_->capture();
+	convert(cspace_from_, cspace_to_, cam_->buffer(), buffer_, img_width_, img_height_);
+	puck_visible_ = false;
 
-  // run classifier
-  classifier_->set_src_buffer(cam_->buffer(), img_width_, img_height_);
+	// run classifier
+	classifier_->set_src_buffer(cam_->buffer(), img_width_, img_height_);
 
-  rois_ = classifier_->classify();
-  cam_->dispose_buffer();
+	rois_ = classifier_->classify();
+	cam_->dispose_buffer();
 
-  FilterROIDraw *f = new FilterROIDraw();
-  f->set_src_buffer(buffer_, ROI::full_image(img_width_, img_height_), 0);
-  // post-process ROIs
-  std::list<firevision::ROI>::iterator r;
-  if (rois_->empty()) {
-    logger->log_debug(name(), "keine ROIS gefunden");
-    shm_buffer_->set_circle_found(false);
-  } else {
-    // if we have at least one ROI
-    puck_visible_ = true;
-    // get only the pucks within 1m radius to the robot
-    min_dist_ = 1.f;
-    // sort the ROIS for distance
-    rois_->sort(sortFunctor(rel_pos_, classifier_));
+	FilterROIDraw *f = new FilterROIDraw();
+	f->set_src_buffer(buffer_, ROI::full_image(img_width_, img_height_), 0);
+	// post-process ROIs
+	std::list<firevision::ROI>::iterator r;
+	if (rois_->empty()) {
+		logger->log_debug(name(), "keine ROIS gefunden");
+		shm_buffer_->set_circle_found(false);
+	} else {
+		// if we have at least one ROI
+		puck_visible_ = true;
+		// get only the pucks within 1m radius to the robot
+		min_dist_ = 1.f;
+		// sort the ROIS for distance
+		rois_->sort(sortFunctor(rel_pos_, classifier_));
 
-    int roicounter = 0;
-    // erase all ROIS with index greater than PUCK_AMOUNT
-    for (r = rois_->begin(); r != rois_->end();) {
-      classifier_->get_mass_point_of_color(&(*r), &mass_point_);
-      rel_pos_->set_center(mass_point_.x, mass_point_.y);
-      rel_pos_->calc_unfiltered();
-      f->set_dst_buffer(buffer_, &(*r));
-      f->set_style(FilterROIDraw::DASHED_HINT);
-      f->apply();
-      if (roicounter > PUCK_AMOUNT || rel_pos_->get_distance() > min_dist_) {
-        r = rois_->erase(r);
-        continue;
-      }
-      r++;
-      roicounter++;
-    }
-  }
-  // pucks has now same length or is longer than rois_
-  std::list<Position3DInterface *>::iterator puckif_it;
-  puckif_it = puck_ifs_.begin();
-  _data_mutex->lock();
-  current_pucks_.clear();
-  relPositions_.clear();
-  for (r = rois_->begin(); r != rois_->end(); r++) {
-    if (puck_visible_) {
-      classifier_->get_mass_point_of_color(&(*r), &mass_point_);
-      rel_pos_->set_center(mass_point_.x, mass_point_.y);
-      drawer_->draw_circle(mass_point_.x, mass_point_.y, 6);
-      if (rel_pos_->is_pos_valid()) {
+		int roicounter = 0;
+		// erase all ROIS with index greater than PUCK_AMOUNT
+		for (r = rois_->begin(); r != rois_->end();) {
+			classifier_->get_mass_point_of_color(&(*r), &mass_point_);
+			rel_pos_->set_center(mass_point_.x, mass_point_.y);
+			rel_pos_->calc_unfiltered();
+			f->set_dst_buffer(buffer_, &(*r));
+			f->set_style(FilterROIDraw::DASHED_HINT);
+			f->apply();
+			if (roicounter > PUCK_AMOUNT || rel_pos_->get_distance() > min_dist_) {
+				r = rois_->erase(r);
+				continue;
+			}
+			r++;
+			roicounter++;
+		}
+	}
+	// pucks has now same length or is longer than rois_
+	std::list<Position3DInterface *>::iterator puckif_it;
+	puckif_it = puck_ifs_.begin();
+	_data_mutex->lock();
+	current_pucks_.clear();
+	relPositions_.clear();
+	for (r = rois_->begin(); r != rois_->end(); r++) {
+		if (puck_visible_) {
+			classifier_->get_mass_point_of_color(&(*r), &mass_point_);
+			rel_pos_->set_center(mass_point_.x, mass_point_.y);
+			drawer_->draw_circle(mass_point_.x, mass_point_.y, 6);
+			if (rel_pos_->is_pos_valid()) {
+				rel_pos_->calc();
 
-        rel_pos_->calc();
-
-        Point3d puck_relative;
-        puck_relative.setX(rel_pos_->get_x());
-        puck_relative.setY(rel_pos_->get_y());
-        Point3d puck_absolute = apply_tf_to_global(puck_relative);
-        current_pucks_.push_back(puck_absolute);
-        relPositions_[puck_absolute] = puck_relative;
-        // logger->log_debug(name(),
-        //		"transformation applied: (%f|%f)->(%f|%f)",
-        //		puck_relative.getX(), puck_relative.getY(),
-        //		current_pucks_.back().getX(),
-        //		current_pucks_.back().getY());
-      }
-    }
-  }
-  associate_pucks_with_ifs();
-  _new_data = true;
-  _data_mutex->unlock();
+				Point3d puck_relative;
+				puck_relative.setX(rel_pos_->get_x());
+				puck_relative.setY(rel_pos_->get_y());
+				Point3d puck_absolute = apply_tf_to_global(puck_relative);
+				current_pucks_.push_back(puck_absolute);
+				relPositions_[puck_absolute] = puck_relative;
+				// logger->log_debug(name(),
+				//		"transformation applied: (%f|%f)->(%f|%f)",
+				//		puck_relative.getX(), puck_relative.getY(),
+				//		current_pucks_.back().getX(),
+				//		current_pucks_.back().getY());
+			}
+		}
+	}
+	associate_pucks_with_ifs();
+	_new_data = true;
+	_data_mutex->unlock();
 }
 
-void OmniVisionPucksPipelineThread::associate_pucks_with_ifs() {
+void
+OmniVisionPucksPipelineThread::associate_pucks_with_ifs()
+{
+	hungarian_problem_t cost_matrix;
+	cost_matrix.num_rows = old_pucks_.size();
+	cost_matrix.num_cols = current_pucks_.size();
+	cost_matrix.cost     = (int **)calloc(cost_matrix.num_rows, sizeof(int *));
+	for (int i = 0; i < cost_matrix.num_rows; ++i) {
+		cost_matrix.cost[i] = (int *)calloc(cost_matrix.num_cols, sizeof(int *));
+	}
+	for (unsigned int index_old = 0; index_old < old_pucks_.size(); ++index_old) {
+		for (unsigned int index_current = 0; index_current < current_pucks_.size(); ++index_current) {
+			// hungarian method takes int, so we transform our floats to suitable ints
+			// e.g.: 0.015 -> 15
+			int dist_in_int = (int)old_pucks_[index_old].distance(current_pucks_[index_current]) * 1000;
+			// take the square distance
+			cost_matrix.cost[index_old][index_current] = dist_in_int * dist_in_int;
+		}
+	}
+	HungarianMethod hSolver;
+	hSolver.init(cost_matrix.cost,
+	             cost_matrix.num_rows,
+	             cost_matrix.num_cols,
+	             HUNGARIAN_MODE_MINIMIZE_COST);
+	hSolver.solve();
 
-  hungarian_problem_t cost_matrix;
-  cost_matrix.num_rows = old_pucks_.size();
-  cost_matrix.num_cols = current_pucks_.size();
-  cost_matrix.cost = (int **)calloc(cost_matrix.num_rows, sizeof(int *));
-  for (int i = 0; i < cost_matrix.num_rows; ++i) {
-    cost_matrix.cost[i] = (int *)calloc(cost_matrix.num_cols, sizeof(int *));
-  }
-  for (unsigned int index_old = 0; index_old < old_pucks_.size(); ++index_old) {
-    for (unsigned int index_current = 0; index_current < current_pucks_.size();
-         ++index_current) {
-      // hungarian method takes int, so we transform our floats to suitable ints
-      // e.g.: 0.015 -> 15
-      int dist_in_int =
-          (int)old_pucks_[index_old].distance(current_pucks_[index_current]) *
-          1000;
-      // take the square distance
-      cost_matrix.cost[index_old][index_current] = dist_in_int * dist_in_int;
-    }
-  }
-  HungarianMethod hSolver;
-  hSolver.init(cost_matrix.cost, cost_matrix.num_rows, cost_matrix.num_cols,
-               HUNGARIAN_MODE_MINIMIZE_COST);
-  hSolver.solve();
+	int  size_assignment;
+	int *assignment = hSolver.get_assignment(size_assignment);
 
-  int size_assignment;
-  int *assignment = hSolver.get_assignment(size_assignment);
+	list<Position3DInterface *> unused_ifs(puck_ifs_);
+	list<Point3d>               new_pucks;
+	PuckIfMap *                 if_puck_map_current = new PuckIfMap();
 
-  list<Position3DInterface *> unused_ifs(puck_ifs_);
-  list<Point3d> new_pucks;
-  PuckIfMap *if_puck_map_current = new PuckIfMap();
+	for (int i = 0; i < size_assignment; ++i) {
+		if ((unsigned int)i >= old_pucks_.size()) {
+			// new puck detected, no match to old
+			new_pucks.push_back(current_pucks_[assignment[i]]);
+		} else if ((unsigned int)assignment[i] >= current_pucks_.size()) {
+			// puck has been lost
+			continue;
+		} else {
+			Point3d &old_puck = old_pucks_[i];
+			Point3d &new_puck = current_pucks_[assignment[i]];
+			// logger->log_debug(name(), "Old: (%f|%f) matches New: (%f|%f)",
+			//		old_puck.getX(), old_puck.getY(), new_puck.getX(),
+			//		new_puck.getY());
+			map<Point3d, Position3DInterface *>::iterator old_if = if_puck_map_->find(old_puck);
+			if (old_if != if_puck_map_->end()) {
+				// logger->log_debug(name(), "Gets old if %s",
+				//		old_if->second->id());
+				unused_ifs.remove(old_if->second);
+				(*if_puck_map_current)[new_puck] = old_if->second;
+				old_if->second->set_visibility_history(old_if->second->visibility_history() + 1);
+			} else {
+				new_pucks.push_back(new_puck);
+			}
+		}
+	}
+	// assign new pucks
+	for (Point3d &new_puck : new_pucks) {
+		if (unused_ifs.size() == 0) {
+			break;
+		}
+		Position3DInterface *pos_if = unused_ifs.front();
+		unused_ifs.pop_front();
+		pos_if->set_visibility_history(1);
+		(*if_puck_map_current)[new_puck] = pos_if;
+		// logger->log_debug(name(), "Puck at (%f|%f) gets if %s", new_puck.getX(),
+		//		new_puck.getY(), pos_if->id());
+	}
 
-  for (int i = 0; i < size_assignment; ++i) {
-    if ((unsigned int)i >= old_pucks_.size()) {
-      // new puck detected, no match to old
-      new_pucks.push_back(current_pucks_[assignment[i]]);
-    } else if ((unsigned int)assignment[i] >= current_pucks_.size()) {
-      // puck has been lost
-      continue;
-    } else {
-      Point3d &old_puck = old_pucks_[i];
-      Point3d &new_puck = current_pucks_[assignment[i]];
-      // logger->log_debug(name(), "Old: (%f|%f) matches New: (%f|%f)",
-      //		old_puck.getX(), old_puck.getY(), new_puck.getX(),
-      //		new_puck.getY());
-      map<Point3d, Position3DInterface *>::iterator old_if =
-          if_puck_map_->find(old_puck);
-      if (old_if != if_puck_map_->end()) {
-        // logger->log_debug(name(), "Gets old if %s",
-        //		old_if->second->id());
-        unused_ifs.remove(old_if->second);
-        (*if_puck_map_current)[new_puck] = old_if->second;
-        old_if->second->set_visibility_history(
-            old_if->second->visibility_history() + 1);
-      } else {
-        new_pucks.push_back(new_puck);
-      }
-    }
-  }
-  // assign new pucks
-  for (Point3d &new_puck : new_pucks) {
-    if (unused_ifs.size() == 0) {
-      break;
-    }
-    Position3DInterface *pos_if = unused_ifs.front();
-    unused_ifs.pop_front();
-    pos_if->set_visibility_history(1);
-    (*if_puck_map_current)[new_puck] = pos_if;
-    // logger->log_debug(name(), "Puck at (%f|%f) gets if %s", new_puck.getX(),
-    //		new_puck.getY(), pos_if->id());
-  }
+	// count down visibility of unseen pucks
+	for (Position3DInterface *unused_if : unused_ifs) {
+		int vis = min(-1, unused_if->visibility_history() - 1);
+		unused_if->set_visibility_history(vis);
+		unused_if->write();
+	}
 
-  // count down visibility of unseen pucks
-  for (Position3DInterface *unused_if : unused_ifs) {
-    int vis = min(-1, unused_if->visibility_history() - 1);
-    unused_if->set_visibility_history(vis);
-    unused_if->write();
-  }
-
-  delete if_puck_map_;
-  if_puck_map_ = if_puck_map_current;
-  for (auto &p : *if_puck_map_) {
-
-    Position3DInterface *pos_if = p.second;
-    Point3d relpos = relPositions_[p.first];
-    pos_if->set_translation(0, relpos.getX());
-    pos_if->set_translation(1, relpos.getY());
-  }
+	delete if_puck_map_;
+	if_puck_map_ = if_puck_map_current;
+	for (auto &p : *if_puck_map_) {
+		Position3DInterface *pos_if = p.second;
+		Point3d              relpos = relPositions_[p.first];
+		pos_if->set_translation(0, relpos.getX());
+		pos_if->set_translation(1, relpos.getY());
+	}
 }
 
 OmniVisionPucksPipelineThread::Point3d
-OmniVisionPucksPipelineThread::apply_tf_to_global(Point3d src) {
+OmniVisionPucksPipelineThread::apply_tf_to_global(Point3d src)
+{
+	const char *source_frame = "/base_link";
+	const char *target_frame = "/map";
 
-  const char *source_frame = "/base_link";
-  const char *target_frame = "/map";
+	src.stamp = Time(0, 0);
+	Point3d targetPoint;
+	targetPoint.frame_id = target_frame;
 
-  src.stamp = Time(0, 0);
-  Point3d targetPoint;
-  targetPoint.frame_id = target_frame;
+	bool link_frame_exists  = tf_listener->frame_exists(target_frame);
+	bool laser_frame_exists = tf_listener->frame_exists(source_frame);
 
-  bool link_frame_exists = tf_listener->frame_exists(target_frame);
-  bool laser_frame_exists = tf_listener->frame_exists(source_frame);
+	if (!link_frame_exists || !laser_frame_exists) {
+		logger->log_warn(name(),
+		                 "Frame missing: %s %s   %s %s",
+		                 source_frame,
+		                 link_frame_exists ? "exists" : "missing",
+		                 target_frame,
+		                 laser_frame_exists ? "exists" : "missing");
+	} else {
+		src.frame_id = source_frame;
+		try {
+			tf_listener->transform_point(target_frame, src, targetPoint);
+		} catch (tf::ExtrapolationException &e) {
+			logger->log_debug(name(), "Extrapolation error: %s", e.what());
+			return src;
+		} catch (tf::ConnectivityException &e) {
+			logger->log_debug(name(), "Connectivity exception: %s", e.what());
+			return src;
+		} catch (Exception &e) {
+			logger->log_debug(name(), "Fawkes exception: %s", e.what());
+			return src;
+		} catch (std::exception &e) {
+			logger->log_debug(name(), "Generic exception: %s", e.what());
+			return src;
+		}
 
-  if (!link_frame_exists || !laser_frame_exists) {
-    logger->log_warn(name(), "Frame missing: %s %s   %s %s", source_frame,
-                     link_frame_exists ? "exists" : "missing", target_frame,
-                     laser_frame_exists ? "exists" : "missing");
-  } else {
-    src.frame_id = source_frame;
-    try {
-      tf_listener->transform_point(target_frame, src, targetPoint);
-    } catch (tf::ExtrapolationException &e) {
-      logger->log_debug(name(), "Extrapolation error: %s", e.what());
-      return src;
-    } catch (tf::ConnectivityException &e) {
-      logger->log_debug(name(), "Connectivity exception: %s", e.what());
-      return src;
-    } catch (Exception &e) {
-      logger->log_debug(name(), "Fawkes exception: %s", e.what());
-      return src;
-    } catch (std::exception &e) {
-      logger->log_debug(name(), "Generic exception: %s", e.what());
-      return src;
-    }
-
-    return targetPoint;
-  }
-  return src;
+		return targetPoint;
+	}
+	return src;
 }
 
-OmniVisionPucksPipelineThread::sortFunctor::sortFunctor(
-    firevision::RelativePositionModel *rp, firevision::SimpleColorClassifier *c)
-    : relpos(rp), classifier(c) {}
-bool OmniVisionPucksPipelineThread::sortFunctor::operator()(firevision::ROI i,
-                                                            firevision::ROI j) {
-  float leftdist, rightdist;
-  fawkes::upoint_t mass_point_comp;
-  classifier->get_mass_point_of_color(&i, &mass_point_comp);
-  relpos->set_center(mass_point_comp.x, mass_point_comp.y);
-  relpos->calc_unfiltered();
-  leftdist = relpos->get_distance();
-  classifier->get_mass_point_of_color(&j, &mass_point_comp);
-  relpos->set_center(mass_point_comp.x, mass_point_comp.y);
-  relpos->calc_unfiltered();
-  rightdist = relpos->get_distance();
-  if (leftdist <= rightdist) {
-    return true;
-  } else {
-    return false;
-  }
+OmniVisionPucksPipelineThread::sortFunctor::sortFunctor(firevision::RelativePositionModel *rp,
+                                                        firevision::SimpleColorClassifier *c)
+: relpos(rp), classifier(c)
+{
+}
+bool
+OmniVisionPucksPipelineThread::sortFunctor::operator()(firevision::ROI i, firevision::ROI j)
+{
+	float            leftdist, rightdist;
+	fawkes::upoint_t mass_point_comp;
+	classifier->get_mass_point_of_color(&i, &mass_point_comp);
+	relpos->set_center(mass_point_comp.x, mass_point_comp.y);
+	relpos->calc_unfiltered();
+	leftdist = relpos->get_distance();
+	classifier->get_mass_point_of_color(&j, &mass_point_comp);
+	relpos->set_center(mass_point_comp.x, mass_point_comp.y);
+	relpos->calc_unfiltered();
+	rightdist = relpos->get_distance();
+	if (leftdist <= rightdist) {
+		return true;
+	} else {
+		return false;
+	}
 }
 /** Lock data if fresh.*/
-bool OmniVisionPucksPipelineThread::lock_if_new_data() {
-  _data_mutex->lock();
-  if (_new_data) {
-    return true;
-  } else {
-    _data_mutex->unlock();
-    return false;
-  }
+bool
+OmniVisionPucksPipelineThread::lock_if_new_data()
+{
+	_data_mutex->lock();
+	if (_new_data) {
+		return true;
+	} else {
+		_data_mutex->unlock();
+		return false;
+	}
 }
 /** Unlock data, */
-void OmniVisionPucksPipelineThread::unlock() {
-  _new_data = false;
-  _data_mutex->unlock();
+void
+OmniVisionPucksPipelineThread::unlock()
+{
+	_new_data = false;
+	_data_mutex->unlock();
 }

--- a/src/plugins/attic/omnivision_pucks/pipeline_thread.h
+++ b/src/plugins/attic/omnivision_pucks/pipeline_thread.h
@@ -24,18 +24,15 @@
 #ifndef __PLUGINS_OMNIVISION_PUCKS_PIPELINE_THREAD_H_
 #define __PLUGINS_OMNIVISION_PUCKS_PIPELINE_THREAD_H_
 
-#include <core/threading/thread.h>
-
 #include <aspect/blackboard.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
+#include <aspect/tf.h>
 #include <aspect/vision.h>
-
+#include <core/threading/thread.h>
 #include <fvutils/base/roi.h>
 #include <fvutils/base/types.h>
 #include <fvutils/color/colorspaces.h>
-
-#include <aspect/tf.h>
 #include <interfaces/SwitchInterface.h>
 #include <tf/transform_listener.h>
 #include <tf/types.h>
@@ -62,95 +59,97 @@ class OmniVisionPucksPipelineThread : public fawkes::Thread,
                                       public fawkes::VisionAspect,
                                       public fawkes::ConfigurableAspect,
                                       public fawkes::BlackBoardAspect,
-                                      public fawkes::TransformAspect {
-
-  // sort functor for sorting ROI Lists
+                                      public fawkes::TransformAspect
+{
+	// sort functor for sorting ROI Lists
 
 public:
-  typedef fawkes::tf::Stamped<fawkes::tf::Point> Point3d;
+	typedef fawkes::tf::Stamped<fawkes::tf::Point> Point3d;
 
-  struct sortFunctor {
-    sortFunctor(firevision::RelativePositionModel *rp,
-                firevision::SimpleColorClassifier *c);
-    bool operator()(firevision::ROI i, firevision::ROI j);
-    firevision::RelativePositionModel *relpos;
-    firevision::SimpleColorClassifier *classifier;
-  };
-  OmniVisionPucksPipelineThread();
-  virtual ~OmniVisionPucksPipelineThread();
+	struct sortFunctor
+	{
+		sortFunctor(firevision::RelativePositionModel *rp, firevision::SimpleColorClassifier *c);
+		bool                               operator()(firevision::ROI i, firevision::ROI j);
+		firevision::RelativePositionModel *relpos;
+		firevision::SimpleColorClassifier *classifier;
+	};
+	OmniVisionPucksPipelineThread();
+	virtual ~OmniVisionPucksPipelineThread();
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
-  bool lock_if_new_data();
-  void unlock();
+	bool lock_if_new_data();
+	void unlock();
 
-  std::list<fawkes::Position3DInterface *> puck_ifs_;
+	std::list<fawkes::Position3DInterface *> puck_ifs_;
 
 private:
-  struct cmpByLocation {
-    bool operator()(const Point3d &a, const Point3d &b) const {
-      return a.getX() + a.getY() * 10 < b.getX() + b.getY() * 10;
-    }
-  };
-  typedef std::map<Point3d, fawkes::Position3DInterface *, cmpByLocation>
-      PuckIfMap;
+	struct cmpByLocation
+	{
+		bool
+		operator()(const Point3d &a, const Point3d &b) const
+		{
+			return a.getX() + a.getY() * 10 < b.getX() + b.getY() * 10;
+		}
+	};
+	typedef std::map<Point3d, fawkes::Position3DInterface *, cmpByLocation> PuckIfMap;
 
-  typedef std::map<Point3d, Point3d, cmpByLocation> PuckPuckMap;
+	typedef std::map<Point3d, Point3d, cmpByLocation> PuckPuckMap;
 
-  PuckPuckMap relPositions_;
+	PuckPuckMap relPositions_;
 
-  PuckIfMap *if_puck_map_;
-  std::vector<Point3d> current_pucks_;
-  std::vector<Point3d> old_pucks_;
-  void associate_pucks_with_ifs();
+	PuckIfMap *          if_puck_map_;
+	std::vector<Point3d> current_pucks_;
+	std::vector<Point3d> old_pucks_;
+	void                 associate_pucks_with_ifs();
 
-  Point3d apply_tf_to_global(Point3d src);
+	Point3d apply_tf_to_global(Point3d src);
 
-  firevision::Camera *cam_;
-  firevision::ScanlineModel *scanline_;
-  firevision::ColorModel *cm_;
-  firevision::MirrorModel *mirror_;
-  firevision::RelativePositionModel *rel_pos_;
-  firevision::SimpleColorClassifier *classifier_;
-  firevision::SharedMemoryImageBuffer *shm_buffer_;
+	firevision::Camera *                 cam_;
+	firevision::ScanlineModel *          scanline_;
+	firevision::ColorModel *             cm_;
+	firevision::MirrorModel *            mirror_;
+	firevision::RelativePositionModel *  rel_pos_;
+	firevision::SimpleColorClassifier *  classifier_;
+	firevision::SharedMemoryImageBuffer *shm_buffer_;
 
-  fawkes::tf::TransformListener *tf_listener_;
+	fawkes::tf::TransformListener *tf_listener_;
 
-  fawkes::SwitchInterface *switchInterface;
+	fawkes::SwitchInterface *switchInterface;
 
-  unsigned char *buffer_;
+	unsigned char *buffer_;
 
-  unsigned int img_width_;
-  unsigned int img_height_;
+	unsigned int img_width_;
+	unsigned int img_height_;
 
-  firevision::colorspace_t cspace_from_;
-  firevision::colorspace_t cspace_to_;
+	firevision::colorspace_t cspace_from_;
+	firevision::colorspace_t cspace_to_;
 
-  bool puck_visible_;
-  unsigned int puck_image_x_;
-  unsigned int puck_image_y_;
-  fawkes::upoint_t mass_point_;
-  float min_dist_;
+	bool             puck_visible_;
+	unsigned int     puck_image_x_;
+	unsigned int     puck_image_y_;
+	fawkes::upoint_t mass_point_;
+	float            min_dist_;
 
-  std::list<firevision::ROI> *rois_;
+	std::list<firevision::ROI> *rois_;
 
-  std::string cfg_prefix_;
-  std::string cfg_camera_;
-  std::string cfg_mirror_file_;
-  std::string cfg_colormap_file_;
-  std::string cfg_frame_;
-  float cfg_neighbors;
-  float cfg_basic_roi_size;
-  float cfg_cam_height_;
-  float cfg_puck_radius_;
+	std::string cfg_prefix_;
+	std::string cfg_camera_;
+	std::string cfg_mirror_file_;
+	std::string cfg_colormap_file_;
+	std::string cfg_frame_;
+	float       cfg_neighbors;
+	float       cfg_basic_roi_size;
+	float       cfg_cam_height_;
+	float       cfg_puck_radius_;
 
-  firevision::Drawer *drawer_;
+	firevision::Drawer *drawer_;
 
 protected:
-  fawkes::Mutex *_data_mutex;
-  bool _new_data;
+	fawkes::Mutex *_data_mutex;
+	bool           _new_data;
 };
 
 #endif

--- a/src/plugins/attic/omnivision_pucks/sensor_thread.cpp
+++ b/src/plugins/attic/omnivision_pucks/sensor_thread.cpp
@@ -26,7 +26,6 @@
 #include <cmath>
 #include <cstdio>
 #include <stdlib.h>
-
 #include <string>
 
 using namespace fawkes;
@@ -44,32 +43,40 @@ using namespace std;
  * @param cfg_prefix configuration path prefix
  * @param aqt LaserAcquisitionThread to get data from
  */
-OmniVisionPucksSensorThread::OmniVisionPucksSensorThread(
-    OmniVisionPucksPipelineThread *aqt)
-    : Thread("OmniVisionPucksSensorThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS) {
-  __aqt = aqt;
-  cfg_frame_ = ("/hardware/robotino/omnivision/frame");
+OmniVisionPucksSensorThread::OmniVisionPucksSensorThread(OmniVisionPucksPipelineThread *aqt)
+: Thread("OmniVisionPucksSensorThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS)
+{
+	__aqt      = aqt;
+	cfg_frame_ = ("/hardware/robotino/omnivision/frame");
 }
 
-void OmniVisionPucksSensorThread::init() {}
+void
+OmniVisionPucksSensorThread::init()
+{
+}
 
-void OmniVisionPucksSensorThread::finalize() {}
+void
+OmniVisionPucksSensorThread::finalize()
+{
+}
 
-void OmniVisionPucksSensorThread::loop() {
-  if (__aqt->lock_if_new_data()) {
-    // Iterator over the List in the Pipeline Thread whilst iterating over the
-    // sensor thread list
-    std::list<fawkes::Position3DInterface *>::iterator pipeline_pucks;
-    for (pipeline_pucks = __aqt->puck_ifs_.begin();
-         pipeline_pucks != __aqt->puck_ifs_.end(); pipeline_pucks++) {
-      (*pipeline_pucks)->write();
+void
+OmniVisionPucksSensorThread::loop()
+{
+	if (__aqt->lock_if_new_data()) {
+		// Iterator over the List in the Pipeline Thread whilst iterating over the
+		// sensor thread list
+		std::list<fawkes::Position3DInterface *>::iterator pipeline_pucks;
+		for (pipeline_pucks = __aqt->puck_ifs_.begin(); pipeline_pucks != __aqt->puck_ifs_.end();
+		     pipeline_pucks++) {
+			(*pipeline_pucks)->write();
 
-      // experimental comment, I am not sure of the consequences
-      // (I am not sure if we need this here at all..) --DE
-      //(*pipeline_pucks)->set_translation(0,0);
-      //(*pipeline_pucks)->set_translation(1,0);
-    }
-  }
-  __aqt->unlock();
+			// experimental comment, I am not sure of the consequences
+			// (I am not sure if we need this here at all..) --DE
+			//(*pipeline_pucks)->set_translation(0,0);
+			//(*pipeline_pucks)->set_translation(1,0);
+		}
+	}
+	__aqt->unlock();
 }

--- a/src/plugins/attic/omnivision_pucks/sensor_thread.h
+++ b/src/plugins/attic/omnivision_pucks/sensor_thread.h
@@ -23,13 +23,14 @@
 #ifndef __PLUGINS_OMNIVISION_SENSOR_THREAD_H_
 #define __PLUGINS_OMNIVISION_SENSOR_THREAD_H_
 
+#include "pipeline_thread.h"
+
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <core/threading/thread.h>
 
-#include "pipeline_thread.h"
 #include <string>
 
 namespace fawkes {
@@ -43,22 +44,27 @@ class OmniVisionPucksSensorThread : public fawkes::Thread,
                                     public fawkes::BlockedTimingAspect,
                                     public fawkes::LoggingAspect,
                                     public fawkes::ConfigurableAspect,
-                                    public fawkes::BlackBoardAspect {
+                                    public fawkes::BlackBoardAspect
+{
 public:
-  OmniVisionPucksSensorThread(OmniVisionPucksPipelineThread *aqt);
+	OmniVisionPucksSensorThread(OmniVisionPucksPipelineThread *aqt);
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  std::string cfg_frame_;
+	std::string cfg_frame_;
 
-  OmniVisionPucksPipelineThread *__aqt;
+	OmniVisionPucksPipelineThread *__aqt;
 };
 
 #endif

--- a/src/plugins/attic/plugin_template/plugin_template_plugin.cpp
+++ b/src/plugins/attic/plugin_template/plugin_template_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "plugin_template_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Template! Makes the robotino move forward for 3 seconds
  * @author Daniel Ewert
  */
-class PluginTemplatePlugin : public fawkes::Plugin {
+class PluginTemplatePlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  PluginTemplatePlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new PluginTemplateThread());
-  }
+	PluginTemplatePlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new PluginTemplateThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Plugin Template")

--- a/src/plugins/attic/plugin_template/plugin_template_thread.cpp
+++ b/src/plugins/attic/plugin_template/plugin_template_thread.cpp
@@ -39,32 +39,47 @@ using namespace fawkes;
 
 /** Constructor. */
 PluginTemplateThread::PluginTemplateThread()
-    : Thread("PluginTemplateThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL) {}
-
-void PluginTemplateThread::init() {
-
-  logger->log_info(name(), "Plugin Template starts up");
-  motor_if_ = blackboard->open_for_reading<MotorInterface>("Robotino");
+: Thread("PluginTemplateThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
 }
 
-bool PluginTemplateThread::prepare_finalize_user() {
-  stop();
-  return true;
+void
+PluginTemplateThread::init()
+{
+	logger->log_info(name(), "Plugin Template starts up");
+	motor_if_ = blackboard->open_for_reading<MotorInterface>("Robotino");
 }
 
-void PluginTemplateThread::finalize() { blackboard->close(motor_if_); }
-
-void PluginTemplateThread::send_transrot(float vx, float vy, float omega) {
-  MotorInterface::TransRotMessage *msg =
-      new MotorInterface::TransRotMessage(vx, vy, omega);
-  motor_if_->msgq_enqueue(msg);
+bool
+PluginTemplateThread::prepare_finalize_user()
+{
+	stop();
+	return true;
 }
 
-void PluginTemplateThread::stop() { send_transrot(0., 0., 0.); }
+void
+PluginTemplateThread::finalize()
+{
+	blackboard->close(motor_if_);
+}
 
-void PluginTemplateThread::loop() {
+void
+PluginTemplateThread::send_transrot(float vx, float vy, float omega)
+{
+	MotorInterface::TransRotMessage *msg = new MotorInterface::TransRotMessage(vx, vy, omega);
+	motor_if_->msgq_enqueue(msg);
+}
 
-  send_transrot(FORWARD_SPEED, SIDEWARD_SPEED, ROTATIONAL_SPEED);
-  logger->log_info(name(), "Driving madly!!");
+void
+PluginTemplateThread::stop()
+{
+	send_transrot(0., 0., 0.);
+}
+
+void
+PluginTemplateThread::loop()
+{
+	send_transrot(FORWARD_SPEED, SIDEWARD_SPEED, ROTATIONAL_SPEED);
+	logger->log_info(name(), "Driving madly!!");
 }

--- a/src/plugins/attic/plugin_template/plugin_template_thread.h
+++ b/src/plugins/attic/plugin_template/plugin_template_thread.h
@@ -39,26 +39,30 @@ class PluginTemplateThread : public fawkes::Thread,
                              public fawkes::BlockedTimingAspect,
                              public fawkes::LoggingAspect,
                              public fawkes::ConfigurableAspect,
-                             public fawkes::BlackBoardAspect {
-
+                             public fawkes::BlackBoardAspect
+{
 public:
-  PluginTemplateThread();
+	PluginTemplateThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual bool prepare_finalize_user();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual bool prepare_finalize_user();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  void stop();
-  void send_transrot(float vx, float vy, float omega);
+	void stop();
+	void send_transrot(float vx, float vy, float omega);
 
 private:
-  fawkes::MotorInterface *motor_if_;
+	fawkes::MotorInterface *motor_if_;
 };
 
 #endif

--- a/src/plugins/attic/puck_vision/puck_vision.cpp
+++ b/src/plugins/attic/puck_vision/puck_vision.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "puck_vision_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /**
  * @author Florian Nolden & Johannes Rothe
  */
-class PuckVision : public fawkes::Plugin {
+class PuckVision : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  PuckVision(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new PuckVisionThread());
-  }
+	PuckVision(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new PuckVisionThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("puck detection using a front looking camera")

--- a/src/plugins/attic/puck_vision/puck_vision_thread.cpp
+++ b/src/plugins/attic/puck_vision/puck_vision_thread.cpp
@@ -16,852 +16,898 @@
 #define CFG_PREFIX "/plugins/puck_vision/"
 
 PuckVisionThread::PuckVisionThread()
-    : Thread("PuckVisionThread", Thread::OPMODE_WAITFORWAKEUP),
-      VisionAspect(VisionAspect::CYCLIC), ConfigurationChangeHandler(CFG_PREFIX)
+: Thread("PuckVisionThread", Thread::OPMODE_WAITFORWAKEUP),
+  VisionAspect(VisionAspect::CYCLIC),
+  ConfigurationChangeHandler(CFG_PREFIX)
 //,   ConfigurationChangeHandler(CFG_TRANSFORM_PREFIX)
 {
-  cfg_prefix_ = CFG_PREFIX;
+	cfg_prefix_ = CFG_PREFIX;
 
-  camera_info_.connection = "";
-  camera_info_.img_width = 0;
-  camera_info_.img_height = 0;
-  camera_info_.opening_angle_horizontal = 0;
-  camera_info_.opening_angle_vertical = 0;
+	camera_info_.connection               = "";
+	camera_info_.img_width                = 0;
+	camera_info_.img_height               = 0;
+	camera_info_.opening_angle_horizontal = 0;
+	camera_info_.opening_angle_vertical   = 0;
 
-  buffer_ = NULL;
-  shm_buffer_ = NULL;
+	buffer_     = NULL;
+	shm_buffer_ = NULL;
 
-  cspaceFrom_ = firevision::YUV422_PLANAR;
-  cspaceTo_ = firevision::YUV422_PLANAR;
+	cspaceFrom_ = firevision::YUV422_PLANAR;
+	cspaceTo_   = firevision::YUV422_PLANAR;
 
-  cam_ = NULL;
+	cam_ = NULL;
 
-  switchInterface_ = NULL;
+	switchInterface_ = NULL;
 
-  puck_info_.main.classifier = NULL;
-  puck_info_.main.colormodel = NULL;
-  puck_info_.main.scanline_grid = NULL;
+	puck_info_.main.classifier    = NULL;
+	puck_info_.main.colormodel    = NULL;
+	puck_info_.main.scanline_grid = NULL;
 
-  puck_info_.top_dots.classifier = NULL;
-  puck_info_.top_dots.colormodel = NULL;
-  puck_info_.top_dots.scanline_grid = NULL;
+	puck_info_.top_dots.classifier    = NULL;
+	puck_info_.top_dots.colormodel    = NULL;
+	puck_info_.top_dots.scanline_grid = NULL;
 
-  drawer_ = NULL;
+	drawer_ = NULL;
 
-  cfg_paintROIsActivated_ = false;
-  cfg_debugMessagesActivated_ = false;
-  cfg_changed_ = false;
+	cfg_paintROIsActivated_     = false;
+	cfg_debugMessagesActivated_ = false;
+	cfg_changed_                = false;
 }
 /*
  * Create a new puck interface for writing and append it to puck_interfaces_
  * vector
  */
-void PuckVisionThread::createPuckInterface() {
-  fawkes::Position3DInterface *puck_if_ = NULL;
+void
+PuckVisionThread::createPuckInterface()
+{
+	fawkes::Position3DInterface *puck_if_ = NULL;
 
-  std::string interface_name =
-      "puck_" + std::to_string(puck_interfaces_.size());
-  logger->log_info(name(), "Creating new Position3DInterface %s",
-                   interface_name.c_str());
+	std::string interface_name = "puck_" + std::to_string(puck_interfaces_.size());
+	logger->log_info(name(), "Creating new Position3DInterface %s", interface_name.c_str());
 
-  try {
-    puck_if_ = blackboard->open_for_writing<fawkes::Position3DInterface>(
-        interface_name.c_str());
-    puck_if_->set_frame(camera_info_.frame.c_str());
-    puck_if_->write();
-    puck_interfaces_.push_back(puck_if_);
-  } catch (std::exception &e) {
-    finalize();
-    throw;
-  }
+	try {
+		puck_if_ = blackboard->open_for_writing<fawkes::Position3DInterface>(interface_name.c_str());
+		puck_if_->set_frame(camera_info_.frame.c_str());
+		puck_if_->write();
+		puck_interfaces_.push_back(puck_if_);
+	} catch (std::exception &e) {
+		finalize();
+		throw;
+	}
 }
 
-void PuckVisionThread::loadConfig() {
-  logger->log_info(name(), "loading config");
-  cfg_prefix_ = CFG_PREFIX;
-  cfg_prefix_static_transforms_ =
-      config->get_string((cfg_prefix_ + "transform").c_str());
+void
+PuckVisionThread::loadConfig()
+{
+	logger->log_info(name(), "loading config");
+	cfg_prefix_                   = CFG_PREFIX;
+	cfg_prefix_static_transforms_ = config->get_string((cfg_prefix_ + "transform").c_str());
 
-  cfg_frame_target = "/base_link";
+	cfg_frame_target = "/base_link";
 
-  cfg_use_new_pucks_ =
-      config->get_bool((cfg_prefix_ + "use_new_pucks").c_str());
+	cfg_use_new_pucks_ = config->get_bool((cfg_prefix_ + "use_new_pucks").c_str());
 
-  // load camera informations
-  camera_info_.connection =
-      config->get_string((cfg_prefix_ + "camera").c_str());
-  camera_info_.position_x =
-      config->get_float((cfg_prefix_static_transforms_ + "trans_x").c_str());
-  camera_info_.position_y =
-      config->get_float((cfg_prefix_static_transforms_ + "trans_y").c_str());
-  camera_info_.position_z =
-      config->get_float((cfg_prefix_static_transforms_ + "trans_z").c_str());
-  camera_info_.position_pitch =
-      config->get_float((cfg_prefix_static_transforms_ + "rot_pitch").c_str());
-  camera_info_.opening_angle_horizontal = config->get_float(
-      (cfg_prefix_ + "camera_opening_angle_horizontal").c_str());
-  camera_info_.opening_angle_vertical = config->get_float(
-      (cfg_prefix_ + "camera_opening_angle_vertical").c_str());
-  // Calculate visible Area
-  camera_info_.angle_horizontal_to_opening_ =
-      (1.57 - camera_info_.position_pitch) -
-      (camera_info_.opening_angle_vertical / 2);
-  camera_info_.visible_lenght_x_in_m_ =
-      camera_info_.position_z *
-      (tan(camera_info_.opening_angle_vertical +
-           camera_info_.angle_horizontal_to_opening_) -
-       tan(camera_info_.angle_horizontal_to_opening_));
-  camera_info_.offset_cam_x_to_groundplane_ =
-      camera_info_.position_z * tan(camera_info_.angle_horizontal_to_opening_);
-  camera_info_.visible_lenght_y_in_m_ =
-      camera_info_.position_z * tan(camera_info_.opening_angle_horizontal / 2);
-  camera_info_.frame = config->get_string(
-      (cfg_prefix_static_transforms_ + "child_frame").c_str());
+	// load camera informations
+	camera_info_.connection = config->get_string((cfg_prefix_ + "camera").c_str());
+	camera_info_.position_x = config->get_float((cfg_prefix_static_transforms_ + "trans_x").c_str());
+	camera_info_.position_y = config->get_float((cfg_prefix_static_transforms_ + "trans_y").c_str());
+	camera_info_.position_z = config->get_float((cfg_prefix_static_transforms_ + "trans_z").c_str());
+	camera_info_.position_pitch =
+	  config->get_float((cfg_prefix_static_transforms_ + "rot_pitch").c_str());
+	camera_info_.opening_angle_horizontal =
+	  config->get_float((cfg_prefix_ + "camera_opening_angle_horizontal").c_str());
+	camera_info_.opening_angle_vertical =
+	  config->get_float((cfg_prefix_ + "camera_opening_angle_vertical").c_str());
+	// Calculate visible Area
+	camera_info_.angle_horizontal_to_opening_ =
+	  (1.57 - camera_info_.position_pitch) - (camera_info_.opening_angle_vertical / 2);
+	camera_info_.visible_lenght_x_in_m_ =
+	  camera_info_.position_z
+	  * (tan(camera_info_.opening_angle_vertical + camera_info_.angle_horizontal_to_opening_)
+	     - tan(camera_info_.angle_horizontal_to_opening_));
+	camera_info_.offset_cam_x_to_groundplane_ =
+	  camera_info_.position_z * tan(camera_info_.angle_horizontal_to_opening_);
+	camera_info_.visible_lenght_y_in_m_ =
+	  camera_info_.position_z * tan(camera_info_.opening_angle_horizontal / 2);
+	camera_info_.frame = config->get_string((cfg_prefix_static_transforms_ + "child_frame").c_str());
 
-  logger->log_debug(name(), "Camera opening angles Horizontal: %f Vertical: %f",
-                    camera_info_.opening_angle_horizontal,
-                    camera_info_.opening_angle_vertical);
+	logger->log_debug(name(),
+	                  "Camera opening angles Horizontal: %f Vertical: %f",
+	                  camera_info_.opening_angle_horizontal,
+	                  camera_info_.opening_angle_vertical);
 
-  cfg_debugMessagesActivated_ =
-      config->get_bool((cfg_prefix_ + "show_debug_messages").c_str());
-  cfg_paintROIsActivated_ =
-      config->get_bool((cfg_prefix_ + "draw_rois").c_str());
+	cfg_debugMessagesActivated_ = config->get_bool((cfg_prefix_ + "show_debug_messages").c_str());
+	cfg_paintROIsActivated_     = config->get_bool((cfg_prefix_ + "draw_rois").c_str());
 
-  search_area.start.x =
-      config->get_uint((cfg_prefix_ + "search_area/start/x").c_str());
-  search_area.start.y =
-      config->get_uint((cfg_prefix_ + "search_area/start/y").c_str());
-  search_area.width =
-      config->get_uint((cfg_prefix_ + "search_area/width").c_str());
-  search_area.height =
-      config->get_uint((cfg_prefix_ + "search_area/height").c_str());
-  search_area.color = firevision::C_BLUE;
+	search_area.start.x = config->get_uint((cfg_prefix_ + "search_area/start/x").c_str());
+	search_area.start.y = config->get_uint((cfg_prefix_ + "search_area/start/y").c_str());
+	search_area.width   = config->get_uint((cfg_prefix_ + "search_area/width").c_str());
+	search_area.height  = config->get_uint((cfg_prefix_ + "search_area/height").c_str());
+	search_area.color   = firevision::C_BLUE;
 
-  // Config Value for the classifier mode
-  cfg_check_yellow_dots_ =
-      config->get_bool((cfg_prefix_ + "puck/dots_required").c_str());
+	// Config Value for the classifier mode
+	cfg_check_yellow_dots_ = config->get_bool((cfg_prefix_ + "puck/dots_required").c_str());
 }
 
-void PuckVisionThread::init_with_config() {
-  // CAM swapping not working
-  if (false && cam_ != NULL) {
-    cam_->stop();
-    cam_->flush();
-    cam_->dispose_buffer();
-    cam_->close();
-    delete cam_;
-    cam_ = NULL;
-  }
-  if (cam_ == NULL) {
-    cam_ = vision_master->register_for_camera(camera_info_.connection.c_str(),
-                                              this);
-    cam_->start();
-    cam_->open();
-    camera_info_.img_width = cam_->pixel_width();
-    camera_info_.img_height = cam_->pixel_height();
+void
+PuckVisionThread::init_with_config()
+{
+	// CAM swapping not working
+	if (false && cam_ != NULL) {
+		cam_->stop();
+		cam_->flush();
+		cam_->dispose_buffer();
+		cam_->close();
+		delete cam_;
+		cam_ = NULL;
+	}
+	if (cam_ == NULL) {
+		cam_ = vision_master->register_for_camera(camera_info_.connection.c_str(), this);
+		cam_->start();
+		cam_->open();
+		camera_info_.img_width  = cam_->pixel_width();
+		camera_info_.img_height = cam_->pixel_height();
 
-    search_area.image_height = camera_info_.img_height;
-    search_area.image_width = camera_info_.img_width;
-    printRoi(search_area);
+		search_area.image_height = camera_info_.img_height;
+		search_area.image_width  = camera_info_.img_width;
+		printRoi(search_area);
 
-    cspaceFrom_ = cam_->colorspace();
+		cspaceFrom_ = cam_->colorspace();
 
-    // SHM image buffer
-    if (shm_buffer_ != NULL) {
-      delete shm_buffer_;
-      shm_buffer_ = NULL;
-      buffer_ = NULL;
-    }
-    std::string shmID =
-        config->get_string((cfg_prefix_ + "shm_image_id").c_str());
-    shm_buffer_ = new firevision::SharedMemoryImageBuffer(
-        shmID.c_str(), cspaceTo_, camera_info_.img_width,
-        camera_info_.img_height);
+		// SHM image buffer
+		if (shm_buffer_ != NULL) {
+			delete shm_buffer_;
+			shm_buffer_ = NULL;
+			buffer_     = NULL;
+		}
+		std::string shmID = config->get_string((cfg_prefix_ + "shm_image_id").c_str());
+		shm_buffer_       = new firevision::SharedMemoryImageBuffer(shmID.c_str(),
+                                                          cspaceTo_,
+                                                          camera_info_.img_width,
+                                                          camera_info_.img_height);
 
-    if (!shm_buffer_->is_valid()) {
-      delete shm_buffer_;
-      delete cam_;
-      shm_buffer_ = NULL;
-      cam_ = NULL;
-      throw fawkes::Exception("Shared memory segment not valid");
-    }
-    shm_buffer_->set_frame_id(camera_info_.frame.c_str());
+		if (!shm_buffer_->is_valid()) {
+			delete shm_buffer_;
+			delete cam_;
+			shm_buffer_ = NULL;
+			cam_        = NULL;
+			throw fawkes::Exception("Shared memory segment not valid");
+		}
+		shm_buffer_->set_frame_id(camera_info_.frame.c_str());
 
-    buffer_ = shm_buffer_->buffer();
-    camera_info_.fullimage = firevision::ROI::full_image(
-        camera_info_.img_width, camera_info_.img_height);
-  }
+		buffer_ = shm_buffer_->buffer();
+		camera_info_.fullimage =
+		  firevision::ROI::full_image(camera_info_.img_width, camera_info_.img_height);
+	}
 
-  //	//load puck infos;
-  puck_info_.radius = config->get_float((cfg_prefix_ + "puck/radius").c_str());
-  puck_info_.height = config->get_float((cfg_prefix_ + "puck/height").c_str());
+	//	//load puck infos;
+	puck_info_.radius = config->get_float((cfg_prefix_ + "puck/radius").c_str());
+	puck_info_.height = config->get_float((cfg_prefix_ + "puck/height").c_str());
 
-  firevision::color_t color_top_dots;
-  std::string prefix_new_pucks = "";
-  if (cfg_use_new_pucks_) {
-    color_top_dots = firevision::C_BLACK;
-    prefix_new_pucks = "/new_pucks";
-  } else {
-    color_top_dots = firevision::C_YELLOW;
-  }
+	firevision::color_t color_top_dots;
+	std::string         prefix_new_pucks = "";
+	if (cfg_use_new_pucks_) {
+		color_top_dots   = firevision::C_BLACK;
+		prefix_new_pucks = "/new_pucks";
+	} else {
+		color_top_dots = firevision::C_YELLOW;
+	}
 
-  setup_color_classifier(&puck_info_.main,
-                         ("puck/red" + prefix_new_pucks).c_str(),
-                         firevision::C_RED);
-  setup_color_classifier(&puck_info_.top_dots,
-                         ("puck/topdots" + prefix_new_pucks).c_str(),
-                         color_top_dots);
+	setup_color_classifier(&puck_info_.main,
+	                       ("puck/red" + prefix_new_pucks).c_str(),
+	                       firevision::C_RED);
+	setup_color_classifier(&puck_info_.top_dots,
+	                       ("puck/topdots" + prefix_new_pucks).c_str(),
+	                       color_top_dots);
 
-  logger->log_debug(name(),
-                    "Visible X: %f y: %f Offset cam groundplane: %f angle "
-                    "(horizontal/opening): %f ",
-                    camera_info_.visible_lenght_x_in_m_,
-                    camera_info_.visible_lenght_y_in_m_,
-                    camera_info_.offset_cam_x_to_groundplane_,
-                    camera_info_.angle_horizontal_to_opening_);
-  logger->log_debug(name(), "cam transform X: %f y: %f z: %f pitch: %f",
-                    camera_info_.position_x, camera_info_.position_y,
-                    camera_info_.position_z, camera_info_.position_pitch);
+	logger->log_debug(name(),
+	                  "Visible X: %f y: %f Offset cam groundplane: %f angle "
+	                  "(horizontal/opening): %f ",
+	                  camera_info_.visible_lenght_x_in_m_,
+	                  camera_info_.visible_lenght_y_in_m_,
+	                  camera_info_.offset_cam_x_to_groundplane_,
+	                  camera_info_.angle_horizontal_to_opening_);
+	logger->log_debug(name(),
+	                  "cam transform X: %f y: %f z: %f pitch: %f",
+	                  camera_info_.position_x,
+	                  camera_info_.position_y,
+	                  camera_info_.position_z,
+	                  camera_info_.position_pitch);
 }
 
-void PuckVisionThread::init() {
-  logger->log_info(name(), "starts init");
+void
+PuckVisionThread::init()
+{
+	logger->log_info(name(), "starts init");
 
-  config->add_change_handler(this);
+	config->add_change_handler(this);
 
-  drawer_ = new firevision::FilterROIDraw();
-  loadConfig();
-  init_with_config();
-  createPuckInterface();
+	drawer_ = new firevision::FilterROIDraw();
+	loadConfig();
+	init_with_config();
+	createPuckInterface();
 
-  logger->log_debug(name(), "end of init()");
+	logger->log_debug(name(), "end of init()");
 }
 
-void PuckVisionThread::deleteClassifier(
-    color_classifier_context_t_ *color_data) {
-  if (color_data->classifier != NULL) {
-    delete color_data->classifier;
-    color_data->classifier = NULL;
-  }
-  if (color_data->colormodel != NULL) {
-    delete color_data->colormodel;
-    color_data->colormodel = NULL;
-  }
-  if (color_data->classifier != NULL) {
-    delete color_data->scanline_grid;
-    color_data->scanline_grid = NULL;
-  }
-  if (!color_data->color_classes.empty()) {
-    while (!color_data->color_classes.empty()) {
-      firevision::ColorModelSimilarity::color_class_t *color_class =
-          color_data->color_classes.back();
-      color_data->color_classes.pop_back();
-      delete color_class;
-    }
-  }
+void
+PuckVisionThread::deleteClassifier(color_classifier_context_t_ *color_data)
+{
+	if (color_data->classifier != NULL) {
+		delete color_data->classifier;
+		color_data->classifier = NULL;
+	}
+	if (color_data->colormodel != NULL) {
+		delete color_data->colormodel;
+		color_data->colormodel = NULL;
+	}
+	if (color_data->classifier != NULL) {
+		delete color_data->scanline_grid;
+		color_data->scanline_grid = NULL;
+	}
+	if (!color_data->color_classes.empty()) {
+		while (!color_data->color_classes.empty()) {
+			firevision::ColorModelSimilarity::color_class_t *color_class =
+			  color_data->color_classes.back();
+			color_data->color_classes.pop_back();
+			delete color_class;
+		}
+	}
 }
 
-void PuckVisionThread::setup_color_classifier(
-    color_classifier_context_t_ *color_data, const char *prefix,
-    firevision::color_t expected) {
-  deleteClassifier(color_data);
-  // Update values from config
-  color_data->color_expect = expected;
-  color_data->cfg_ref_col =
-      config->get_uints((cfg_prefix_ + prefix + "/reference_color").c_str());
-  color_data->cfg_chroma_thresh =
-      config->get_int((cfg_prefix_ + prefix + "/chroma_thresh").c_str());
-  color_data->cfg_sat_thresh =
-      config->get_int((cfg_prefix_ + prefix + "/saturation_thresh").c_str());
-  color_data->cfg_roi_min_points =
-      config->get_int((cfg_prefix_ + prefix + "/min_points").c_str());
-  color_data->cfg_roi_basic_size =
-      config->get_int((cfg_prefix_ + prefix + "/basic_roi_size").c_str());
-  color_data->cfg_roi_neighborhood_min_match = config->get_int(
-      (cfg_prefix_ + prefix + "/neighborhood_min_match").c_str());
-  color_data->cfg_scangrid_x_offset =
-      config->get_int((cfg_prefix_ + prefix + "/scangrid_x_offset").c_str());
-  color_data->cfg_scangrid_y_offset =
-      config->get_int((cfg_prefix_ + prefix + "/scangrid_y_offset").c_str());
+void
+PuckVisionThread::setup_color_classifier(color_classifier_context_t_ *color_data,
+                                         const char *                 prefix,
+                                         firevision::color_t          expected)
+{
+	deleteClassifier(color_data);
+	// Update values from config
+	color_data->color_expect = expected;
+	color_data->cfg_ref_col  = config->get_uints((cfg_prefix_ + prefix + "/reference_color").c_str());
+	color_data->cfg_chroma_thresh =
+	  config->get_int((cfg_prefix_ + prefix + "/chroma_thresh").c_str());
+	color_data->cfg_sat_thresh =
+	  config->get_int((cfg_prefix_ + prefix + "/saturation_thresh").c_str());
+	color_data->cfg_roi_min_points = config->get_int((cfg_prefix_ + prefix + "/min_points").c_str());
+	color_data->cfg_roi_basic_size =
+	  config->get_int((cfg_prefix_ + prefix + "/basic_roi_size").c_str());
+	color_data->cfg_roi_neighborhood_min_match =
+	  config->get_int((cfg_prefix_ + prefix + "/neighborhood_min_match").c_str());
+	color_data->cfg_scangrid_x_offset =
+	  config->get_int((cfg_prefix_ + prefix + "/scangrid_x_offset").c_str());
+	color_data->cfg_scangrid_y_offset =
+	  config->get_int((cfg_prefix_ + prefix + "/scangrid_y_offset").c_str());
 
-  std::string cfg_color_mode =
-      config->get_string((cfg_prefix_ + prefix + "/colormodel_mode").c_str());
+	std::string cfg_color_mode =
+	  config->get_string((cfg_prefix_ + prefix + "/colormodel_mode").c_str());
 
-  color_data->scanline_grid = new firevision::ScanlineGrid(
-      camera_info_.img_width, camera_info_.img_height,
-      color_data->cfg_scangrid_x_offset, color_data->cfg_scangrid_y_offset);
+	color_data->scanline_grid = new firevision::ScanlineGrid(camera_info_.img_width,
+	                                                         camera_info_.img_height,
+	                                                         color_data->cfg_scangrid_x_offset,
+	                                                         color_data->cfg_scangrid_y_offset);
 
-  if (cfg_color_mode == "colormap") {
-    std::string lutname = std::string(prefix) + "/lut"; //"puck_vison/" +
-    std::string filename =
-        std::string(CONFDIR) + "/" +
-        config->get_string((cfg_prefix_ + prefix + "/lut").c_str());
-    color_data->colormodel = new firevision::ColorModelLookupTable(
-        filename.c_str(), lutname.c_str(), true /* destroy on delete */
-    );
+	if (cfg_color_mode == "colormap") {
+		std::string lutname = std::string(prefix) + "/lut"; //"puck_vison/" +
+		std::string filename =
+		  std::string(CONFDIR) + "/" + config->get_string((cfg_prefix_ + prefix + "/lut").c_str());
+		color_data->colormodel = new firevision::ColorModelLookupTable(filename.c_str(),
+		                                                               lutname.c_str(),
+		                                                               true /* destroy on delete */
+		);
 
-  } else if (cfg_color_mode == "similarity") {
-    firevision::ColorModelSimilarity *cm =
-        new firevision::ColorModelSimilarity();
+	} else if (cfg_color_mode == "similarity") {
+		firevision::ColorModelSimilarity *cm = new firevision::ColorModelSimilarity();
 
-    while (!color_data->cfg_ref_col.empty()) {
-      std::vector<unsigned int> color(color_data->cfg_ref_col.begin(),
-                                      color_data->cfg_ref_col.begin() + 3);
-      color_data->cfg_ref_col = std::vector<unsigned int>(
-          color_data->cfg_ref_col.begin() + 3, color_data->cfg_ref_col.end());
-      firevision::ColorModelSimilarity::color_class_t *color_class =
-          new firevision::ColorModelSimilarity::color_class_t(
-              color_data->color_expect, color, color_data->cfg_chroma_thresh,
-              color_data->cfg_sat_thresh);
+		while (!color_data->cfg_ref_col.empty()) {
+			std::vector<unsigned int> color(color_data->cfg_ref_col.begin(),
+			                                color_data->cfg_ref_col.begin() + 3);
+			color_data->cfg_ref_col = std::vector<unsigned int>(color_data->cfg_ref_col.begin() + 3,
+			                                                    color_data->cfg_ref_col.end());
+			firevision::ColorModelSimilarity::color_class_t *color_class =
+			  new firevision::ColorModelSimilarity::color_class_t(color_data->color_expect,
+			                                                      color,
+			                                                      color_data->cfg_chroma_thresh,
+			                                                      color_data->cfg_sat_thresh);
 
-      color_data->color_classes.push_back(color_class);
-      cm->add_color(color_class);
-      logger->log_info(name(), "Color %i added reference color R:%i G:%i B:%i",
-                       color_data->color_expect, color[0], color[1], color[2]);
-    }
+			color_data->color_classes.push_back(color_class);
+			cm->add_color(color_class);
+			logger->log_info(name(),
+			                 "Color %i added reference color R:%i G:%i B:%i",
+			                 color_data->color_expect,
+			                 color[0],
+			                 color[1],
+			                 color[2]);
+		}
 
-    color_data->colormodel = cm;
-    color_data->classifier = new firevision::SimpleColorClassifier(
-        color_data->scanline_grid, color_data->colormodel,
-        color_data->cfg_roi_min_points, color_data->cfg_roi_basic_size, false,
-        color_data->cfg_roi_neighborhood_min_match, 0,
-        color_data->color_expect);
-  } else if (cfg_color_mode == "thresholds_black") {
-    //	  unsigned int y_thresh;
-    //	  unsigned int u_thresh;
-    //	  unsigned int v_thresh;
-    //	  unsigned int ref_u;
-    //	  unsigned int ref_v;
-    firevision::ColorModelBlack *cm = new firevision::ColorModelBlack(
-        /*y_thresh, u_thresh, v_thresh, ref_u, ref_v*/);
+		color_data->colormodel = cm;
+		color_data->classifier =
+		  new firevision::SimpleColorClassifier(color_data->scanline_grid,
+		                                        color_data->colormodel,
+		                                        color_data->cfg_roi_min_points,
+		                                        color_data->cfg_roi_basic_size,
+		                                        false,
+		                                        color_data->cfg_roi_neighborhood_min_match,
+		                                        0,
+		                                        color_data->color_expect);
+	} else if (cfg_color_mode == "thresholds_black") {
+		//	  unsigned int y_thresh;
+		//	  unsigned int u_thresh;
+		//	  unsigned int v_thresh;
+		//	  unsigned int ref_u;
+		//	  unsigned int ref_v;
+		firevision::ColorModelBlack *cm = new firevision::ColorModelBlack(
+		  /*y_thresh, u_thresh, v_thresh, ref_u, ref_v*/);
 
-    color_data->colormodel = cm;
-    color_data->classifier = new firevision::SimpleColorClassifier(
-        color_data->scanline_grid, color_data->colormodel,
-        color_data->cfg_roi_min_points, color_data->cfg_roi_basic_size, false,
-        color_data->cfg_roi_neighborhood_min_match, 0,
-        color_data->color_expect);
-  } else {
-    throw new fawkes::Exception("selected colormodel not supported");
-  }
+		color_data->colormodel = cm;
+		color_data->classifier =
+		  new firevision::SimpleColorClassifier(color_data->scanline_grid,
+		                                        color_data->colormodel,
+		                                        color_data->cfg_roi_min_points,
+		                                        color_data->cfg_roi_basic_size,
+		                                        false,
+		                                        color_data->cfg_roi_neighborhood_min_match,
+		                                        0,
+		                                        color_data->color_expect);
+	} else {
+		throw new fawkes::Exception("selected colormodel not supported");
+	}
 }
 
-void PuckVisionThread::drawRois(std::list<firevision::ROI> *rois_) {
-  if (cfg_paintROIsActivated_) {
-    for (std::list<firevision::ROI>::iterator list_iter = rois_->begin();
-         list_iter != rois_->end(); list_iter++) {
-      drawROIIntoBuffer(*list_iter, firevision::FilterROIDraw::DASHED_HINT);
-    }
-  }
+void
+PuckVisionThread::drawRois(std::list<firevision::ROI> *rois_)
+{
+	if (cfg_paintROIsActivated_) {
+		for (std::list<firevision::ROI>::iterator list_iter = rois_->begin(); list_iter != rois_->end();
+		     list_iter++) {
+			drawROIIntoBuffer(*list_iter, firevision::FilterROIDraw::DASHED_HINT);
+		}
+	}
 }
 
-void PuckVisionThread::mergeWithColorInformation(
-    firevision::color_t color, std::list<firevision::ROI> *rois_color_,
-    std::list<firevision::ROI> *rois_all) {
-  while (rois_color_->size() != 0) {
-    rois_color_->front().color = color;
-    rois_all->push_front(rois_color_->front());
-    rois_color_->pop_front();
-  }
+void
+PuckVisionThread::mergeWithColorInformation(firevision::color_t         color,
+                                            std::list<firevision::ROI> *rois_color_,
+                                            std::list<firevision::ROI> *rois_all)
+{
+	while (rois_color_->size() != 0) {
+		rois_color_->front().color = color;
+		rois_all->push_front(rois_color_->front());
+		rois_color_->pop_front();
+	}
 }
 
-void PuckVisionThread::loop() {
-  if (!cfg_mutex_.try_lock()) {
-    logger->log_info(name(), "Skipping loop(), mutex locked");
-    return; // If I cant lock it its locked already (config is changing/reinit
-            // in progress)
-  } else {
-    if (cam_ != NULL && !cam_->ready()) {
-      logger->log_info(name(), "camera not ready\n");
-      loadConfig();
-      return;
-    }
-    // logger->log_info(name(), "capture");
-    cam_->capture();
-    firevision::convert(cspaceFrom_, cspaceTo_, cam_->buffer(), buffer_,
-                        camera_info_.img_width, camera_info_.img_height);
-    cam_->dispose_buffer();
+void
+PuckVisionThread::loop()
+{
+	if (!cfg_mutex_.try_lock()) {
+		logger->log_info(name(), "Skipping loop(), mutex locked");
+		return; // If I cant lock it its locked already (config is changing/reinit
+		        // in progress)
+	} else {
+		if (cam_ != NULL && !cam_->ready()) {
+			logger->log_info(name(), "camera not ready\n");
+			loadConfig();
+			return;
+		}
+		// logger->log_info(name(), "capture");
+		cam_->capture();
+		firevision::convert(cspaceFrom_,
+		                    cspaceTo_,
+		                    cam_->buffer(),
+		                    buffer_,
+		                    camera_info_.img_width,
+		                    camera_info_.img_height);
+		cam_->dispose_buffer();
 
-    std::list<firevision::ROI> pucks_in_view = detectPucks();
-    std::vector<puck> pucks;
+		std::list<firevision::ROI> pucks_in_view = detectPucks();
+		std::vector<puck>          pucks;
 
-    // calculate ROI to POS3D
-    calculatePuckPositions(&pucks, pucks_in_view);
-    // sort pucks
-    sortPucks(&pucks);
+		// calculate ROI to POS3D
+		calculatePuckPositions(&pucks, pucks_in_view);
+		// sort pucks
+		sortPucks(&pucks);
 
-    updateInterface(&pucks);
-  }
-  cfg_mutex_.unlock();
+		updateInterface(&pucks);
+	}
+	cfg_mutex_.unlock();
 }
 
-void PuckVisionThread::sortPucks(std::vector<puck> *pucks) {
-  // Sort pucks
-  std::sort(
-      pucks->begin(), pucks->end(),
-      [](const puck a, const puck &b) -> bool { return a.pol.r < b.pol.r; });
+void
+PuckVisionThread::sortPucks(std::vector<puck> *pucks)
+{
+	// Sort pucks
+	std::sort(pucks->begin(), pucks->end(), [](const puck a, const puck &b) -> bool {
+		return a.pol.r < b.pol.r;
+	});
 }
 
-void PuckVisionThread::calculatePuckPositions(
-    std::vector<puck> *pucks, std::list<firevision::ROI> pucks_in_view) {
-  for (std::list<firevision::ROI>::iterator it = pucks_in_view.begin();
-       it != pucks_in_view.end(); it++) {
-    puck p;
-    getPuckPosition(&p, (*it));
-    pucks->push_back(p);
-  }
+void
+PuckVisionThread::calculatePuckPositions(std::vector<puck> *        pucks,
+                                         std::list<firevision::ROI> pucks_in_view)
+{
+	for (std::list<firevision::ROI>::iterator it = pucks_in_view.begin(); it != pucks_in_view.end();
+	     it++) {
+		puck p;
+		getPuckPosition(&p, (*it));
+		pucks->push_back(p);
+	}
 }
 
-void PuckVisionThread::printRoi(firevision::ROI roi) {
-  if (cfg_debugMessagesActivated_) {
-    logger->log_debug(name(),
-                      "x: %i y: %i width: %i height: %i color: %i image_hight: "
-                      "%i image_width: %i",
-                      roi.start.x, roi.start.y, roi.width, roi.height,
-                      roi.color, roi.image_height, roi.image_width);
-  }
+void
+PuckVisionThread::printRoi(firevision::ROI roi)
+{
+	if (cfg_debugMessagesActivated_) {
+		logger->log_debug(name(),
+		                  "x: %i y: %i width: %i height: %i color: %i image_hight: "
+		                  "%i image_width: %i",
+		                  roi.start.x,
+		                  roi.start.y,
+		                  roi.width,
+		                  roi.height,
+		                  roi.color,
+		                  roi.image_height,
+		                  roi.image_width);
+	}
 }
 
-std::list<firevision::ROI> *splitROI(firevision::ROI bigroi,
-                                     firevision::ROI cut) {
-  std::list<firevision::ROI> *rois = new std::list<firevision::ROI>();
+std::list<firevision::ROI> *
+splitROI(firevision::ROI bigroi, firevision::ROI cut)
+{
+	std::list<firevision::ROI> *rois = new std::list<firevision::ROI>();
 
-  //	unsigned int center_x = cut.start.x+cut.width/2;
-  //	unsigned int center_y = cut.start.y+cut.height/2;
-  //	if(bigroi.contains(center_x, center_y)){
-  //		if( (bigroi.width - cut.width) > 50){ //check if roi width makes
-  // sense to cut
-  //
-  //			firevision::ROI roi(bigroi);
-  //			int posx = bigroi.start.x - cut.start.x;
-  //			if( posx > 0 ){ //cut left from roi
-  //				//change width
-  //			}
-  //			else{
-  //				//change width and start
-  //
-  //			}
-  //		}
-  //	}
+	//	unsigned int center_x = cut.start.x+cut.width/2;
+	//	unsigned int center_y = cut.start.y+cut.height/2;
+	//	if(bigroi.contains(center_x, center_y)){
+	//		if( (bigroi.width - cut.width) > 50){ //check if roi width makes
+	// sense to cut
+	//
+	//			firevision::ROI roi(bigroi);
+	//			int posx = bigroi.start.x - cut.start.x;
+	//			if( posx > 0 ){ //cut left from roi
+	//				//change width
+	//			}
+	//			else{
+	//				//change width and start
+	//
+	//			}
+	//		}
+	//	}
 
-  return rois;
+	return rois;
 }
 
-void PuckVisionThread::fitROI(firevision::ROI &roi, int x, int y, int w,
-                              int h) {
-  // Check x position in in image range
-  if (cfg_debugMessagesActivated_) {
-    logger->log_debug(name(), "Fit puck %i %i %i %i", x, y, w, h);
-    printRoi(roi);
-  }
+void
+PuckVisionThread::fitROI(firevision::ROI &roi, int x, int y, int w, int h)
+{
+	// Check x position in in image range
+	if (cfg_debugMessagesActivated_) {
+		logger->log_debug(name(), "Fit puck %i %i %i %i", x, y, w, h);
+		printRoi(roi);
+	}
 
-  firevision::ROI old(roi);
+	firevision::ROI old(roi);
 
-  roi.start.x = std::max(0, (std::min((int)roi.image_width, x)));
-  roi.start.y = std::max(0, (std::min((int)roi.image_height, y)));
+	roi.start.x = std::max(0, (std::min((int)roi.image_width, x)));
+	roi.start.y = std::max(0, (std::min((int)roi.image_height, y)));
 
-  roi.width = std::max(0, (std::min((int)roi.image_width, w)));
-  roi.height = std::max(0, (std::min((int)roi.image_height, h)));
+	roi.width  = std::max(0, (std::min((int)roi.image_width, w)));
+	roi.height = std::max(0, (std::min((int)roi.image_height, h)));
 
-  if (roi.start.x + roi.width > roi.image_width) {
-    roi.width = roi.image_width - roi.start.x;
-  }
+	if (roi.start.x + roi.width > roi.image_width) {
+		roi.width = roi.image_width - roi.start.x;
+	}
 
-  if (roi.start.y + roi.height > roi.image_height) {
-    roi.height = roi.image_height - roi.start.y;
-  }
+	if (roi.start.y + roi.height > roi.image_height) {
+		roi.height = roi.image_height - roi.start.y;
+	}
 
-  if (roi.start.y + roi.height > roi.image_height ||
-      roi.start.x + roi.width > roi.image_width) {
-    logger->log_error(
-        name(),
-        "Failed fitRoi(x: %i y: %i w: %i h: %i) with roi: x: %i y:%i width: %i "
-        "height: %i , image_width: %i image_height: %i",
-        x, y, w, h, old.start.x, old.start.y, old.width, old.height,
-        old.image_width, old.image_height);
-    logger->log_error(name(),
-                      "Results Roi: x: %i y:%i width: %i height: %i , "
-                      "image_width: %i image_height: %i",
-                      roi.start.x, roi.start.y, roi.width, roi.height,
-                      roi.image_width, roi.image_height);
-  } else if (cfg_debugMessagesActivated_) {
-    printRoi(roi);
-  }
+	if (roi.start.y + roi.height > roi.image_height || roi.start.x + roi.width > roi.image_width) {
+		logger->log_error(name(),
+		                  "Failed fitRoi(x: %i y: %i w: %i h: %i) with roi: x: %i y:%i width: %i "
+		                  "height: %i , image_width: %i image_height: %i",
+		                  x,
+		                  y,
+		                  w,
+		                  h,
+		                  old.start.x,
+		                  old.start.y,
+		                  old.width,
+		                  old.height,
+		                  old.image_width,
+		                  old.image_height);
+		logger->log_error(name(),
+		                  "Results Roi: x: %i y:%i width: %i height: %i , "
+		                  "image_width: %i image_height: %i",
+		                  roi.start.x,
+		                  roi.start.y,
+		                  roi.width,
+		                  roi.height,
+		                  roi.image_width,
+		                  roi.image_height);
+	} else if (cfg_debugMessagesActivated_) {
+		printRoi(roi);
+	}
 }
 
 /** detectPucks
  *  Returns a list of ROIs. Each ROI contains a Puck
  */
-std::list<firevision::ROI> PuckVisionThread::detectPucks() {
+std::list<firevision::ROI>
+PuckVisionThread::detectPucks()
+{
+	std::list<firevision::ROI> rois_all_;
+	std::list<firevision::ROI> pucks;
 
-  std::list<firevision::ROI> rois_all_;
-  std::list<firevision::ROI> pucks;
+	// Find all RED Areas ( Can contain multiple Pucks, or no Pucks (just red
+	// without any features)
+	std::list<firevision::ROI> *rois_red_ = classifyInRoi(search_area, &puck_info_.main);
 
-  // Find all RED Areas ( Can contain multiple Pucks, or no Pucks (just red
-  // without any features)
-  std::list<firevision::ROI> *rois_red_ =
-      classifyInRoi(search_area, &puck_info_.main);
+	for (std::list<firevision::ROI>::iterator big_red_rois_it = rois_red_->begin();
+	     big_red_rois_it != rois_red_->end();
+	     ++big_red_rois_it) {
+		firevision::ROI scan_for_red((*big_red_rois_it));
+		{
+			// Scan the bottem of the red roi to seperate the pucks
+			int x, y, w, h;
+			h = std::max(search_area.height / 10, (unsigned int)10);
+			w = (*big_red_rois_it).width; // scan the full width of the search area
+			x = (*big_red_rois_it).start.x;
+			y = (*big_red_rois_it).start.y + (*big_red_rois_it).height
+			    - h / 2; // search in the lowest area of the possible puck
 
-  for (std::list<firevision::ROI>::iterator big_red_rois_it =
-           rois_red_->begin();
-       big_red_rois_it != rois_red_->end(); ++big_red_rois_it) {
+			fitROI(scan_for_red, x, y, w, h);
+		}
 
-    firevision::ROI scan_for_red((*big_red_rois_it));
-    {
-      // Scan the bottem of the red roi to seperate the pucks
-      int x, y, w, h;
-      h = std::max(search_area.height / 10, (unsigned int)10);
-      w = (*big_red_rois_it).width; // scan the full width of the search area
-      x = (*big_red_rois_it).start.x;
-      y = (*big_red_rois_it).start.y + (*big_red_rois_it).height -
-          h / 2; // search in the lowest area of the possible puck
+		scan_for_red.color = firevision::C_GREEN;
+		drawROIIntoBuffer(scan_for_red);
 
-      fitROI(scan_for_red, x, y, w, h);
-    }
+		std::list<firevision::ROI> *possible_pucks_bottem =
+		  classifyInRoi(scan_for_red, &puck_info_.main);
+		// Scan for red end
 
-    scan_for_red.color = firevision::C_GREEN;
-    drawROIIntoBuffer(scan_for_red);
+		// enlarge rois (height and check for puck features (Yellow dots)
+		for (std::list<firevision::ROI>::iterator possible_puck_it = possible_pucks_bottem->begin();
+		     possible_puck_it != possible_pucks_bottem->end();
+		     ++possible_puck_it) {
+			// Enlarge ROI for yellow dots
+			if (cfg_check_yellow_dots_) {
+				// unsigned int shift = possible_puck_it->height/10; //shift roi up a
+				// bit (yellow dots can be over the red area)
+				(*possible_puck_it).color = firevision::C_BLUE;
+				drawROIIntoBuffer((*possible_puck_it));
+				int x, y, w, h;
+				int enlarge = (*possible_puck_it).width / 5;
+				;
+				h = (*possible_puck_it).width;
+				x = (*possible_puck_it).start.x - enlarge / 2;
+				y = (*possible_puck_it).start.y + (*possible_puck_it).height - h; // lower bound - hight
+				w = (*possible_puck_it).width + enlarge;
+				fitROI((*possible_puck_it), x, y, w, h);
 
-    std::list<firevision::ROI> *possible_pucks_bottem =
-        classifyInRoi(scan_for_red, &puck_info_.main);
-    // Scan for red end
-
-    // enlarge rois (height and check for puck features (Yellow dots)
-    for (std::list<firevision::ROI>::iterator possible_puck_it =
-             possible_pucks_bottem->begin();
-         possible_puck_it != possible_pucks_bottem->end(); ++possible_puck_it) {
-      // Enlarge ROI for yellow dots
-      if (cfg_check_yellow_dots_) {
-        // unsigned int shift = possible_puck_it->height/10; //shift roi up a
-        // bit (yellow dots can be over the red area)
-        (*possible_puck_it).color = firevision::C_BLUE;
-        drawROIIntoBuffer((*possible_puck_it));
-        int x, y, w, h;
-        int enlarge = (*possible_puck_it).width / 5;
-        ;
-        h = (*possible_puck_it).width;
-        x = (*possible_puck_it).start.x - enlarge / 2;
-        y = (*possible_puck_it).start.y + (*possible_puck_it).height -
-            h; // lower bound - hight
-        w = (*possible_puck_it).width + enlarge;
-        fitROI((*possible_puck_it), x, y, w, h);
-
-        // Search in this roi for yellow dots
-        std::list<firevision::ROI> *yellow_rois =
-            classifyInRoi((*possible_puck_it), &puck_info_.top_dots);
-        drawRois(yellow_rois);
-        if (yellow_rois->size() > 2) { // ROI has enough features its a PUCK
-          firevision::ROI mypuck((*possible_puck_it));
-          mypuck.color = firevision::C_WHITE;
-          pucks.push_back(mypuck);
-        }
-        delete yellow_rois;
-      } else { /* Dont check for yellow dots, all elements with proper color are
+				// Search in this roi for yellow dots
+				std::list<firevision::ROI> *yellow_rois =
+				  classifyInRoi((*possible_puck_it), &puck_info_.top_dots);
+				drawRois(yellow_rois);
+				if (yellow_rois->size() > 2) { // ROI has enough features its a PUCK
+					firevision::ROI mypuck((*possible_puck_it));
+					mypuck.color = firevision::C_WHITE;
+					pucks.push_back(mypuck);
+				}
+				delete yellow_rois;
+			} else { /* Dont check for yellow dots, all elements with proper color are
                   pucks */
-        firevision::ROI mypuck((*possible_puck_it));
-        mypuck.color = firevision::C_WHITE;
-        pucks.push_back(mypuck);
-      }
-    }
+				firevision::ROI mypuck((*possible_puck_it));
+				mypuck.color = firevision::C_WHITE;
+				pucks.push_back(mypuck);
+			}
+		}
 
-    delete possible_pucks_bottem;
-  }
+		delete possible_pucks_bottem;
+	}
 
-  drawRois(&rois_all_);
-  drawRois(&pucks);
-  drawROIIntoBuffer(search_area);
+	drawRois(&rois_all_);
+	drawRois(&pucks);
+	drawROIIntoBuffer(search_area);
 
-  return pucks;
+	return pucks;
 }
 
 firevision::ROI *
 PuckVisionThread::getRoiContainingRoi(std::list<firevision::ROI> *roiList,
-                                      firevision::ROI containing) {
-  for (std::list<firevision::ROI>::iterator it = roiList->begin();
-       it != roiList->end(); ++it) {
-    if ((*it).contains(containing.start.x + containing.width / 2,
-                       +containing.start.y + containing.height / 2)) {
-      return new firevision::ROI(*it);
-    }
-  }
-  return NULL; // getBiggestRoi(roiList);
+                                      firevision::ROI             containing)
+{
+	for (std::list<firevision::ROI>::iterator it = roiList->begin(); it != roiList->end(); ++it) {
+		if ((*it).contains(containing.start.x + containing.width / 2,
+		                   +containing.start.y + containing.height / 2)) {
+			return new firevision::ROI(*it);
+		}
+	}
+	return NULL; // getBiggestRoi(roiList);
 }
 
 firevision::ROI *
-PuckVisionThread::getBiggestRoi(std::list<firevision::ROI> *roiList) {
-  firevision::ROI *biggestRoi = NULL;
+PuckVisionThread::getBiggestRoi(std::list<firevision::ROI> *roiList)
+{
+	firevision::ROI *biggestRoi = NULL;
 
-  for (std::list<firevision::ROI>::iterator it = roiList->begin();
-       it != roiList->end(); ++it) {
-    if (biggestRoi == NULL ||
-        biggestRoi->width * biggestRoi->height < (*it).width * (*it).height) {
-      biggestRoi = &(*it);
-    }
-  }
-  if (biggestRoi != NULL) {
-    return new firevision::ROI(biggestRoi);
-  }
-  return NULL;
+	for (std::list<firevision::ROI>::iterator it = roiList->begin(); it != roiList->end(); ++it) {
+		if (biggestRoi == NULL || biggestRoi->width * biggestRoi->height < (*it).width * (*it).height) {
+			biggestRoi = &(*it);
+		}
+	}
+	if (biggestRoi != NULL) {
+		return new firevision::ROI(biggestRoi);
+	}
+	return NULL;
 }
 
-PuckVisionThread::~PuckVisionThread() {
-  // TODO Auto-generated destructor stub
+PuckVisionThread::~PuckVisionThread()
+{
+	// TODO Auto-generated destructor stub
 }
 
-void PuckVisionThread::cartToPol(fawkes::polar_coord_2d_t &pol, float x,
-                                 float y) {
-  pol.phi = atan2f(y, x);
-  pol.r = sqrtf(x * x + y * y);
+void
+PuckVisionThread::cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y)
+{
+	pol.phi = atan2f(y, x);
+	pol.r   = sqrtf(x * x + y * y);
 
-  if (cfg_debugMessagesActivated_) {
-    logger->log_debug(name(), "x: %f; y: %f", x, y);
-    logger->log_debug(name(), "Calculated r: %f; phi: %f", pol.r, pol.phi);
-  }
+	if (cfg_debugMessagesActivated_) {
+		logger->log_debug(name(), "x: %f; y: %f", x, y);
+		logger->log_debug(name(), "Calculated r: %f; phi: %f", pol.r, pol.phi);
+	}
 }
 
-void PuckVisionThread::polToCart(float &x, float &y,
-                                 fawkes::polar_coord_2d_t pol) {
-  x = pol.r * std::cos(pol.phi);
-  y = pol.r * std::sin(pol.phi);
+void
+PuckVisionThread::polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol)
+{
+	x = pol.r * std::cos(pol.phi);
+	y = pol.r * std::sin(pol.phi);
 }
 
-void PuckVisionThread::drawROIIntoBuffer(
-    firevision::ROI roi,
-    firevision::FilterROIDraw::border_style_t borderStyle) {
-  try {
-    if (cfg_paintROIsActivated_) {
-      drawer_->set_src_buffer(
-          buffer_,
-          firevision::ROI::full_image(camera_info_.img_width,
-                                      camera_info_.img_height),
-          0);
-      drawer_->set_dst_buffer(buffer_, &roi);
-      drawer_->set_style(borderStyle);
-      drawer_->apply();
-      if (cfg_debugMessagesActivated_) {
-        logger->log_debug(name(), "drawed element in buffer");
-      }
-    }
-  } catch (fawkes::Exception &e) {
-    logger->log_error(name(), e);
-  }
+void
+PuckVisionThread::drawROIIntoBuffer(firevision::ROI                           roi,
+                                    firevision::FilterROIDraw::border_style_t borderStyle)
+{
+	try {
+		if (cfg_paintROIsActivated_) {
+			drawer_->set_src_buffer(
+			  buffer_, firevision::ROI::full_image(camera_info_.img_width, camera_info_.img_height), 0);
+			drawer_->set_dst_buffer(buffer_, &roi);
+			drawer_->set_style(borderStyle);
+			drawer_->apply();
+			if (cfg_debugMessagesActivated_) {
+				logger->log_debug(name(), "drawed element in buffer");
+			}
+		}
+	} catch (fawkes::Exception &e) {
+		logger->log_error(name(), e);
+	}
 }
 
 std::list<firevision::ROI> *
-PuckVisionThread::classifyInRoi(firevision::ROI searchArea,
-                                color_classifier_context_t_ *color_data) {
-  try {
-    color_data->scanline_grid->reset();
-    color_data->scanline_grid->set_roi(&searchArea);
-    color_data->classifier->set_src_buffer(buffer_, camera_info_.img_width,
-                                           camera_info_.img_height);
+PuckVisionThread::classifyInRoi(firevision::ROI searchArea, color_classifier_context_t_ *color_data)
+{
+	try {
+		color_data->scanline_grid->reset();
+		color_data->scanline_grid->set_roi(&searchArea);
+		color_data->classifier->set_src_buffer(buffer_,
+		                                       camera_info_.img_width,
+		                                       camera_info_.img_height);
 
-    std::list<firevision::ROI> *ROIs = color_data->classifier->classify();
+		std::list<firevision::ROI> *ROIs = color_data->classifier->classify();
 
-    return ROIs;
-  } catch (fawkes::Exception &e) {
-    logger->log_error(name(), e);
-  }
-  return new std::list<firevision::ROI>; // return a empty list if a exception
-                                         // is thrown
+		return ROIs;
+	} catch (fawkes::Exception &e) {
+		logger->log_error(name(), e);
+	}
+	return new std::list<firevision::ROI>; // return a empty list if a exception
+	                                       // is thrown
 }
 
-float PuckVisionThread::getX(firevision::ROI *roi) {
-  // Distance X
-  int roiPositionY = camera_info_.img_height - (roi->start.y + roi->height / 2);
-  float angle = ((float)roiPositionY * camera_info_.opening_angle_vertical) /
-                (float)camera_info_.img_height;
-  float distance_x = camera_info_.position_z *
-                     (tan(angle + camera_info_.angle_horizontal_to_opening_) -
-                      tan(camera_info_.angle_horizontal_to_opening_));
+float
+PuckVisionThread::getX(firevision::ROI *roi)
+{
+	// Distance X
+	int   roiPositionY = camera_info_.img_height - (roi->start.y + roi->height / 2);
+	float angle =
+	  ((float)roiPositionY * camera_info_.opening_angle_vertical) / (float)camera_info_.img_height;
+	float distance_x = camera_info_.position_z
+	                   * (tan(angle + camera_info_.angle_horizontal_to_opening_)
+	                      - tan(camera_info_.angle_horizontal_to_opening_));
 
-  // logger->log_debug(name(),"angle: %f, image_size x: %i y: %i,roi x: %i y:
-  // %i", (angle*180) / M_PI, img_width_, img_height_, roi->start.x,
-  // roi->start.y);
+	// logger->log_debug(name(),"angle: %f, image_size x: %i y: %i,roi x: %i y:
+	// %i", (angle*180) / M_PI, img_width_, img_height_, roi->start.x,
+	// roi->start.y);
 
-  return distance_x + camera_info_.offset_cam_x_to_groundplane_;
-  ;
+	return distance_x + camera_info_.offset_cam_x_to_groundplane_;
+	;
 }
 
-float PuckVisionThread::getY(firevision::ROI *roi) {
-  // Left-Right
-  int roiPositionX = (roi->start.x + roi->width / 2);
-  float alpha = ((((float)camera_info_.img_width / 2) - (float)roiPositionX) /
-                 ((float)camera_info_.img_width / 2)) *
-                (camera_info_.opening_angle_horizontal / 2);
-  float x = getX(roi);
-  float position_y_in_m = sin(alpha * x);
+float
+PuckVisionThread::getY(firevision::ROI *roi)
+{
+	// Left-Right
+	int   roiPositionX = (roi->start.x + roi->width / 2);
+	float alpha        = ((((float)camera_info_.img_width / 2) - (float)roiPositionX)
+                 / ((float)camera_info_.img_width / 2))
+	              * (camera_info_.opening_angle_horizontal / 2);
+	float x               = getX(roi);
+	float position_y_in_m = sin(alpha * x);
 
-  // logger->log_debug(name(),"angle: %f, roi pos X: %i, distance y: %f, cfg
-  // %f", alpha, roiPositionX, position_y_in_m,
-  // cfg_camera_opening_angle_horizontal_);
+	// logger->log_debug(name(),"angle: %f, roi pos X: %i, distance y: %f, cfg
+	// %f", alpha, roiPositionX, position_y_in_m,
+	// cfg_camera_opening_angle_horizontal_);
 
-  return position_y_in_m;
+	return position_y_in_m;
 }
 
-void PuckVisionThread::getPuckPosition(puck *p, firevision::ROI roi) {
-  // Left-Right
-  int roiPositionX_L = (roi.start.x);
-  int roiPositionX_R = (roi.start.x + roi.width);
-  float alpha_L =
-      ((((float)camera_info_.img_width / 2) - (float)roiPositionX_L) /
-       ((float)camera_info_.img_width / 2)) *
-      (camera_info_.opening_angle_horizontal / 2);
-  float alpha_R =
-      ((((float)camera_info_.img_width / 2) - (float)roiPositionX_R) /
-       ((float)camera_info_.img_width / 2)) *
-      (camera_info_.opening_angle_horizontal / 2);
-  float x = getX(&roi);
-  float position_y_in_m_L = sin(alpha_L * x);
-  float position_y_in_m_R = sin(alpha_R * x);
+void
+PuckVisionThread::getPuckPosition(puck *p, firevision::ROI roi)
+{
+	// Left-Right
+	int   roiPositionX_L = (roi.start.x);
+	int   roiPositionX_R = (roi.start.x + roi.width);
+	float alpha_L        = ((((float)camera_info_.img_width / 2) - (float)roiPositionX_L)
+                   / ((float)camera_info_.img_width / 2))
+	                * (camera_info_.opening_angle_horizontal / 2);
+	float alpha_R = ((((float)camera_info_.img_width / 2) - (float)roiPositionX_R)
+	                 / ((float)camera_info_.img_width / 2))
+	                * (camera_info_.opening_angle_horizontal / 2);
+	float x                 = getX(&roi);
+	float position_y_in_m_L = sin(alpha_L * x);
+	float position_y_in_m_R = sin(alpha_R * x);
 
-  p->roi = roi;
+	p->roi = roi;
 
-  p->cart[0] = getX(&roi);
-  p->cart[1] = getY(&roi);
-  p->cart[2] = 0;
-  p->cart.stamp = fawkes::Time();
-  p->cart.frame_id = camera_info_.frame;
-  p->cart = apply_tf(cfg_frame_target.c_str(), p->cart);
+	p->cart[0]       = getX(&roi);
+	p->cart[1]       = getY(&roi);
+	p->cart[2]       = 0;
+	p->cart.stamp    = fawkes::Time();
+	p->cart.frame_id = camera_info_.frame;
+	p->cart          = apply_tf(cfg_frame_target.c_str(), p->cart);
 
-  cartToPol(p->pol, p->cart[0], p->cart[1]);
-  p->visibility_history = 1;
-  p->radius = position_y_in_m_L - position_y_in_m_R;
+	cartToPol(p->pol, p->cart[0], p->cart[1]);
+	p->visibility_history = 1;
+	p->radius             = position_y_in_m_L - position_y_in_m_R;
 
-  if (cfg_debugMessagesActivated_) {
-    logger->log_info(name(), "puck: r: %f pol: phi %f, r%f", p->radius,
-                     p->pol.phi, p->pol.r);
-  }
+	if (cfg_debugMessagesActivated_) {
+		logger->log_info(name(), "puck: r: %f pol: phi %f, r%f", p->radius, p->pol.phi, p->pol.r);
+	}
 }
 
-void PuckVisionThread::updatePos3dInferface(
-    fawkes::Position3DInterface *interface, puck *p) {
-  int visibility_history = interface->visibility_history();
-  if (p) {
-    interface->set_translation(0, p->cart[0]);
-    interface->set_translation(1, p->cart[1]);
-    interface->set_translation(2, p->cart[2]);
-    interface->set_rotation(0, p->pol.phi);
-    interface->set_rotation(1, p->pol.r);
-    // interface->set_timestamp(&p->cart.stamp);
-    interface->set_frame(p->cart.frame_id.c_str());
-    interface->set_visibility_history(p->visibility_history);
-    if (visibility_history >= 0) {
-      interface->set_visibility_history(visibility_history + 1);
-    } else {
-      interface->set_visibility_history(1);
-    }
-  } else {
-    // puck not visible
-    if (visibility_history <= 0) {
-      interface->set_visibility_history(visibility_history - 1);
-    } else {
-      interface->set_visibility_history(-1);
-    }
-  }
+void
+PuckVisionThread::updatePos3dInferface(fawkes::Position3DInterface *interface, puck *p)
+{
+	int visibility_history = interface->visibility_history();
+	if (p) {
+		interface->set_translation(0, p->cart[0]);
+		interface->set_translation(1, p->cart[1]);
+		interface->set_translation(2, p->cart[2]);
+		interface->set_rotation(0, p->pol.phi);
+		interface->set_rotation(1, p->pol.r);
+		// interface->set_timestamp(&p->cart.stamp);
+		interface->set_frame(p->cart.frame_id.c_str());
+		interface->set_visibility_history(p->visibility_history);
+		if (visibility_history >= 0) {
+			interface->set_visibility_history(visibility_history + 1);
+		} else {
+			interface->set_visibility_history(1);
+		}
+	} else {
+		// puck not visible
+		if (visibility_history <= 0) {
+			interface->set_visibility_history(visibility_history - 1);
+		} else {
+			interface->set_visibility_history(-1);
+		}
+	}
 }
 
-void PuckVisionThread::updateInterface(std::vector<puck> *pucks) {
-  /* Create missing interfaces */
-  if (pucks->size() > puck_interfaces_.size()) {
-    unsigned int nr_missing_interfaces =
-        pucks->size() - puck_interfaces_.size();
-    for (unsigned int i = 0; i < nr_missing_interfaces; ++i) {
-      createPuckInterface();
-    }
-  }
+void
+PuckVisionThread::updateInterface(std::vector<puck> *pucks)
+{
+	/* Create missing interfaces */
+	if (pucks->size() > puck_interfaces_.size()) {
+		unsigned int nr_missing_interfaces = pucks->size() - puck_interfaces_.size();
+		for (unsigned int i = 0; i < nr_missing_interfaces; ++i) {
+			createPuckInterface();
+		}
+	}
 
-  if (cfg_debugMessagesActivated_) {
-    logger->log_info(name(), "Detected pucks in view:  %i", pucks->size());
-  }
+	if (cfg_debugMessagesActivated_) {
+		logger->log_info(name(), "Detected pucks in view:  %i", pucks->size());
+	}
 
-  std::vector<fawkes::Position3DInterface *>::iterator interface_it =
-      puck_interfaces_.begin();
-  std::vector<puck>::iterator puck_it = pucks->begin();
-  for (; interface_it != puck_interfaces_.end(); ++interface_it) {
-    fawkes::Position3DInterface *interface = (*interface_it);
-    if (puck_it != pucks->end()) {
-      updatePos3dInferface(interface, &(*puck_it));
-      ++puck_it;
-    } else {
-      updatePos3dInferface(interface, NULL);
-    }
-    interface->write();
-  }
+	std::vector<fawkes::Position3DInterface *>::iterator interface_it = puck_interfaces_.begin();
+	std::vector<puck>::iterator                          puck_it      = pucks->begin();
+	for (; interface_it != puck_interfaces_.end(); ++interface_it) {
+		fawkes::Position3DInterface *interface = (*interface_it);
+		if (puck_it != pucks->end()) {
+			updatePos3dInferface(interface, &(*puck_it));
+			++puck_it;
+		} else {
+			updatePos3dInferface(interface, NULL);
+		}
+		interface->write();
+	}
 }
 
 void PuckVisionThread::finalize() // TODO check if everthing gets deleted
 {
-  logger->log_debug(name(), "finalize starts");
+	logger->log_debug(name(), "finalize starts");
 
-  vision_master->unregister_thread(this);
-  delete shm_buffer_;
-  config->rem_change_handler(this);
-  delete cam_;
-  cam_ = NULL;
+	vision_master->unregister_thread(this);
+	delete shm_buffer_;
+	config->rem_change_handler(this);
+	delete cam_;
+	cam_ = NULL;
 
-  fawkes::Position3DInterface *interface;
-  while (!puck_interfaces_.empty()) {
-    interface = puck_interfaces_.back();
-    blackboard->close(interface);
-    puck_interfaces_.pop_back();
-  }
+	fawkes::Position3DInterface *interface;
+	while (!puck_interfaces_.empty()) {
+		interface = puck_interfaces_.back();
+		blackboard->close(interface);
+		puck_interfaces_.pop_back();
+	}
 
-  deleteClassifier(&puck_info_.main);
-  deleteClassifier(&puck_info_.top_dots);
+	deleteClassifier(&puck_info_.main);
+	deleteClassifier(&puck_info_.top_dots);
 
-  logger->log_info(name(), "finalize ends");
+	logger->log_info(name(), "finalize ends");
 }
 
 void PuckVisionThread::config_value_erased(const char *path){};
 void PuckVisionThread::config_tag_changed(const char *new_tag){};
-void PuckVisionThread::config_comment_changed(
-    const fawkes::Configuration::ValueIterator *v){};
-void PuckVisionThread::config_value_changed(
-    const fawkes::Configuration::ValueIterator *v) {
-
-  if (cfg_mutex_.try_lock()) {
-    try {
-      loadConfig();
-      init_with_config();
-    } catch (fawkes::Exception &e) {
-      logger->log_error(name(), e);
-    }
-  }
-  // gets called for every changed entry... so init is called once per change.
-  cfg_mutex_.unlock();
+void PuckVisionThread::config_comment_changed(const fawkes::Configuration::ValueIterator *v){};
+void
+PuckVisionThread::config_value_changed(const fawkes::Configuration::ValueIterator *v)
+{
+	if (cfg_mutex_.try_lock()) {
+		try {
+			loadConfig();
+			init_with_config();
+		} catch (fawkes::Exception &e) {
+			logger->log_error(name(), e);
+		}
+	}
+	// gets called for every changed entry... so init is called once per change.
+	cfg_mutex_.unlock();
 }
 
-Point3d PuckVisionThread::apply_tf(const char *target_frame, Point3d src) {
+Point3d
+PuckVisionThread::apply_tf(const char *target_frame, Point3d src)
+{
+	Point3d targetPoint;
+	targetPoint.frame_id     = target_frame;
+	const char *source_frame = src.frame_id.c_str();
 
-  Point3d targetPoint;
-  targetPoint.frame_id = target_frame;
-  const char *source_frame = src.frame_id.c_str();
+	bool link_frame_exists  = tf_listener->frame_exists(target_frame);
+	bool laser_frame_exists = tf_listener->frame_exists(source_frame);
 
-  bool link_frame_exists = tf_listener->frame_exists(target_frame);
-  bool laser_frame_exists = tf_listener->frame_exists(source_frame);
-
-  if (!link_frame_exists || !laser_frame_exists) {
-    logger->log_warn(name(), "Frame missing: %s %s   %s %s", source_frame,
-                     link_frame_exists ? "exists" : "missing", target_frame,
-                     laser_frame_exists ? "exists" : "missing");
-  } else {
-    try {
-      tf_listener->transform_point(target_frame, src, targetPoint);
-    } catch (fawkes::tf::ExtrapolationException &e) {
-      logger->log_debug(name(), "Extrapolation error: %s", e.what());
-      return src;
-    } catch (fawkes::tf::ConnectivityException &e) {
-      logger->log_debug(name(), "Connectivity exception: %s", e.what());
-      return src;
-    } catch (fawkes::Exception &e) {
-      logger->log_debug(name(), "Fawkes exception: %s", e.what());
-      return src;
-    } catch (std::exception &e) {
-      logger->log_debug(name(), "Generic exception: %s", e.what());
-      return src;
-    }
-    return targetPoint;
-  }
-  return src;
+	if (!link_frame_exists || !laser_frame_exists) {
+		logger->log_warn(name(),
+		                 "Frame missing: %s %s   %s %s",
+		                 source_frame,
+		                 link_frame_exists ? "exists" : "missing",
+		                 target_frame,
+		                 laser_frame_exists ? "exists" : "missing");
+	} else {
+		try {
+			tf_listener->transform_point(target_frame, src, targetPoint);
+		} catch (fawkes::tf::ExtrapolationException &e) {
+			logger->log_debug(name(), "Extrapolation error: %s", e.what());
+			return src;
+		} catch (fawkes::tf::ConnectivityException &e) {
+			logger->log_debug(name(), "Connectivity exception: %s", e.what());
+			return src;
+		} catch (fawkes::Exception &e) {
+			logger->log_debug(name(), "Fawkes exception: %s", e.what());
+			return src;
+		} catch (std::exception &e) {
+			logger->log_debug(name(), "Generic exception: %s", e.what());
+			return src;
+		}
+		return targetPoint;
+	}
+	return src;
 }

--- a/src/plugins/attic/puck_vision/puck_vision_thread.h
+++ b/src/plugins/attic/puck_vision/puck_vision_thread.h
@@ -14,18 +14,15 @@
 #ifndef puck_vision_THREAD_H_
 #define puck_vision_THREAD_H_
 
-#include <core/threading/mutex.h>
-#include <core/threading/thread.h>
-
 #include <aspect/blackboard.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <aspect/tf.h>
 #include <aspect/vision.h>
+#include <core/threading/mutex.h>
+#include <core/threading/thread.h>
 
 //#include <interfaces/PuckVisionInterface.h>
-#include <interfaces/Position3DInterface.h>
-
 #include <config/change_handler.h>
 #include <fvcams/camera.h>
 #include <fvclassifiers/simple.h>
@@ -37,6 +34,7 @@
 #include <fvutils/base/roi.h>
 #include <fvutils/color/conversions.h>
 #include <fvutils/ipc/shm_image.h>
+#include <interfaces/Position3DInterface.h>
 #include <tf/exceptions.h>
 #include <tf/transformer.h>
 #include <tf/types.h>
@@ -69,55 +67,59 @@ class TransformListener;
 
 typedef fawkes::tf::Stamped<fawkes::tf::Point> Point3d;
 
-struct camera_info {
-  std::string connection;
-  std::string frame;
-  float opening_angle_horizontal;
-  float opening_angle_vertical;
-  unsigned int img_width;
-  unsigned int img_height;
-  float position_x;
-  float position_y;
-  float position_z;
-  float position_pitch;
-  float offset_cam_x_to_groundplane_;
-  float angle_horizontal_to_opening_;
-  float visible_lenght_x_in_m_;
-  float visible_lenght_y_in_m_;
-  firevision::ROI fullimage;
+struct camera_info
+{
+	std::string     connection;
+	std::string     frame;
+	float           opening_angle_horizontal;
+	float           opening_angle_vertical;
+	unsigned int    img_width;
+	unsigned int    img_height;
+	float           position_x;
+	float           position_y;
+	float           position_z;
+	float           position_pitch;
+	float           offset_cam_x_to_groundplane_;
+	float           angle_horizontal_to_opening_;
+	float           visible_lenght_x_in_m_;
+	float           visible_lenght_y_in_m_;
+	firevision::ROI fullimage;
 };
 
-typedef struct {
-  firevision::ColorModel *colormodel;
-  firevision::SimpleColorClassifier *classifier;
-  std::vector<firevision::ColorModelSimilarity::color_class_t *> color_classes;
-  firevision::ScanlineGrid *scanline_grid;
-  std::vector<unsigned int> cfg_ref_col;
-  int cfg_chroma_thresh;
-  int cfg_sat_thresh;
-  firevision::color_t color_expect;
-  unsigned int cfg_roi_min_points;
-  unsigned int cfg_roi_basic_size;
-  unsigned int cfg_roi_neighborhood_min_match;
-  unsigned int cfg_scangrid_x_offset;
-  unsigned int cfg_scangrid_y_offset;
+typedef struct
+{
+	firevision::ColorModel *                                       colormodel;
+	firevision::SimpleColorClassifier *                            classifier;
+	std::vector<firevision::ColorModelSimilarity::color_class_t *> color_classes;
+	firevision::ScanlineGrid *                                     scanline_grid;
+	std::vector<unsigned int>                                      cfg_ref_col;
+	int                                                            cfg_chroma_thresh;
+	int                                                            cfg_sat_thresh;
+	firevision::color_t                                            color_expect;
+	unsigned int                                                   cfg_roi_min_points;
+	unsigned int                                                   cfg_roi_basic_size;
+	unsigned int                                                   cfg_roi_neighborhood_min_match;
+	unsigned int                                                   cfg_scangrid_x_offset;
+	unsigned int                                                   cfg_scangrid_y_offset;
 } color_classifier_context_t_;
 
-struct puck_features {
-  float radius;
-  float height;
-  color_classifier_context_t_ main;
-  color_classifier_context_t_ top_dots;
-  // color holes;
-  // color top_center;
+struct puck_features
+{
+	float                       radius;
+	float                       height;
+	color_classifier_context_t_ main;
+	color_classifier_context_t_ top_dots;
+	// color holes;
+	// color top_center;
 };
 
-struct puck {
-  Point3d cart;
-  fawkes::polar_coord_2d_t pol;
-  double radius;
-  int visibility_history;
-  firevision::ROI roi;
+struct puck
+{
+	Point3d                  cart;
+	fawkes::polar_coord_2d_t pol;
+	double                   radius;
+	int                      visibility_history;
+	firevision::ROI          roi;
 };
 
 class PuckVisionThread : public fawkes::Thread,
@@ -126,107 +128,108 @@ class PuckVisionThread : public fawkes::Thread,
                          public fawkes::VisionAspect,
                          public fawkes::BlackBoardAspect,
                          public fawkes::TransformAspect,
-                         public fawkes::ConfigurationChangeHandler {
+                         public fawkes::ConfigurationChangeHandler
+{
 public:
-  PuckVisionThread();
-  virtual ~PuckVisionThread();
+	PuckVisionThread();
+	virtual ~PuckVisionThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  Point3d apply_tf(const char *target_frame, Point3d src_point);
+	Point3d apply_tf(const char *target_frame, Point3d src_point);
 
-  fawkes::Mutex cfg_mutex_;
+	fawkes::Mutex cfg_mutex_;
 
-  std::string cfg_prefix_;
-  std::string cfg_prefix_static_transforms_;
-  std::string cfg_frame_target;
-  bool cfg_use_new_pucks_;
+	std::string cfg_prefix_;
+	std::string cfg_prefix_static_transforms_;
+	std::string cfg_frame_target;
+	bool        cfg_use_new_pucks_;
 
-  // Camera
-  camera_info camera_info_;
-  puck_features puck_info_;
+	// Camera
+	camera_info   camera_info_;
+	puck_features puck_info_;
 
-  bool cfg_debugMessagesActivated_;
-  bool cfg_paintROIsActivated_;
-  bool cfg_changed_;
-  bool cfg_check_yellow_dots_;
+	bool cfg_debugMessagesActivated_;
+	bool cfg_paintROIsActivated_;
+	bool cfg_changed_;
+	bool cfg_check_yellow_dots_;
 
-  std::string cfg_frame_;
+	std::string cfg_frame_;
 
-  firevision::Camera *cam_;
-  firevision::SharedMemoryImageBuffer *shm_buffer_;
+	firevision::Camera *                 cam_;
+	firevision::SharedMemoryImageBuffer *shm_buffer_;
 
-  // interfaces
-  std::vector<fawkes::Position3DInterface *> puck_interfaces_;
-  std::vector<firevision::ROI> detected_pucks;
-  fawkes::SwitchInterface *switchInterface_;
+	// interfaces
+	std::vector<fawkes::Position3DInterface *> puck_interfaces_;
+	std::vector<firevision::ROI>               detected_pucks;
+	fawkes::SwitchInterface *                  switchInterface_;
 
-  unsigned char
-      *buffer_; // reference to the buffer of shm_buffer_YCbCr (to use in code)
+	unsigned char *buffer_; // reference to the buffer of shm_buffer_YCbCr (to use in code)
 
-  firevision::colorspace_t cspaceFrom_;
-  firevision::colorspace_t cspaceTo_;
+	firevision::colorspace_t cspaceFrom_;
+	firevision::colorspace_t cspaceTo_;
 
-  firevision::FilterROIDraw *drawer_;
+	firevision::FilterROIDraw *drawer_;
 
-  firevision::ROI search_area;
+	firevision::ROI search_area;
 
-  // Helper functions
-  float getX(firevision::ROI *roi);
-  float getY(firevision::ROI *roi);
+	// Helper functions
+	float getX(firevision::ROI *roi);
+	float getY(firevision::ROI *roi);
 
-  firevision::ROI *getBiggestRoi(std::list<firevision::ROI> *roiList);
-  firevision::ROI *getRoiContainingRoi(std::list<firevision::ROI> *roiList,
-                                       firevision::ROI containing);
-  void mergeWithColorInformation(firevision::color_t color,
-                                 std::list<firevision::ROI> *rois_color_,
-                                 std::list<firevision::ROI> *rois_all);
+	firevision::ROI *getBiggestRoi(std::list<firevision::ROI> *roiList);
+	firevision::ROI *getRoiContainingRoi(std::list<firevision::ROI> *roiList,
+	                                     firevision::ROI             containing);
+	void             mergeWithColorInformation(firevision::color_t         color,
+	                                           std::list<firevision::ROI> *rois_color_,
+	                                           std::list<firevision::ROI> *rois_all);
 
-  void setup_color_classifier(color_classifier_context_t_ *color_data,
-                              const char *prefix, firevision::color_t expected);
+	void setup_color_classifier(color_classifier_context_t_ *color_data,
+	                            const char *                 prefix,
+	                            firevision::color_t          expected);
 
-  std::list<firevision::ROI> *
-  classifyInRoi(firevision::ROI searchArea,
-                color_classifier_context_t_ *color_data);
+	std::list<firevision::ROI> *classifyInRoi(firevision::ROI              searchArea,
+	                                          color_classifier_context_t_ *color_data);
 
-  void printRoi(firevision::ROI roi);
-  void fitROI(firevision::ROI &roi, int x, int y, int w, int h);
+	void printRoi(firevision::ROI roi);
+	void fitROI(firevision::ROI &roi, int x, int y, int w, int h);
 
-  /** detectPucks
+	/** detectPucks
    *  Returns a list of ROIs. Each ROI contians a puck
    */
-  std::list<firevision::ROI> detectPucks();
+	std::list<firevision::ROI> detectPucks();
 
-  void loadConfig();
-  void polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol);
-  void createPuckInterface();
-  void cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y);
-  void drawRois(std::list<firevision::ROI> *rois_red_);
-  void drawROIIntoBuffer(firevision::ROI roi,
-                         firevision::FilterROIDraw::border_style_t borderStyle =
-                             firevision::FilterROIDraw::DASHED_HINT);
-  void calculatePuckPositions(std::vector<puck> *pucks,
-                              std::list<firevision::ROI> pucks_in_view);
-  void getPuckPosition(puck *p, firevision::ROI roi);
-  void sortPucks(std::vector<puck> *pucks);
+	void loadConfig();
+	void polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol);
+	void createPuckInterface();
+	void cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y);
+	void drawRois(std::list<firevision::ROI> *rois_red_);
+	void drawROIIntoBuffer(
+	  firevision::ROI                           roi,
+	  firevision::FilterROIDraw::border_style_t borderStyle = firevision::FilterROIDraw::DASHED_HINT);
+	void calculatePuckPositions(std::vector<puck> *pucks, std::list<firevision::ROI> pucks_in_view);
+	void getPuckPosition(puck *p, firevision::ROI roi);
+	void sortPucks(std::vector<puck> *pucks);
 
-  void updatePos3dInferface(fawkes::Position3DInterface *interface, puck *p);
-  void updateInterface(std::vector<puck> *puck);
-  void init_with_config();
+	void updatePos3dInferface(fawkes::Position3DInterface *interface, puck *p);
+	void updateInterface(std::vector<puck> *puck);
+	void init_with_config();
 
-  virtual void config_value_erased(const char *path);
-  virtual void config_tag_changed(const char *new_tag);
-  virtual void
-  config_comment_changed(const fawkes::Configuration::ValueIterator *v);
-  virtual void
-  config_value_changed(const fawkes::Configuration::ValueIterator *v);
-  void deleteClassifier(color_classifier_context_t_ *color_data);
+	virtual void config_value_erased(const char *path);
+	virtual void config_tag_changed(const char *new_tag);
+	virtual void config_comment_changed(const fawkes::Configuration::ValueIterator *v);
+	virtual void config_value_changed(const fawkes::Configuration::ValueIterator *v);
+	void         deleteClassifier(color_classifier_context_t_ *color_data);
 
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 };
 
 #endif /* puck_vision_THREAD_H_ */

--- a/src/plugins/attic/robotino_worldmodel/WmState.cpp
+++ b/src/plugins/attic/robotino_worldmodel/WmState.cpp
@@ -19,29 +19,39 @@
  */
 
 #include "WmState.h"
+
 #include <algorithm>
 
 using namespace fawkes;
 
-WmState::WmState() {}
-
-WmState::~WmState() {
-  // TODO Auto-generated destructor stub
+WmState::WmState()
+{
 }
 
-void WmState::set_logger(fawkes::Logger *logger) { logger_ = logger; }
+WmState::~WmState()
+{
+	// TODO Auto-generated destructor stub
+}
+
+void
+WmState::set_logger(fawkes::Logger *logger)
+{
+	logger_ = logger;
+}
 
 /**
  * Copies the values of the given interface.
  */
-void WmState::update_worldmodel(RobotinoWorldModelInterface *wm_if) {
-  for (unsigned int i = 0; i < wm_if->maxlenof_machine_states(); ++i) {
-    machine_states_[i] = wm_if->machine_states(i);
-  }
-  for (unsigned int i = 0; i < wm_if->maxlenof_machine_types(); ++i) {
-    machine_types_[i] = wm_if->machine_types(i);
-  }
-  express_machine = wm_if->express_machine();
+void
+WmState::update_worldmodel(RobotinoWorldModelInterface *wm_if)
+{
+	for (unsigned int i = 0; i < wm_if->maxlenof_machine_states(); ++i) {
+		machine_states_[i] = wm_if->machine_states(i);
+	}
+	for (unsigned int i = 0; i < wm_if->maxlenof_machine_types(); ++i) {
+		machine_types_[i] = wm_if->machine_types(i);
+	}
+	express_machine = wm_if->express_machine();
 }
 
 /**
@@ -49,16 +59,20 @@ void WmState::update_worldmodel(RobotinoWorldModelInterface *wm_if) {
  * internal data
  */
 std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t>
-WmState::get_changed_states(RobotinoWorldModelInterface *wm_if) {
-  std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t> changes;
-  for (uint32_t i = 0; i < wm_if->maxlenof_machine_states(); ++i) {
-    if (wm_if->machine_states(i) != machine_states_[i]) {
-      logger_->log_debug("WmState", "State of %i changed from %i to %i", i,
-                         machine_states_[i], wm_if->machine_states(i));
-      changes[i] = wm_if->machine_states(i);
-    }
-  }
-  return changes;
+WmState::get_changed_states(RobotinoWorldModelInterface *wm_if)
+{
+	std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t> changes;
+	for (uint32_t i = 0; i < wm_if->maxlenof_machine_states(); ++i) {
+		if (wm_if->machine_states(i) != machine_states_[i]) {
+			logger_->log_debug("WmState",
+			                   "State of %i changed from %i to %i",
+			                   i,
+			                   machine_states_[i],
+			                   wm_if->machine_states(i));
+			changes[i] = wm_if->machine_states(i);
+		}
+	}
+	return changes;
 }
 
 /**
@@ -66,15 +80,19 @@ WmState::get_changed_states(RobotinoWorldModelInterface *wm_if) {
  * internal data
  */
 std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t>
-WmState::get_changed_types(RobotinoWorldModelInterface *wm_if) {
-  std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t> changes;
-  for (uint32_t i = 0; i < wm_if->maxlenof_machine_types(); ++i) {
-    if (wm_if->machine_types(i) != machine_types_[i]) {
-      changes[i] = wm_if->machine_types(i);
-      logger_->log_debug("WmState", "Type of %i changed from %i to %i", i,
-                         machine_types_[i], wm_if->machine_types(i));
-    }
-  }
+WmState::get_changed_types(RobotinoWorldModelInterface *wm_if)
+{
+	std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t> changes;
+	for (uint32_t i = 0; i < wm_if->maxlenof_machine_types(); ++i) {
+		if (wm_if->machine_types(i) != machine_types_[i]) {
+			changes[i] = wm_if->machine_types(i);
+			logger_->log_debug("WmState",
+			                   "Type of %i changed from %i to %i",
+			                   i,
+			                   machine_types_[i],
+			                   wm_if->machine_types(i));
+		}
+	}
 
-  return changes;
+	return changes;
 }

--- a/src/plugins/attic/robotino_worldmodel/WmState.h
+++ b/src/plugins/attic/robotino_worldmodel/WmState.h
@@ -23,25 +23,27 @@
 
 #include <interfaces/RobotinoWorldModelInterface.h>
 #include <logging/logger.h>
+
 #include <map>
 
-class WmState {
+class WmState
+{
 public:
-  WmState();
-  void set_logger(fawkes::Logger *logger);
-  virtual ~WmState();
+	WmState();
+	void set_logger(fawkes::Logger *logger);
+	virtual ~WmState();
 
-  void update_worldmodel(fawkes::RobotinoWorldModelInterface *wm_if);
-  std::map<uint32_t, fawkes::RobotinoWorldModelInterface::machine_state_t>
-  get_changed_states(fawkes::RobotinoWorldModelInterface *wm_if);
-  std::map<uint32_t, fawkes::RobotinoWorldModelInterface::machine_type_t>
-  get_changed_types(fawkes::RobotinoWorldModelInterface *wm_if);
+	void update_worldmodel(fawkes::RobotinoWorldModelInterface *wm_if);
+	std::map<uint32_t, fawkes::RobotinoWorldModelInterface::machine_state_t>
+	get_changed_states(fawkes::RobotinoWorldModelInterface *wm_if);
+	std::map<uint32_t, fawkes::RobotinoWorldModelInterface::machine_type_t>
+	get_changed_types(fawkes::RobotinoWorldModelInterface *wm_if);
 
 private:
-  fawkes::RobotinoWorldModelInterface::machine_state_t machine_states_[13];
-  fawkes::RobotinoWorldModelInterface::machine_type_t machine_types_[13];
-  u_int32_t express_machine;
-  fawkes::Logger *logger_;
+	fawkes::RobotinoWorldModelInterface::machine_state_t machine_states_[13];
+	fawkes::RobotinoWorldModelInterface::machine_type_t  machine_types_[13];
+	u_int32_t                                            express_machine;
+	fawkes::Logger *                                     logger_;
 };
 
 #endif /* WMSTATE_H_ */

--- a/src/plugins/attic/robotino_worldmodel/robotino_worldmodel_plugin.cpp
+++ b/src/plugins/attic/robotino_worldmodel/robotino_worldmodel_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "robotino_worldmodel_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Template! Makes the robotino move forward for 3 seconds
  * @author Daniel Ewert
  */
-class RobotinoWorldModelPlugin : public fawkes::Plugin {
+class RobotinoWorldModelPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  RobotinoWorldModelPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new RobotinoWorldModelThread());
-  }
+	RobotinoWorldModelPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new RobotinoWorldModelThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Robotino World Model")

--- a/src/plugins/attic/robotino_worldmodel/robotino_worldmodel_thread.cpp
+++ b/src/plugins/attic/robotino_worldmodel/robotino_worldmodel_thread.cpp
@@ -37,115 +37,131 @@ using namespace fawkes;
 
 /** Constructor. */
 RobotinoWorldModelThread::RobotinoWorldModelThread()
-    : Thread("RobotinoWorldModelThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL) {}
-
-void RobotinoWorldModelThread::init() {
-  logger->log_info(name(), "Plugin Template starts up");
-  wm_if_data_.set_logger(logger);
-  wm_ext_if_data_.set_logger(logger);
-  wm_if_ = blackboard->open_for_reading<RobotinoWorldModelInterface>(
-      config->get_string(CFG_PREFIX "local_model").c_str());
-  wm_ext_if_ = blackboard->open_for_reading<RobotinoWorldModelInterface>(
-      config->get_string(CFG_PREFIX "ext_model").c_str());
-  wm_changed_if_ = blackboard->open_for_writing<RobotinoWorldModelInterface>(
-      "Model fll changes_only");
-  wm_merged_if_ = blackboard->open_for_writing<RobotinoWorldModelInterface>(
-      "Model fll merged");
-  wm_if_data_.update_worldmodel(wm_if_);
-  wm_ext_if_data_.update_worldmodel(wm_ext_if_);
+: Thread("RobotinoWorldModelThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
 }
 
-bool RobotinoWorldModelThread::prepare_finalize_user() { return true; }
-
-void RobotinoWorldModelThread::finalize() {
-  blackboard->close(wm_if_);
-  blackboard->close(wm_ext_if_);
-  blackboard->close(wm_merged_if_);
-  blackboard->close(wm_changed_if_);
+void
+RobotinoWorldModelThread::init()
+{
+	logger->log_info(name(), "Plugin Template starts up");
+	wm_if_data_.set_logger(logger);
+	wm_ext_if_data_.set_logger(logger);
+	wm_if_ = blackboard->open_for_reading<RobotinoWorldModelInterface>(
+	  config->get_string(CFG_PREFIX "local_model").c_str());
+	wm_ext_if_ = blackboard->open_for_reading<RobotinoWorldModelInterface>(
+	  config->get_string(CFG_PREFIX "ext_model").c_str());
+	wm_changed_if_ =
+	  blackboard->open_for_writing<RobotinoWorldModelInterface>("Model fll changes_only");
+	wm_merged_if_ = blackboard->open_for_writing<RobotinoWorldModelInterface>("Model fll merged");
+	wm_if_data_.update_worldmodel(wm_if_);
+	wm_ext_if_data_.update_worldmodel(wm_ext_if_);
 }
 
-void RobotinoWorldModelThread::write_state_changes(
-    RobotinoWorldModelInterface *wm_if,
-    std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t>
-        changed_machine_states) {
-  for (std::map<uint32_t,
-                RobotinoWorldModelInterface::machine_state_t>::iterator it =
-           changed_machine_states.begin();
-       it != changed_machine_states.end(); ++it) {
-    wm_if->set_machine_states(it->first, it->second);
-  }
+bool
+RobotinoWorldModelThread::prepare_finalize_user()
+{
+	return true;
 }
 
-void RobotinoWorldModelThread::write_type_changes(
-    RobotinoWorldModelInterface *wm_if,
-    std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t>
-        changed_machine_types) {
-  for (std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t>::iterator
-           it = changed_machine_types.begin();
-       it != changed_machine_types.end(); ++it) {
-    wm_if->set_machine_types(it->first, it->second);
-  }
+void
+RobotinoWorldModelThread::finalize()
+{
+	blackboard->close(wm_if_);
+	blackboard->close(wm_ext_if_);
+	blackboard->close(wm_merged_if_);
+	blackboard->close(wm_changed_if_);
 }
 
-void RobotinoWorldModelThread::publish_changes() {
-  wm_changed_if_->write();
-  wm_merged_if_->write();
-  wm_if_data_.update_worldmodel(wm_if_);
-  wm_ext_if_data_.update_worldmodel(wm_ext_if_);
+void
+RobotinoWorldModelThread::write_state_changes(
+  RobotinoWorldModelInterface *                                    wm_if,
+  std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t> changed_machine_states)
+{
+	for (std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t>::iterator it =
+	       changed_machine_states.begin();
+	     it != changed_machine_states.end();
+	     ++it) {
+		wm_if->set_machine_states(it->first, it->second);
+	}
 }
 
-void RobotinoWorldModelThread::loop() {
-  /*
+void
+RobotinoWorldModelThread::write_type_changes(
+  RobotinoWorldModelInterface *                                   wm_if,
+  std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t> changed_machine_types)
+{
+	for (std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t>::iterator it =
+	       changed_machine_types.begin();
+	     it != changed_machine_types.end();
+	     ++it) {
+		wm_if->set_machine_types(it->first, it->second);
+	}
+}
+
+void
+RobotinoWorldModelThread::publish_changes()
+{
+	wm_changed_if_->write();
+	wm_merged_if_->write();
+	wm_if_data_.update_worldmodel(wm_if_);
+	wm_ext_if_data_.update_worldmodel(wm_ext_if_);
+}
+
+void
+RobotinoWorldModelThread::loop()
+{
+	/*
    * The changes of all all Interfaces are merged into each other. Should work
    * since different robots are not expected to perceive different changes at
    * the same machine. It's ugly anyways..
    */
-  wm_if_->read();
-  wm_ext_if_->read();
-  std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t>
-      changed_machine_states = wm_if_data_.get_changed_states(wm_if_);
-  std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t>
-      changed_machine_states_ext =
-          wm_ext_if_data_.get_changed_states(wm_ext_if_);
-  changed_machine_states.insert(changed_machine_states_ext.begin(),
-                                changed_machine_states_ext.end());
-  std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t>
-      changed_machine_types = wm_if_data_.get_changed_types(wm_if_);
-  std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t>
-      changed_machine_types_ext = wm_ext_if_data_.get_changed_types(wm_ext_if_);
-  changed_machine_types.insert(changed_machine_types_ext.begin(),
-                               changed_machine_types_ext.end());
-  if (!(changed_machine_states.empty() && changed_machine_types.empty())) {
-    wipe_worldmodel(wm_changed_if_);
-    if (!changed_machine_states.empty()) {
-      write_state_changes(wm_changed_if_, changed_machine_states);
-      write_state_changes(wm_merged_if_, changed_machine_states);
-    }
-    if (!changed_machine_types.empty()) {
-      write_type_changes(wm_changed_if_, changed_machine_types);
-      write_type_changes(wm_merged_if_, changed_machine_types);
-    }
-    publish_changes();
-  }
+	wm_if_->read();
+	wm_ext_if_->read();
+	std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t> changed_machine_states =
+	  wm_if_data_.get_changed_states(wm_if_);
+	std::map<uint32_t, RobotinoWorldModelInterface::machine_state_t> changed_machine_states_ext =
+	  wm_ext_if_data_.get_changed_states(wm_ext_if_);
+	changed_machine_states.insert(changed_machine_states_ext.begin(),
+	                              changed_machine_states_ext.end());
+	std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t> changed_machine_types =
+	  wm_if_data_.get_changed_types(wm_if_);
+	std::map<uint32_t, RobotinoWorldModelInterface::machine_type_t> changed_machine_types_ext =
+	  wm_ext_if_data_.get_changed_types(wm_ext_if_);
+	changed_machine_types.insert(changed_machine_types_ext.begin(), changed_machine_types_ext.end());
+	if (!(changed_machine_states.empty() && changed_machine_types.empty())) {
+		wipe_worldmodel(wm_changed_if_);
+		if (!changed_machine_states.empty()) {
+			write_state_changes(wm_changed_if_, changed_machine_states);
+			write_state_changes(wm_merged_if_, changed_machine_states);
+		}
+		if (!changed_machine_types.empty()) {
+			write_type_changes(wm_changed_if_, changed_machine_types);
+			write_type_changes(wm_merged_if_, changed_machine_types);
+		}
+		publish_changes();
+	}
 }
 
-void RobotinoWorldModelThread::merge_worldmodels(
-    fawkes::RobotinoWorldModelInterface *wm_sink_if,
-    fawkes::RobotinoWorldModelInterface *wm_source_if) {
-  for (uint32_t i = 0; i < wm_source_if->maxlenof_machine_states(); ++i) {
-    wm_sink_if->set_machine_states(i, wm_source_if->machine_states(i));
-  }
-  for (uint32_t i = 0; i < wm_source_if->maxlenof_machine_types(); ++i) {
-    wm_sink_if->set_machine_types(i, wm_source_if->machine_types(i));
-  }
-  wm_sink_if->set_express_machine(wm_source_if->express_machine());
+void
+RobotinoWorldModelThread::merge_worldmodels(fawkes::RobotinoWorldModelInterface *wm_sink_if,
+                                            fawkes::RobotinoWorldModelInterface *wm_source_if)
+{
+	for (uint32_t i = 0; i < wm_source_if->maxlenof_machine_states(); ++i) {
+		wm_sink_if->set_machine_states(i, wm_source_if->machine_states(i));
+	}
+	for (uint32_t i = 0; i < wm_source_if->maxlenof_machine_types(); ++i) {
+		wm_sink_if->set_machine_types(i, wm_source_if->machine_types(i));
+	}
+	wm_sink_if->set_express_machine(wm_source_if->express_machine());
 }
 
-void RobotinoWorldModelThread::wipe_worldmodel(
-    RobotinoWorldModelInterface *wm_if) {
-  for (unsigned int i = 0; i < wm_if->maxlenof_machine_states(); ++i) {
-    wm_if->set_machine_states(i, RobotinoWorldModelInterface::STATE_UNKNOWN);
-    wm_if->set_machine_types(i, RobotinoWorldModelInterface::TYPE_UNKNOWN);
-  }
+void
+RobotinoWorldModelThread::wipe_worldmodel(RobotinoWorldModelInterface *wm_if)
+{
+	for (unsigned int i = 0; i < wm_if->maxlenof_machine_states(); ++i) {
+		wm_if->set_machine_states(i, RobotinoWorldModelInterface::STATE_UNKNOWN);
+		wm_if->set_machine_types(i, RobotinoWorldModelInterface::TYPE_UNKNOWN);
+	}
 }

--- a/src/plugins/attic/robotino_worldmodel/robotino_worldmodel_thread.h
+++ b/src/plugins/attic/robotino_worldmodel/robotino_worldmodel_thread.h
@@ -22,59 +22,61 @@
 #ifndef __PLUGINS_ROBOTINO_WORLDMODEL_THREAD_H_
 #define __PLUGINS_ROBOTINO_WORLDMODEL_THREAD_H_
 
+#include "WmState.h"
+
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <core/threading/thread.h>
-
 #include <interfaces/RobotinoWorldModelInterface.h>
+
 #include <map>
 #include <string>
 #include <vector>
-
-#include "WmState.h"
 
 class RobotinoWorldModelThread : public fawkes::Thread,
                                  public fawkes::BlockedTimingAspect,
                                  public fawkes::LoggingAspect,
                                  public fawkes::ConfigurableAspect,
-                                 public fawkes::BlackBoardAspect {
-
+                                 public fawkes::BlackBoardAspect
+{
 public:
-  RobotinoWorldModelThread();
+	RobotinoWorldModelThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual bool prepare_finalize_user();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual bool prepare_finalize_user();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  void publish_changes();
-  void write_state_changes(
-      fawkes::RobotinoWorldModelInterface *wm_if,
-      std::map<uint32_t, fawkes::RobotinoWorldModelInterface::machine_state_t>
-          changed_machine_states);
-  void write_type_changes(
-      fawkes::RobotinoWorldModelInterface *wm_if,
-      std::map<uint32_t, fawkes::RobotinoWorldModelInterface::machine_type_t>
-          changed_machine_types);
-  void merge_worldmodels(fawkes::RobotinoWorldModelInterface *wm_sink_if,
-                         fawkes::RobotinoWorldModelInterface *wm_source_if);
-  void wipe_worldmodel(fawkes::RobotinoWorldModelInterface *wm_if);
+	void publish_changes();
+	void write_state_changes(fawkes::RobotinoWorldModelInterface *wm_if,
+	                         std::map<uint32_t, fawkes::RobotinoWorldModelInterface::machine_state_t>
+	                           changed_machine_states);
+	void write_type_changes(
+	  fawkes::RobotinoWorldModelInterface *                                   wm_if,
+	  std::map<uint32_t, fawkes::RobotinoWorldModelInterface::machine_type_t> changed_machine_types);
+	void merge_worldmodels(fawkes::RobotinoWorldModelInterface *wm_sink_if,
+	                       fawkes::RobotinoWorldModelInterface *wm_source_if);
+	void wipe_worldmodel(fawkes::RobotinoWorldModelInterface *wm_if);
 
 private:
-  fawkes::RobotinoWorldModelInterface *wm_if_;
-  fawkes::RobotinoWorldModelInterface *wm_ext_if_;
-  fawkes::RobotinoWorldModelInterface *wm_merged_if_;
-  fawkes::RobotinoWorldModelInterface *wm_changed_if_;
+	fawkes::RobotinoWorldModelInterface *wm_if_;
+	fawkes::RobotinoWorldModelInterface *wm_ext_if_;
+	fawkes::RobotinoWorldModelInterface *wm_merged_if_;
+	fawkes::RobotinoWorldModelInterface *wm_changed_if_;
 
-  WmState wm_if_data_;
-  WmState wm_ext_if_data_;
+	WmState wm_if_data_;
+	WmState wm_ext_if_data_;
 };
 
 #endif

--- a/src/plugins/attic/robotino_worldmodel_tester/robotino_wm_tester_plugin.cpp
+++ b/src/plugins/attic/robotino_worldmodel_tester/robotino_wm_tester_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "robotino_wm_tester_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Template! Makes the robotino move forward for 3 seconds
  * @author Daniel Ewert
  */
-class RobotinoWMTesterPlugin : public fawkes::Plugin {
+class RobotinoWMTesterPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  RobotinoWMTesterPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new RobotinoWMTesterThread());
-  }
+	RobotinoWMTesterPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new RobotinoWMTesterThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Robotino World Model Tester")

--- a/src/plugins/attic/robotino_worldmodel_tester/robotino_wm_tester_thread.cpp
+++ b/src/plugins/attic/robotino_worldmodel_tester/robotino_wm_tester_thread.cpp
@@ -36,104 +36,86 @@ using namespace fawkes;
 
 /** Constructor. */
 RobotinoWMTesterThread::RobotinoWMTesterThread()
-    : Thread("RobotinoWorldModelThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL) {}
-
-void RobotinoWMTesterThread::init() {
-  wm_if_ =
-      blackboard->open_for_writing<RobotinoWorldModelInterface>("Model fll");
-  wm_ext1_if_ = blackboard->open_for_writing<RobotinoWorldModelInterface>(
-      "Model fll ext1");
-  wm_ext2_if_ = blackboard->open_for_writing<RobotinoWorldModelInterface>(
-      "Model fll ext2");
-  time_ = clock->now();
-  state_ = 0;
-  type_ = 0;
+: Thread("RobotinoWorldModelThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
 }
 
-bool RobotinoWMTesterThread::prepare_finalize_user() { return true; }
-
-void RobotinoWMTesterThread::finalize() {
-  blackboard->close(wm_if_);
-  blackboard->close(wm_ext1_if_);
-  blackboard->close(wm_ext2_if_);
+void
+RobotinoWMTesterThread::init()
+{
+	wm_if_      = blackboard->open_for_writing<RobotinoWorldModelInterface>("Model fll");
+	wm_ext1_if_ = blackboard->open_for_writing<RobotinoWorldModelInterface>("Model fll ext1");
+	wm_ext2_if_ = blackboard->open_for_writing<RobotinoWorldModelInterface>("Model fll ext2");
+	time_       = clock->now();
+	state_      = 0;
+	type_       = 0;
 }
 
-void RobotinoWMTesterThread::loop() {
-  if (clock->elapsed(&time_) > 5) {
-    apply_random_change();
-    time_ = clock->now();
-  }
-  wm_if_->write();
-  wm_ext1_if_->write();
-  wm_ext2_if_->write();
+bool
+RobotinoWMTesterThread::prepare_finalize_user()
+{
+	return true;
 }
 
-void RobotinoWMTesterThread::apply_random_change() {
-  int machine = rand() % 13;
-  int interface = rand() % 3;
-  int state_or_type = rand() % 2;
-  if (state_or_type == 0) {
-    RobotinoWorldModelInterface::machine_state_t state;
-    switch (state_) {
-    case 0:
-      state = RobotinoWorldModelInterface::EMPTY;
-      break;
-    case 1:
-      state = RobotinoWorldModelInterface::S0_ONLY;
-      break;
-    case 2:
-      state = RobotinoWorldModelInterface::S1_ONLY;
-      break;
-    case 3:
-    default:
-      state = RobotinoWorldModelInterface::S1_S2;
-      break;
-    }
+void
+RobotinoWMTesterThread::finalize()
+{
+	blackboard->close(wm_if_);
+	blackboard->close(wm_ext1_if_);
+	blackboard->close(wm_ext2_if_);
+}
 
-    switch (interface) {
-    case 0:
-      wm_if_->set_machine_states(machine, state);
-      break;
-    case 1:
-      wm_ext1_if_->set_machine_states(machine, state);
-      break;
-    case 2:
-      wm_ext2_if_->set_machine_states(machine, state);
-      break;
-    }
-    state_++;
-    state_ %= 4;
-  } else {
-    RobotinoWorldModelInterface::machine_type_t type;
-    switch (type_) {
-    case 0:
-      type = RobotinoWorldModelInterface::TEST;
-      break;
-    case 1:
-      type = RobotinoWorldModelInterface::M1_2;
-      break;
-    case 2:
-      type = RobotinoWorldModelInterface::M1;
-      break;
-    case 3:
-    default:
-      type = RobotinoWorldModelInterface::M2;
-      break;
-    }
-    switch (interface) {
-    case 0:
+void
+RobotinoWMTesterThread::loop()
+{
+	if (clock->elapsed(&time_) > 5) {
+		apply_random_change();
+		time_ = clock->now();
+	}
+	wm_if_->write();
+	wm_ext1_if_->write();
+	wm_ext2_if_->write();
+}
 
-      wm_if_->set_machine_types(machine, type);
-      break;
-    case 1:
-      wm_ext1_if_->set_machine_types(machine, type);
-      break;
-    case 2:
-      wm_ext2_if_->set_machine_types(machine, type);
-      break;
-    }
-    type_++;
-    type_ %= 4;
-  }
+void
+RobotinoWMTesterThread::apply_random_change()
+{
+	int machine       = rand() % 13;
+	int interface     = rand() % 3;
+	int state_or_type = rand() % 2;
+	if (state_or_type == 0) {
+		RobotinoWorldModelInterface::machine_state_t state;
+		switch (state_) {
+		case 0: state = RobotinoWorldModelInterface::EMPTY; break;
+		case 1: state = RobotinoWorldModelInterface::S0_ONLY; break;
+		case 2: state = RobotinoWorldModelInterface::S1_ONLY; break;
+		case 3:
+		default: state = RobotinoWorldModelInterface::S1_S2; break;
+		}
+
+		switch (interface) {
+		case 0: wm_if_->set_machine_states(machine, state); break;
+		case 1: wm_ext1_if_->set_machine_states(machine, state); break;
+		case 2: wm_ext2_if_->set_machine_states(machine, state); break;
+		}
+		state_++;
+		state_ %= 4;
+	} else {
+		RobotinoWorldModelInterface::machine_type_t type;
+		switch (type_) {
+		case 0: type = RobotinoWorldModelInterface::TEST; break;
+		case 1: type = RobotinoWorldModelInterface::M1_2; break;
+		case 2: type = RobotinoWorldModelInterface::M1; break;
+		case 3:
+		default: type = RobotinoWorldModelInterface::M2; break;
+		}
+		switch (interface) {
+		case 0: wm_if_->set_machine_types(machine, type); break;
+		case 1: wm_ext1_if_->set_machine_types(machine, type); break;
+		case 2: wm_ext2_if_->set_machine_types(machine, type); break;
+		}
+		type_++;
+		type_ %= 4;
+	}
 }

--- a/src/plugins/attic/robotino_worldmodel_tester/robotino_wm_tester_thread.h
+++ b/src/plugins/attic/robotino_worldmodel_tester/robotino_wm_tester_thread.h
@@ -28,8 +28,8 @@
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <core/threading/thread.h>
-
 #include <interfaces/RobotinoWorldModelInterface.h>
+
 #include <map>
 #include <string>
 #include <vector>
@@ -39,31 +39,35 @@ class RobotinoWMTesterThread : public fawkes::Thread,
                                public fawkes::LoggingAspect,
                                public fawkes::ConfigurableAspect,
                                public fawkes::BlackBoardAspect,
-                               public fawkes::ClockAspect {
-
+                               public fawkes::ClockAspect
+{
 public:
-  RobotinoWMTesterThread();
+	RobotinoWMTesterThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual bool prepare_finalize_user();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual bool prepare_finalize_user();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  void apply_random_change();
+	void apply_random_change();
 
 private:
-  fawkes::RobotinoWorldModelInterface *wm_if_;
-  fawkes::RobotinoWorldModelInterface *wm_ext1_if_;
-  fawkes::RobotinoWorldModelInterface *wm_ext2_if_;
+	fawkes::RobotinoWorldModelInterface *wm_if_;
+	fawkes::RobotinoWorldModelInterface *wm_ext1_if_;
+	fawkes::RobotinoWorldModelInterface *wm_ext2_if_;
 
-  fawkes::Time time_;
-  int state_;
-  int type_;
+	fawkes::Time time_;
+	int          state_;
+	int          type_;
 };
 
 #endif

--- a/src/plugins/attic/visual_position/visual_position_thread.cpp
+++ b/src/plugins/attic/visual_position/visual_position_thread.cpp
@@ -14,995 +14,1041 @@
 #include "visual_position_thread.h"
 
 VisualPositionThread::VisualPositionThread()
-    : Thread("VisualPositionThread", Thread::OPMODE_WAITFORWAKEUP),
-      VisionAspect(VisionAspect::CYCLIC),
-      ConfigurationChangeHandler(CFG_PREFIX) {
-  cfg_prefix_ = CFG_PREFIX;
-  cfg_frame_camera_pos_ = "";
+: Thread("VisualPositionThread", Thread::OPMODE_WAITFORWAKEUP),
+  VisionAspect(VisionAspect::CYCLIC),
+  ConfigurationChangeHandler(CFG_PREFIX)
+{
+	cfg_prefix_           = CFG_PREFIX;
+	cfg_frame_camera_pos_ = "";
 
-  camera_info_.cfg_camera_ = "";
-  camera_info_.img_width_ = 0;
-  camera_info_.img_height_ = 0;
-  camera_info_.opening_angle_horizontal_ = 0;
-  camera_info_.opening_angle_vertical_ = 0;
+	camera_info_.cfg_camera_               = "";
+	camera_info_.img_width_                = 0;
+	camera_info_.img_height_               = 0;
+	camera_info_.opening_angle_horizontal_ = 0;
+	camera_info_.opening_angle_vertical_   = 0;
 
-  buffer_color_ = NULL;
-  buffer_gray_ = NULL;
-  buffer_gray_edgy_ = NULL;
+	buffer_color_     = NULL;
+	buffer_gray_      = NULL;
+	buffer_gray_edgy_ = NULL;
 
-  shm_buffer_color_ = NULL;
-  shm_buffer_gray_ = NULL;
-  shm_buffer_gray_edgy_ = NULL;
+	shm_buffer_color_     = NULL;
+	shm_buffer_gray_      = NULL;
+	shm_buffer_gray_edgy_ = NULL;
 
-  cspaceFrom_ = firevision::YUV422_PLANAR;
-  cspaceTo_ = firevision::YUV422_PLANAR;
+	cspaceFrom_ = firevision::YUV422_PLANAR;
+	cspaceTo_   = firevision::YUV422_PLANAR;
 
-  cam_ = NULL;
+	cam_ = NULL;
 
-  switchInterface_ = NULL;
-  no_pucK_ = NULL;
+	switchInterface_ = NULL;
+	no_pucK_         = NULL;
 
-  puck_info_.main.classifier = NULL;
-  puck_info_.main.colormodel = NULL;
-  puck_info_.main.scanline_grid = NULL;
+	puck_info_.main.classifier    = NULL;
+	puck_info_.main.colormodel    = NULL;
+	puck_info_.main.scanline_grid = NULL;
 
-  puck_info_.top_dots.classifier = NULL;
-  puck_info_.top_dots.colormodel = NULL;
-  puck_info_.top_dots.scanline_grid = NULL;
+	puck_info_.top_dots.classifier    = NULL;
+	puck_info_.top_dots.colormodel    = NULL;
+	puck_info_.top_dots.scanline_grid = NULL;
 
-  drawer_ = NULL;
+	drawer_ = NULL;
 
-  cfg_paintROIsActivated_ = false;
-  cfg_debugMessagesActivated_ = false;
-  cfg_changed_ = false;
+	cfg_paintROIsActivated_     = false;
+	cfg_debugMessagesActivated_ = false;
+	cfg_changed_                = false;
 }
 /*
  * Create a new puck interface for writing and append it to puck_interfaces_
  * vector
  */
-void VisualPositionThread::createPuckInterface() {
-  fawkes::Position3DInterface *puck_if_ = NULL;
+void
+VisualPositionThread::createPuckInterface()
+{
+	fawkes::Position3DInterface *puck_if_ = NULL;
 
-  std::string interface_name =
-      "puck_" + std::to_string(puck_interfaces_.size());
-  logger->log_info(name(), "Creating new Position3DInterface %s",
-                   interface_name.c_str());
+	std::string interface_name = "puck_" + std::to_string(puck_interfaces_.size());
+	logger->log_info(name(), "Creating new Position3DInterface %s", interface_name.c_str());
 
-  try {
-    puck_if_ = blackboard->open_for_writing<fawkes::Position3DInterface>(
-        interface_name.c_str());
-    puck_if_->set_visibility_history(-9999);
-    puck_if_->set_frame("/base_link");
-    puck_if_->write();
-    puck_interfaces_.push_back(puck_if_);
-  } catch (std::exception &e) {
-    finalize();
-    throw;
-  }
+	try {
+		puck_if_ = blackboard->open_for_writing<fawkes::Position3DInterface>(interface_name.c_str());
+		puck_if_->set_visibility_history(-9999);
+		puck_if_->set_frame("/base_link");
+		puck_if_->write();
+		puck_interfaces_.push_back(puck_if_);
+	} catch (std::exception &e) {
+		finalize();
+		throw;
+	}
 }
 
-void VisualPositionThread::loadConfig() {
-  logger->log_info(name(), "loading config");
-  cfg_prefix_ = CFG_PREFIX;
-  cfg_prefix_static_transforms_ =
-      config->get_string((cfg_prefix_ + "transform").c_str());
+void
+VisualPositionThread::loadConfig()
+{
+	logger->log_info(name(), "loading config");
+	cfg_prefix_                   = CFG_PREFIX;
+	cfg_prefix_static_transforms_ = config->get_string((cfg_prefix_ + "transform").c_str());
 
-  cfg_frame_camera_pos_ = config->get_string(
-      (cfg_prefix_static_transforms_ + "child_frame").c_str());
+	cfg_frame_camera_pos_ =
+	  config->get_string((cfg_prefix_static_transforms_ + "child_frame").c_str());
 
-  // load camera informations
-  camera_info_.cfg_camera_ =
-      config->get_string((cfg_prefix_ + "camera").c_str());
-  camera_info_.position_x_ =
-      config->get_float((cfg_prefix_static_transforms_ + "trans_x").c_str());
-  camera_info_.position_y_ =
-      config->get_float((cfg_prefix_static_transforms_ + "trans_y").c_str());
-  camera_info_.position_z_ =
-      config->get_float((cfg_prefix_static_transforms_ + "trans_z").c_str());
-  camera_info_.position_pitch_ =
-      config->get_float((cfg_prefix_static_transforms_ + "rot_pitch").c_str());
-  camera_info_.opening_angle_horizontal_ = config->get_float(
-      (cfg_prefix_ + "camera_opening_angle_horizontal").c_str());
-  camera_info_.opening_angle_vertical_ = config->get_float(
-      (cfg_prefix_ + "camera_opening_angle_vertical").c_str());
-  // Calculate visible Area
-  camera_info_.angle_horizontal_to_opening_ =
-      (1.57 - camera_info_.position_pitch_) -
-      (camera_info_.opening_angle_vertical_ / 2);
-  camera_info_.visible_lenght_x_in_m_ =
-      camera_info_.position_z_ *
-      (tan(camera_info_.opening_angle_vertical_ +
-           camera_info_.angle_horizontal_to_opening_) -
-       tan(camera_info_.angle_horizontal_to_opening_));
-  camera_info_.offset_cam_x_to_groundplane_ =
-      camera_info_.position_z_ * tan(camera_info_.angle_horizontal_to_opening_);
-  camera_info_.visible_lenght_y_in_m_ =
-      camera_info_.position_z_ *
-      tan(camera_info_.opening_angle_horizontal_ / 2);
+	// load camera informations
+	camera_info_.cfg_camera_ = config->get_string((cfg_prefix_ + "camera").c_str());
+	camera_info_.position_x_ = config->get_float((cfg_prefix_static_transforms_ + "trans_x").c_str());
+	camera_info_.position_y_ = config->get_float((cfg_prefix_static_transforms_ + "trans_y").c_str());
+	camera_info_.position_z_ = config->get_float((cfg_prefix_static_transforms_ + "trans_z").c_str());
+	camera_info_.position_pitch_ =
+	  config->get_float((cfg_prefix_static_transforms_ + "rot_pitch").c_str());
+	camera_info_.opening_angle_horizontal_ =
+	  config->get_float((cfg_prefix_ + "camera_opening_angle_horizontal").c_str());
+	camera_info_.opening_angle_vertical_ =
+	  config->get_float((cfg_prefix_ + "camera_opening_angle_vertical").c_str());
+	// Calculate visible Area
+	camera_info_.angle_horizontal_to_opening_ =
+	  (1.57 - camera_info_.position_pitch_) - (camera_info_.opening_angle_vertical_ / 2);
+	camera_info_.visible_lenght_x_in_m_ =
+	  camera_info_.position_z_
+	  * (tan(camera_info_.opening_angle_vertical_ + camera_info_.angle_horizontal_to_opening_)
+	     - tan(camera_info_.angle_horizontal_to_opening_));
+	camera_info_.offset_cam_x_to_groundplane_ =
+	  camera_info_.position_z_ * tan(camera_info_.angle_horizontal_to_opening_);
+	camera_info_.visible_lenght_y_in_m_ =
+	  camera_info_.position_z_ * tan(camera_info_.opening_angle_horizontal_ / 2);
 
-  logger->log_debug(name(), "Camera opening angles Horizontal: %f Vertical: %f",
-                    camera_info_.opening_angle_horizontal_,
-                    camera_info_.opening_angle_vertical_);
+	logger->log_debug(name(),
+	                  "Camera opening angles Horizontal: %f Vertical: %f",
+	                  camera_info_.opening_angle_horizontal_,
+	                  camera_info_.opening_angle_vertical_);
 
-  cfg_debugMessagesActivated_ =
-      config->get_bool((cfg_prefix_ + "show_debug_messages").c_str());
-  cfg_paintROIsActivated_ =
-      config->get_bool((cfg_prefix_ + "draw_rois").c_str());
+	cfg_debugMessagesActivated_ = config->get_bool((cfg_prefix_ + "show_debug_messages").c_str());
+	cfg_paintROIsActivated_     = config->get_bool((cfg_prefix_ + "draw_rois").c_str());
 
-  search_area.start.x =
-      config->get_uint((cfg_prefix_ + "search_area/start/x").c_str());
-  search_area.start.y =
-      config->get_uint((cfg_prefix_ + "search_area/start/y").c_str());
-  search_area.width =
-      config->get_uint((cfg_prefix_ + "search_area/width").c_str());
-  search_area.height =
-      config->get_uint((cfg_prefix_ + "search_area/height").c_str());
-  search_area.color = firevision::C_BLUE;
+	search_area.start.x = config->get_uint((cfg_prefix_ + "search_area/start/x").c_str());
+	search_area.start.y = config->get_uint((cfg_prefix_ + "search_area/start/y").c_str());
+	search_area.width   = config->get_uint((cfg_prefix_ + "search_area/width").c_str());
+	search_area.height  = config->get_uint((cfg_prefix_ + "search_area/height").c_str());
+	search_area.color   = firevision::C_BLUE;
 
-  // Config Value for the classifier mode
-  cfg_colormodel_mode_ =
-      config->get_string((cfg_prefix_ + "colormodel_mode").c_str());
+	// Config Value for the classifier mode
+	cfg_colormodel_mode_ = config->get_string((cfg_prefix_ + "colormodel_mode").c_str());
 }
 
-void VisualPositionThread::init_with_config() {
-  // CAM swapping not working
-  if (false && cam_ != NULL) {
-    cam_->stop();
-    cam_->flush();
-    cam_->dispose_buffer();
-    cam_->close();
-    delete cam_;
-    cam_ = NULL;
-  }
-  if (cam_ == NULL) {
-    cam_ = vision_master->register_for_camera(camera_info_.cfg_camera_.c_str(),
-                                              this);
-    cam_->start();
-    cam_->open();
-    camera_info_.img_width_ = cam_->pixel_width();
-    camera_info_.img_height_ = cam_->pixel_height();
+void
+VisualPositionThread::init_with_config()
+{
+	// CAM swapping not working
+	if (false && cam_ != NULL) {
+		cam_->stop();
+		cam_->flush();
+		cam_->dispose_buffer();
+		cam_->close();
+		delete cam_;
+		cam_ = NULL;
+	}
+	if (cam_ == NULL) {
+		cam_ = vision_master->register_for_camera(camera_info_.cfg_camera_.c_str(), this);
+		cam_->start();
+		cam_->open();
+		camera_info_.img_width_  = cam_->pixel_width();
+		camera_info_.img_height_ = cam_->pixel_height();
 
-    search_area.image_height = camera_info_.img_height_;
-    search_area.image_width = camera_info_.img_width_;
-    printRoi(search_area);
+		search_area.image_height = camera_info_.img_height_;
+		search_area.image_width  = camera_info_.img_width_;
+		printRoi(search_area);
 
-    cspaceFrom_ = cam_->colorspace();
+		cspaceFrom_ = cam_->colorspace();
 
-    // SHM image buffer
-    if (shm_buffer_color_ != NULL) {
-      delete shm_buffer_color_;
-      shm_buffer_color_ = NULL;
-      buffer_color_ = NULL;
+		// SHM image buffer
+		if (shm_buffer_color_ != NULL) {
+			delete shm_buffer_color_;
+			shm_buffer_color_ = NULL;
+			buffer_color_     = NULL;
 
-      delete shm_buffer_gray_;
-      shm_buffer_gray_ = NULL;
-      buffer_gray_ = NULL;
+			delete shm_buffer_gray_;
+			shm_buffer_gray_ = NULL;
+			buffer_gray_     = NULL;
 
-      delete shm_buffer_gray_edgy_;
-      shm_buffer_gray_edgy_ = NULL;
-      buffer_gray_edgy_ = NULL;
-    }
-    std::string shmID =
-        config->get_string((cfg_prefix_ + "shm_image_id").c_str());
-    shm_buffer_color_ = new firevision::SharedMemoryImageBuffer(
-        shmID.c_str(), cspaceTo_, camera_info_.img_width_,
-        camera_info_.img_height_);
+			delete shm_buffer_gray_edgy_;
+			shm_buffer_gray_edgy_ = NULL;
+			buffer_gray_edgy_     = NULL;
+		}
+		std::string shmID = config->get_string((cfg_prefix_ + "shm_image_id").c_str());
+		shm_buffer_color_ = new firevision::SharedMemoryImageBuffer(shmID.c_str(),
+		                                                            cspaceTo_,
+		                                                            camera_info_.img_width_,
+		                                                            camera_info_.img_height_);
 
-    shmID = shmID + "_gray";
-    shm_buffer_gray_ = new firevision::SharedMemoryImageBuffer(
-        shmID.c_str(), firevision::GRAY8, camera_info_.img_width_,
-        camera_info_.img_height_);
+		shmID            = shmID + "_gray";
+		shm_buffer_gray_ = new firevision::SharedMemoryImageBuffer(shmID.c_str(),
+		                                                           firevision::GRAY8,
+		                                                           camera_info_.img_width_,
+		                                                           camera_info_.img_height_);
 
-    shmID = shmID + "_edgy";
-    shm_buffer_gray_edgy_ = new firevision::SharedMemoryImageBuffer(
-        shmID.c_str(), firevision::GRAY8, camera_info_.img_width_,
-        camera_info_.img_height_);
+		shmID                 = shmID + "_edgy";
+		shm_buffer_gray_edgy_ = new firevision::SharedMemoryImageBuffer(shmID.c_str(),
+		                                                                firevision::GRAY8,
+		                                                                camera_info_.img_width_,
+		                                                                camera_info_.img_height_);
 
-    if (!shm_buffer_color_->is_valid() || !shm_buffer_gray_->is_valid() ||
-        !shm_buffer_gray_edgy_->is_valid()) {
-      delete shm_buffer_color_;
-      delete shm_buffer_gray_;
-      delete cam_;
-      shm_buffer_color_ = NULL;
-      shm_buffer_gray_ = NULL;
-      cam_ = NULL;
-      throw fawkes::Exception("Shared memory segment not valid");
-    }
+		if (!shm_buffer_color_->is_valid() || !shm_buffer_gray_->is_valid()
+		    || !shm_buffer_gray_edgy_->is_valid()) {
+			delete shm_buffer_color_;
+			delete shm_buffer_gray_;
+			delete cam_;
+			shm_buffer_color_ = NULL;
+			shm_buffer_gray_  = NULL;
+			cam_              = NULL;
+			throw fawkes::Exception("Shared memory segment not valid");
+		}
 
-    shm_buffer_color_->set_frame_id(cfg_frame_camera_pos_.c_str());
-    shm_buffer_gray_->set_frame_id(cfg_frame_camera_pos_.c_str());
-    shm_buffer_gray_edgy_->set_frame_id(cfg_frame_camera_pos_.c_str());
+		shm_buffer_color_->set_frame_id(cfg_frame_camera_pos_.c_str());
+		shm_buffer_gray_->set_frame_id(cfg_frame_camera_pos_.c_str());
+		shm_buffer_gray_edgy_->set_frame_id(cfg_frame_camera_pos_.c_str());
 
-    buffer_color_ = shm_buffer_color_->buffer();
-    buffer_gray_ = shm_buffer_gray_->buffer();
-    buffer_gray_edgy_ = shm_buffer_gray_edgy_->buffer();
+		buffer_color_     = shm_buffer_color_->buffer();
+		buffer_gray_      = shm_buffer_gray_->buffer();
+		buffer_gray_edgy_ = shm_buffer_gray_edgy_->buffer();
 
-    camera_info_.fullimage = firevision::ROI::full_image(
-        camera_info_.img_width_, camera_info_.img_height_);
-  }
+		camera_info_.fullimage =
+		  firevision::ROI::full_image(camera_info_.img_width_, camera_info_.img_height_);
+	}
 
-  //	//load puck infos;
-  puck_info_.radius = config->get_float((cfg_prefix_ + "puck/radius").c_str());
-  puck_info_.height = config->get_float((cfg_prefix_ + "puck/height").c_str());
+	//	//load puck infos;
+	puck_info_.radius = config->get_float((cfg_prefix_ + "puck/radius").c_str());
+	puck_info_.height = config->get_float((cfg_prefix_ + "puck/height").c_str());
 
-  // Configure classifier
-  logger->log_info(name(), "Loading colormodel %s",
-                   cfg_colormodel_mode_.c_str());
+	// Configure classifier
+	logger->log_info(name(), "Loading colormodel %s", cfg_colormodel_mode_.c_str());
 
-  setup_color_classifier(&puck_info_.main, "puck/red", firevision::C_RED);
-  setup_color_classifier(&puck_info_.top_dots, "puck/topdots",
-                         firevision::C_YELLOW);
+	setup_color_classifier(&puck_info_.main, "puck/red", firevision::C_RED);
+	setup_color_classifier(&puck_info_.top_dots, "puck/topdots", firevision::C_YELLOW);
 
-  logger->log_debug(name(),
-                    "Visible X: %f y: %f Offset cam groundplane: %f angle "
-                    "(horizontal/opening): %f ",
-                    camera_info_.visible_lenght_x_in_m_,
-                    camera_info_.visible_lenght_y_in_m_,
-                    camera_info_.offset_cam_x_to_groundplane_,
-                    camera_info_.angle_horizontal_to_opening_);
-  logger->log_debug(name(), "cam transform X: %f y: %f z: %f pitch: %f",
-                    camera_info_.position_x_, camera_info_.position_y_,
-                    camera_info_.position_z_, camera_info_.position_pitch_);
+	logger->log_debug(name(),
+	                  "Visible X: %f y: %f Offset cam groundplane: %f angle "
+	                  "(horizontal/opening): %f ",
+	                  camera_info_.visible_lenght_x_in_m_,
+	                  camera_info_.visible_lenght_y_in_m_,
+	                  camera_info_.offset_cam_x_to_groundplane_,
+	                  camera_info_.angle_horizontal_to_opening_);
+	logger->log_debug(name(),
+	                  "cam transform X: %f y: %f z: %f pitch: %f",
+	                  camera_info_.position_x_,
+	                  camera_info_.position_y_,
+	                  camera_info_.position_z_,
+	                  camera_info_.position_pitch_);
 }
 
-void VisualPositionThread::init() {
-  logger->log_info(name(), "starts init");
+void
+VisualPositionThread::init()
+{
+	logger->log_info(name(), "starts init");
 
-  config->add_change_handler(this);
+	config->add_change_handler(this);
 
-  no_pucK_ = new puck();
-  int val_empty = -9999;
-  no_pucK_->visibiity_history = val_empty;
-  no_pucK_->cart.x = val_empty;
-  no_pucK_->cart.y = val_empty;
-  no_pucK_->cart.z = val_empty;
-  drawer_ = new firevision::FilterROIDraw();
-  loadConfig();
-  init_with_config();
-  createPuckInterface();
+	no_pucK_                    = new puck();
+	int val_empty               = -9999;
+	no_pucK_->visibiity_history = val_empty;
+	no_pucK_->cart.x            = val_empty;
+	no_pucK_->cart.y            = val_empty;
+	no_pucK_->cart.z            = val_empty;
+	drawer_                     = new firevision::FilterROIDraw();
+	loadConfig();
+	init_with_config();
+	createPuckInterface();
 
-  logger->log_debug(name(), "end of init()");
+	logger->log_debug(name(), "end of init()");
 }
 
-void VisualPositionThread::deleteClassifier(
-    color_classifier_context_t_ *color_data) {
-  if (color_data->classifier != NULL) {
-    delete color_data->classifier;
-    color_data->classifier = NULL;
-  }
-  if (color_data->colormodel != NULL) {
-    delete color_data->colormodel;
-    color_data->colormodel = NULL;
-  }
-  if (color_data->classifier != NULL) {
-    delete color_data->scanline_grid;
-    color_data->scanline_grid = NULL;
-  }
-  if (!color_data->color_classes.empty()) {
-    while (!color_data->color_classes.empty()) {
-      firevision::ColorModelSimilarity::color_class_t *color_class =
-          color_data->color_classes.back();
-      color_data->color_classes.pop_back();
-      delete color_class;
-    }
-  }
+void
+VisualPositionThread::deleteClassifier(color_classifier_context_t_ *color_data)
+{
+	if (color_data->classifier != NULL) {
+		delete color_data->classifier;
+		color_data->classifier = NULL;
+	}
+	if (color_data->colormodel != NULL) {
+		delete color_data->colormodel;
+		color_data->colormodel = NULL;
+	}
+	if (color_data->classifier != NULL) {
+		delete color_data->scanline_grid;
+		color_data->scanline_grid = NULL;
+	}
+	if (!color_data->color_classes.empty()) {
+		while (!color_data->color_classes.empty()) {
+			firevision::ColorModelSimilarity::color_class_t *color_class =
+			  color_data->color_classes.back();
+			color_data->color_classes.pop_back();
+			delete color_class;
+		}
+	}
 }
 
-void VisualPositionThread::setup_color_classifier(
-    color_classifier_context_t_ *color_data, const char *prefix,
-    firevision::color_t expected) {
-  deleteClassifier(color_data);
-  // Update values from config
-  color_data->color_expect = expected;
-  color_data->cfg_ref_col =
-      config->get_uints((cfg_prefix_ + prefix + "/reference_color").c_str());
-  color_data->cfg_chroma_thresh =
-      config->get_int((cfg_prefix_ + prefix + "/chroma_thresh").c_str());
-  color_data->cfg_sat_thresh =
-      config->get_int((cfg_prefix_ + prefix + "/saturation_thresh").c_str());
-  color_data->cfg_roi_min_points =
-      config->get_int((cfg_prefix_ + prefix + "/min_points").c_str());
-  color_data->cfg_roi_basic_size =
-      config->get_int((cfg_prefix_ + prefix + "/basic_roi_size").c_str());
-  color_data->cfg_roi_neighborhood_min_match = config->get_int(
-      (cfg_prefix_ + prefix + "/neighborhood_min_match").c_str());
-  color_data->cfg_scangrid_x_offset =
-      config->get_int((cfg_prefix_ + prefix + "/scangrid_x_offset").c_str());
-  color_data->cfg_scangrid_y_offset =
-      config->get_int((cfg_prefix_ + prefix + "/scangrid_y_offset").c_str());
+void
+VisualPositionThread::setup_color_classifier(color_classifier_context_t_ *color_data,
+                                             const char *                 prefix,
+                                             firevision::color_t          expected)
+{
+	deleteClassifier(color_data);
+	// Update values from config
+	color_data->color_expect = expected;
+	color_data->cfg_ref_col  = config->get_uints((cfg_prefix_ + prefix + "/reference_color").c_str());
+	color_data->cfg_chroma_thresh =
+	  config->get_int((cfg_prefix_ + prefix + "/chroma_thresh").c_str());
+	color_data->cfg_sat_thresh =
+	  config->get_int((cfg_prefix_ + prefix + "/saturation_thresh").c_str());
+	color_data->cfg_roi_min_points = config->get_int((cfg_prefix_ + prefix + "/min_points").c_str());
+	color_data->cfg_roi_basic_size =
+	  config->get_int((cfg_prefix_ + prefix + "/basic_roi_size").c_str());
+	color_data->cfg_roi_neighborhood_min_match =
+	  config->get_int((cfg_prefix_ + prefix + "/neighborhood_min_match").c_str());
+	color_data->cfg_scangrid_x_offset =
+	  config->get_int((cfg_prefix_ + prefix + "/scangrid_x_offset").c_str());
+	color_data->cfg_scangrid_y_offset =
+	  config->get_int((cfg_prefix_ + prefix + "/scangrid_y_offset").c_str());
 
-  color_data->scanline_grid = new firevision::ScanlineGrid(
-      camera_info_.img_width_, camera_info_.img_height_,
-      color_data->cfg_scangrid_x_offset, color_data->cfg_scangrid_y_offset);
+	color_data->scanline_grid = new firevision::ScanlineGrid(camera_info_.img_width_,
+	                                                         camera_info_.img_height_,
+	                                                         color_data->cfg_scangrid_x_offset,
+	                                                         color_data->cfg_scangrid_y_offset);
 
-  if (cfg_colormodel_mode_ == "colormap") {
-    std::string lutname = std::string(prefix) + "/lut"; //"puck_vison/" +
-    std::string filename =
-        std::string(CONFDIR) + "/" +
-        config->get_string((cfg_prefix_ + prefix + "/lut").c_str());
-    color_data->colormodel = new firevision::ColorModelLookupTable(
-        filename.c_str(), lutname.c_str(), true /* destroy on delete */);
+	if (cfg_colormodel_mode_ == "colormap") {
+		std::string lutname = std::string(prefix) + "/lut"; //"puck_vison/" +
+		std::string filename =
+		  std::string(CONFDIR) + "/" + config->get_string((cfg_prefix_ + prefix + "/lut").c_str());
+		color_data->colormodel = new firevision::ColorModelLookupTable(filename.c_str(),
+		                                                               lutname.c_str(),
+		                                                               true /* destroy on delete */);
 
-    color_data->classifier = new firevision::SimpleColorClassifier(
-        color_data->scanline_grid, color_data->colormodel,
-        color_data->cfg_roi_min_points, color_data->cfg_roi_basic_size, false,
-        color_data->cfg_roi_neighborhood_min_match, 0);
+		color_data->classifier =
+		  new firevision::SimpleColorClassifier(color_data->scanline_grid,
+		                                        color_data->colormodel,
+		                                        color_data->cfg_roi_min_points,
+		                                        color_data->cfg_roi_basic_size,
+		                                        false,
+		                                        color_data->cfg_roi_neighborhood_min_match,
+		                                        0);
 
-  } else if (cfg_colormodel_mode_ == "similarity") {
-    firevision::ColorModelSimilarity *cm =
-        new firevision::ColorModelSimilarity();
+	} else if (cfg_colormodel_mode_ == "similarity") {
+		firevision::ColorModelSimilarity *cm = new firevision::ColorModelSimilarity();
 
-    while (!color_data->cfg_ref_col.empty()) {
-      std::vector<unsigned int> color(color_data->cfg_ref_col.begin(),
-                                      color_data->cfg_ref_col.begin() + 3);
-      color_data->cfg_ref_col = std::vector<unsigned int>(
-          color_data->cfg_ref_col.begin() + 3, color_data->cfg_ref_col.end());
-      firevision::ColorModelSimilarity::color_class_t *color_class =
-          new firevision::ColorModelSimilarity::color_class_t(
-              color_data->color_expect, color, color_data->cfg_chroma_thresh,
-              color_data->cfg_sat_thresh);
+		while (!color_data->cfg_ref_col.empty()) {
+			std::vector<unsigned int> color(color_data->cfg_ref_col.begin(),
+			                                color_data->cfg_ref_col.begin() + 3);
+			color_data->cfg_ref_col = std::vector<unsigned int>(color_data->cfg_ref_col.begin() + 3,
+			                                                    color_data->cfg_ref_col.end());
+			firevision::ColorModelSimilarity::color_class_t *color_class =
+			  new firevision::ColorModelSimilarity::color_class_t(color_data->color_expect,
+			                                                      color,
+			                                                      color_data->cfg_chroma_thresh,
+			                                                      color_data->cfg_sat_thresh);
 
-      color_data->color_classes.push_back(color_class);
-      cm->add_color(color_class);
-      logger->log_info(name(), "Color %i added reference color R:%i G:%i B:%i",
-                       color_data->color_expect, color[0], color[1], color[2]);
-    }
+			color_data->color_classes.push_back(color_class);
+			cm->add_color(color_class);
+			logger->log_info(name(),
+			                 "Color %i added reference color R:%i G:%i B:%i",
+			                 color_data->color_expect,
+			                 color[0],
+			                 color[1],
+			                 color[2]);
+		}
 
-    color_data->colormodel = cm;
-    color_data->classifier = new firevision::SimpleColorClassifier(
-        color_data->scanline_grid, color_data->colormodel,
-        color_data->cfg_roi_min_points, color_data->cfg_roi_basic_size, false,
-        color_data->cfg_roi_neighborhood_min_match, 0,
-        color_data->color_expect);
-  } else {
-    throw new fawkes::Exception("selected colormodel not supported");
-  }
+		color_data->colormodel = cm;
+		color_data->classifier =
+		  new firevision::SimpleColorClassifier(color_data->scanline_grid,
+		                                        color_data->colormodel,
+		                                        color_data->cfg_roi_min_points,
+		                                        color_data->cfg_roi_basic_size,
+		                                        false,
+		                                        color_data->cfg_roi_neighborhood_min_match,
+		                                        0,
+		                                        color_data->color_expect);
+	} else {
+		throw new fawkes::Exception("selected colormodel not supported");
+	}
 }
 
-void VisualPositionThread::drawRois(std::list<firevision::ROI> *rois_) {
-  if (cfg_paintROIsActivated_) {
-    for (std::list<firevision::ROI>::iterator list_iter = rois_->begin();
-         list_iter != rois_->end(); list_iter++) {
-      drawROIIntoBuffer(*list_iter, firevision::FilterROIDraw::DASHED_HINT);
-    }
-  }
+void
+VisualPositionThread::drawRois(std::list<firevision::ROI> *rois_)
+{
+	if (cfg_paintROIsActivated_) {
+		for (std::list<firevision::ROI>::iterator list_iter = rois_->begin(); list_iter != rois_->end();
+		     list_iter++) {
+			drawROIIntoBuffer(*list_iter, firevision::FilterROIDraw::DASHED_HINT);
+		}
+	}
 }
 
-void VisualPositionThread::mergeWithColorInformation(
-    firevision::color_t color, std::list<firevision::ROI> *rois_color_,
-    std::list<firevision::ROI> *rois_all) {
-  while (rois_color_->size() != 0) {
-    rois_color_->front().color = color;
-    rois_all->push_front(rois_color_->front());
-    rois_color_->pop_front();
-  }
+void
+VisualPositionThread::mergeWithColorInformation(firevision::color_t         color,
+                                                std::list<firevision::ROI> *rois_color_,
+                                                std::list<firevision::ROI> *rois_all)
+{
+	while (rois_color_->size() != 0) {
+		rois_color_->front().color = color;
+		rois_all->push_front(rois_color_->front());
+		rois_color_->pop_front();
+	}
 }
 
-int schnittpunkt(myLine line1, myLine line2, firevision::ROI &result) {
-  using namespace std;
-  // Die 4 Punkte, p1 und p2 ergeben Linie 1 und p3, p4 ergeben Linie 2
-  int p1[] = {(int)line1.upper_point.start.x, (int)line1.upper_point.start.y,
-              1};
-  int p2[] = {(int)line1.lower_point.start.x, (int)line1.lower_point.start.y,
-              1};
-  int p3[] = {(int)line2.upper_point.start.x, (int)line2.upper_point.start.y,
-              1};
-  int p4[] = {(int)line2.lower_point.start.x, (int)line2.lower_point.start.y,
-              1};
+int
+schnittpunkt(myLine line1, myLine line2, firevision::ROI &result)
+{
+	using namespace std;
+	// Die 4 Punkte, p1 und p2 ergeben Linie 1 und p3, p4 ergeben Linie 2
+	int p1[] = {(int)line1.upper_point.start.x, (int)line1.upper_point.start.y, 1};
+	int p2[] = {(int)line1.lower_point.start.x, (int)line1.lower_point.start.y, 1};
+	int p3[] = {(int)line2.upper_point.start.x, (int)line2.upper_point.start.y, 1};
+	int p4[] = {(int)line2.lower_point.start.x, (int)line2.lower_point.start.y, 1};
 
-  int l1[3], l2[3], s[3];
-  double sch[2];
-  l1[0] = p1[1] * p2[2] - p1[2] * p2[1];
-  l1[1] = p1[2] * p2[0] - p1[0] * p2[2];
-  l1[2] = p1[0] * p2[1] - p1[1] * p2[0];
-  l2[0] = p3[1] * p4[2] - p3[2] * p4[1];
-  l2[1] = p3[2] * p4[0] - p3[0] * p4[2];
-  l2[2] = p3[0] * p4[1] - p3[1] * p4[0];
-  s[0] = l1[1] * l2[2] - l1[2] * l2[1];
-  s[1] = l1[2] * l2[0] - l1[0] * l2[2];
-  s[2] = l1[0] * l2[1] - l1[1] * l2[0];
-  sch[0] = (double)s[0] / (double)s[2];
-  sch[1] = (double)s[1] / (double)s[2];
+	int    l1[3], l2[3], s[3];
+	double sch[2];
+	l1[0]  = p1[1] * p2[2] - p1[2] * p2[1];
+	l1[1]  = p1[2] * p2[0] - p1[0] * p2[2];
+	l1[2]  = p1[0] * p2[1] - p1[1] * p2[0];
+	l2[0]  = p3[1] * p4[2] - p3[2] * p4[1];
+	l2[1]  = p3[2] * p4[0] - p3[0] * p4[2];
+	l2[2]  = p3[0] * p4[1] - p3[1] * p4[0];
+	s[0]   = l1[1] * l2[2] - l1[2] * l2[1];
+	s[1]   = l1[2] * l2[0] - l1[0] * l2[2];
+	s[2]   = l1[0] * l2[1] - l1[1] * l2[0];
+	sch[0] = (double)s[0] / (double)s[2];
+	sch[1] = (double)s[1] / (double)s[2];
 
-  result.start.x = (unsigned int)sch[0];
-  result.start.y = (unsigned int)sch[1];
+	result.start.x = (unsigned int)sch[0];
+	result.start.y = (unsigned int)sch[1];
 
-  cout << "Ergebnis: x" << sch[0] << " y: " << sch[1] << endl;
+	cout << "Ergebnis: x" << sch[0] << " y: " << sch[1] << endl;
 
-  return 0;
+	return 0;
 }
 
-void VisualPositionThread::loop() {
-  if (!cfg_mutex_.try_lock()) {
-    logger->log_info(name(), "Skipping loop(), mutex locked");
-    return; // If I cant lock it its locked already (config is changing/reinit
-            // in progress)
-  } else {
-    if (cam_ != NULL && !cam_->ready()) {
-      logger->log_info(name(), "camera not ready\n");
-      loadConfig();
-      return;
-    }
-    // logger->log_info(name(), "capture");
-    cam_->capture();
+void
+VisualPositionThread::loop()
+{
+	if (!cfg_mutex_.try_lock()) {
+		logger->log_info(name(), "Skipping loop(), mutex locked");
+		return; // If I cant lock it its locked already (config is changing/reinit
+		        // in progress)
+	} else {
+		if (cam_ != NULL && !cam_->ready()) {
+			logger->log_info(name(), "camera not ready\n");
+			loadConfig();
+			return;
+		}
+		// logger->log_info(name(), "capture");
+		cam_->capture();
 
-    firevision::convert(cspaceFrom_, cspaceTo_, cam_->buffer(), buffer_color_,
-                        camera_info_.img_width_, camera_info_.img_height_);
+		firevision::convert(cspaceFrom_,
+		                    cspaceTo_,
+		                    cam_->buffer(),
+		                    buffer_color_,
+		                    camera_info_.img_width_,
+		                    camera_info_.img_height_);
 
-    cam_->dispose_buffer();
-    IplImage *p_image =
-        cvCreateImage(cvSize(camera_info_.img_width_, camera_info_.img_height_),
-                      IPL_DEPTH_8U, 3);
-    firevision::IplImageAdapter::convert_image_bgr(cam_->buffer(), p_image);
-    //
-    cv::Mat image_edgy;
-    cv::Mat image_colored(p_image, false);
-    cv::cvtColor(image_colored, image_edgy, CV_BGR2GRAY);
-    // cv::imwrite("edgy_grey.jpg",image_edgy);
-    // cv::threshold(image_edgy, image_edgy, 70, 255, cv::THRESH_BINARY );
-    // cv::imwrite("edgy_threshold.jpg",image_edgy);
-    //
-    // cv::imshow("cam",m);
+		cam_->dispose_buffer();
+		IplImage *p_image =
+		  cvCreateImage(cvSize(camera_info_.img_width_, camera_info_.img_height_), IPL_DEPTH_8U, 3);
+		firevision::IplImageAdapter::convert_image_bgr(cam_->buffer(), p_image);
+		//
+		cv::Mat image_edgy;
+		cv::Mat image_colored(p_image, false);
+		cv::cvtColor(image_colored, image_edgy, CV_BGR2GRAY);
+		// cv::imwrite("edgy_grey.jpg",image_edgy);
+		// cv::threshold(image_edgy, image_edgy, 70, 255, cv::THRESH_BINARY );
+		// cv::imwrite("edgy_threshold.jpg",image_edgy);
+		//
+		// cv::imshow("cam",m);
 
-    cv::medianBlur(image_edgy, image_edgy, 3);
-    cv::imwrite("edgy_clean_median.jpg", image_edgy);
-    cv::Canny(image_edgy, image_edgy, 200, 230, 3, true);
-    cv::imwrite("edgy_clean.jpg", image_edgy);
-    // cv::imshow("edge",image_edgy);
-    cv::imwrite("edgy_threshold.jpg", image_edgy);
+		cv::medianBlur(image_edgy, image_edgy, 3);
+		cv::imwrite("edgy_clean_median.jpg", image_edgy);
+		cv::Canny(image_edgy, image_edgy, 200, 230, 3, true);
+		cv::imwrite("edgy_clean.jpg", image_edgy);
+		// cv::imshow("edge",image_edgy);
+		cv::imwrite("edgy_threshold.jpg", image_edgy);
 
-    //		std::vector<cv::Vec2f> lines;
-    //		cv::HoughLines(m, lines, 1, CV_PI/180, 100, 0, 0 );
-    //		std::vector<cv::Vec2f>::iterator lineshape_it = lines.begin();
+		//		std::vector<cv::Vec2f> lines;
+		//		cv::HoughLines(m, lines, 1, CV_PI/180, 100, 0, 0 );
+		//		std::vector<cv::Vec2f>::iterator lineshape_it = lines.begin();
 
-    std::vector<cv::Vec4i> lines;
-    cv::HoughLinesP(image_edgy, lines, 1, CV_PI / (180 * 4), 50, 60, 30);
-    std::vector<cv::Vec4i>::iterator lineshape_it = lines.begin();
-    //
+		std::vector<cv::Vec4i> lines;
+		cv::HoughLinesP(image_edgy, lines, 1, CV_PI / (180 * 4), 50, 60, 30);
+		std::vector<cv::Vec4i>::iterator lineshape_it = lines.begin();
+		//
 
-    // delete p_image;
+		// delete p_image;
 
-    // cv::imshow("lines",image_edgy);
-    // cv::waitKey(2);
+		// cv::imshow("lines",image_edgy);
+		// cv::waitKey(2);
 
-    std::vector<myLine> myLines;
+		std::vector<myLine> myLines;
 
-    logger->log_info(name(), "%i Lines", lines.size());
-    for (; lineshape_it != lines.end(); lineshape_it++) {
+		logger->log_info(name(), "%i Lines", lines.size());
+		for (; lineshape_it != lines.end(); lineshape_it++) {
+			myLine line(search_area, search_area);
+			line.set(*lineshape_it, 5);
 
-      myLine line(search_area, search_area);
-      line.set(*lineshape_it, 5);
+			double angle_abs = sqrt(line.angle * line.angle); // abs(angle);
+			logger->log_info(name(), "Angle: %f %f", line.angle, angle_abs);
 
-      double angle_abs = sqrt(line.angle * line.angle); // abs(angle);
-      logger->log_info(name(), "Angle: %f %f", line.angle, angle_abs);
+			if (angle_abs > 70 && angle_abs < 110) {
+				// calculate positions of roi
+				// Bottem line should be 16 cm
+				// line height 6 cm
 
-      if (angle_abs > 70 && angle_abs < 110) {
-        // calculate positions of roi
-        // Bottem line should be 16 cm
-        // line height 6 cm
+				if (search_area.contains(line.lower_point.start.x, line.lower_point.start.y)
+				    && search_area.contains(line.upper_point.start.x, line.upper_point.start.y)) {
+					myLines.push_back(line);
+					printRoi(line.lower_point);
+					printRoi(line.upper_point);
 
-        if (search_area.contains(line.lower_point.start.x,
-                                 line.lower_point.start.y) &&
-            search_area.contains(line.upper_point.start.x,
-                                 line.upper_point.start.y)) {
-          myLines.push_back(line);
-          printRoi(line.lower_point);
-          printRoi(line.upper_point);
+					drawROIIntoBuffer(line.lower_point);
+					drawROIIntoBuffer(line.upper_point);
+					line.drawCV(image_colored, cv::Scalar(0, 0, 255));
+				} else {
+					line.drawCV(image_colored, cv::Scalar(255, 0, 255));
+				}
+			} else {
+				line.drawCV(image_colored, cv::Scalar(0, 255, 255));
+			}
 
-          drawROIIntoBuffer(line.lower_point);
-          drawROIIntoBuffer(line.upper_point);
-          line.drawCV(image_colored, cv::Scalar(0, 0, 255));
-        } else {
-          line.drawCV(image_colored, cv::Scalar(255, 0, 255));
-        }
-      } else {
-        line.drawCV(image_colored, cv::Scalar(0, 255, 255));
-      }
+			// logger->log_info(name(), "rois in buffer");
+		}
 
-      // logger->log_info(name(), "rois in buffer");
-    }
+		logger->log_info(name(), "%i Lines", myLines.size());
 
-    logger->log_info(name(), "%i Lines", myLines.size());
+		if (myLines.size() == 2) {
+			myLine bottem(myLines[0].lower_point, myLines[1].lower_point);
+			bottem.drawCV(image_colored, cv::Scalar(0, 255, 0));
 
-    if (myLines.size() == 2) {
-      myLine bottem(myLines[0].lower_point, myLines[1].lower_point);
-      bottem.drawCV(image_colored, cv::Scalar(0, 255, 0));
+			myLine top(myLines[0].upper_point, myLines[1].upper_point);
+			top.drawCV(image_colored, cv::Scalar(0, 255, 0));
 
-      myLine top(myLines[0].upper_point, myLines[1].upper_point);
-      top.drawCV(image_colored, cv::Scalar(0, 255, 0));
+			myLine diag1(myLines[0].upper_point, myLines[1].lower_point);
+			diag1.drawCV(image_colored, cv::Scalar(0, 255, 0));
 
-      myLine diag1(myLines[0].upper_point, myLines[1].lower_point);
-      diag1.drawCV(image_colored, cv::Scalar(0, 255, 0));
+			myLine diag2(myLines[0].lower_point, myLines[1].upper_point);
+			diag2.drawCV(image_colored, cv::Scalar(0, 255, 0));
 
-      myLine diag2(myLines[0].lower_point, myLines[1].upper_point);
-      diag2.drawCV(image_colored, cv::Scalar(0, 255, 0));
+			firevision::ROI center = getCenterRoi(bottem.lower_point, bottem.upper_point);
+			cv::circle(image_colored,
+			           cv::Point(center.start.x - 1, center.start.y - 1),
+			           3,
+			           cv::Scalar(255, 0, 0),
+			           1);
 
-      firevision::ROI center =
-          getCenterRoi(bottem.lower_point, bottem.upper_point);
-      cv::circle(image_colored,
-                 cv::Point(center.start.x - 1, center.start.y - 1), 3,
-                 cv::Scalar(255, 0, 0), 1);
+			schnittpunkt(diag1, diag2, center);
 
-      schnittpunkt(diag1, diag2, center);
+			center.color = firevision::C_BLUE;
+			drawROIIntoBuffer(center);
+		}
 
-      center.color = firevision::C_BLUE;
-      drawROIIntoBuffer(center);
-    }
+		cv::imwrite("edgy_lines.jpg", image_colored);
+		drawROIIntoBuffer(search_area);
 
-    cv::imwrite("edgy_lines.jpg", image_colored);
-    drawROIIntoBuffer(search_area);
+		//		firevision::grayscale(cspaceFrom_,
+		//					cam_->buffer(),
+		//					buffer_gray_,
+		//					camera_info_.img_width_,
+		//					camera_info_.img_height_);
 
-    //		firevision::grayscale(cspaceFrom_,
-    //					cam_->buffer(),
-    //					buffer_gray_,
-    //					camera_info_.img_width_,
-    //					camera_info_.img_height_);
+		//		firevision::FilterSobel edge_filter;
+		//		edge_filter.set_src_buffer(buffer_gray_, &search_area,
+		// firevision::ORI_HORIZONTAL);
+		// edge_filter.set_dst_buffer(buffer_gray_edgy_, &search_area);
+		// edge_filter.apply();
 
-    //		firevision::FilterSobel edge_filter;
-    //		edge_filter.set_src_buffer(buffer_gray_, &search_area,
-    // firevision::ORI_HORIZONTAL);
-    // edge_filter.set_dst_buffer(buffer_gray_edgy_, &search_area);
-    // edge_filter.apply();
+		//		firevision::convert(firevision::GRAY8,
+		//							cspaceTo_,
+		//							buffer_gray_edgy_,
+		//							buffer_color_,
+		//							camera_info_.img_width_,
+		//							camera_info_.img_height_);
 
-    //		firevision::convert(firevision::GRAY8,
-    //							cspaceTo_,
-    //							buffer_gray_edgy_,
-    //							buffer_color_,
-    //							camera_info_.img_width_,
-    //							camera_info_.img_height_);
+		//		firevision::RhtLinesModel model;
+		//		int nrFirevision = model.parseImage(buffer_gray_, &search_area);
+		//		logger->log_info(name(),"found lines: %i %i", nrFirevision,
+		// model.getShapeCount());
 
-    //		firevision::RhtLinesModel model;
-    //		int nrFirevision = model.parseImage(buffer_gray_, &search_area);
-    //		logger->log_info(name(),"found lines: %i %i", nrFirevision,
-    // model.getShapeCount());
+		//		std::vector<firevision::LineShape>* lineshapes =
+		// model.getShapes();
 
-    //		std::vector<firevision::LineShape>* lineshapes =
-    // model.getShapes();
-
-    //		std::vector<firevision::ROI> rois;
-    //		for(std::vector<firevision::LineShape>::iterator lineshape_it =
-    // lineshapes->begin(); 				lineshape_it !=
-    // lineshapes->end(); lineshape_it++)
-    //		{
-    //			int w = 10;
-    //			int h = 10;
-    //
-    //			firevision::ROI r1(search_area);
-    //			r1.height = h;
-    //			r1.width = w;
-    //
-    //			firevision::ROI r2(search_area);
-    //			r2.height = h;
-    //			r2.width = w;
-    //			(*lineshape_it).calcPoints();
-    //			int points[4];
-    //			(*lineshape_it).getPoints(&points[0], &points[1],
-    //&points[2], &points[3]); 			r1.start.x = (unsigned int)
-    // points[0]; 			r1.start.y = (unsigned int) points[1];
-    // r2.start.x = (unsigned int) points[2]; 			r2.start.y =
-    //(unsigned int) points[3];
-    //
-    //			r1.color = firevision::C_BLUE;
-    //			r2.color = firevision::C_RED;
-    //
-    //			printRoi(r1);
-    //			printRoi(r2);
-    //
-    //			drawROIIntoBuffer(r1);
-    //			drawROIIntoBuffer(r2);
-    //
-    //			logger->log_info(name(), "rois in buffer");
-    //		}
-  }
-  cfg_mutex_.unlock();
+		//		std::vector<firevision::ROI> rois;
+		//		for(std::vector<firevision::LineShape>::iterator lineshape_it =
+		// lineshapes->begin(); 				lineshape_it !=
+		// lineshapes->end(); lineshape_it++)
+		//		{
+		//			int w = 10;
+		//			int h = 10;
+		//
+		//			firevision::ROI r1(search_area);
+		//			r1.height = h;
+		//			r1.width = w;
+		//
+		//			firevision::ROI r2(search_area);
+		//			r2.height = h;
+		//			r2.width = w;
+		//			(*lineshape_it).calcPoints();
+		//			int points[4];
+		//			(*lineshape_it).getPoints(&points[0], &points[1],
+		//&points[2], &points[3]); 			r1.start.x = (unsigned int)
+		// points[0]; 			r1.start.y = (unsigned int) points[1];
+		// r2.start.x = (unsigned int) points[2]; 			r2.start.y =
+		//(unsigned int) points[3];
+		//
+		//			r1.color = firevision::C_BLUE;
+		//			r2.color = firevision::C_RED;
+		//
+		//			printRoi(r1);
+		//			printRoi(r2);
+		//
+		//			drawROIIntoBuffer(r1);
+		//			drawROIIntoBuffer(r2);
+		//
+		//			logger->log_info(name(), "rois in buffer");
+		//		}
+	}
+	cfg_mutex_.unlock();
 }
 
-void VisualPositionThread::sortPucks(std::vector<puck> *pucks) {
-  // Sort pucks
-  std::sort(
-      pucks->begin(), pucks->end(),
-      [](const puck a, const puck &b) -> bool { return a.pol.r < b.pol.r; });
+void
+VisualPositionThread::sortPucks(std::vector<puck> *pucks)
+{
+	// Sort pucks
+	std::sort(pucks->begin(), pucks->end(), [](const puck a, const puck &b) -> bool {
+		return a.pol.r < b.pol.r;
+	});
 }
 
-void VisualPositionThread::calculatePuckPositions(
-    std::vector<puck> *pucks, std::list<firevision::ROI> pucks_in_view) {
-  for (std::list<firevision::ROI>::iterator it = pucks_in_view.begin();
-       it != pucks_in_view.end(); it++) {
-    puck p;
-    getPuckPosition(&p, (*it));
-    pucks->push_back(p);
-  }
+void
+VisualPositionThread::calculatePuckPositions(std::vector<puck> *        pucks,
+                                             std::list<firevision::ROI> pucks_in_view)
+{
+	for (std::list<firevision::ROI>::iterator it = pucks_in_view.begin(); it != pucks_in_view.end();
+	     it++) {
+		puck p;
+		getPuckPosition(&p, (*it));
+		pucks->push_back(p);
+	}
 }
 
-void VisualPositionThread::printRoi(firevision::ROI roi) {
-  if (cfg_debugMessagesActivated_) {
-    logger->log_debug(name(),
-                      "x: %i y: %i width: %i height: %i color: %i image_hight: "
-                      "%i image_width: %i",
-                      roi.start.x, roi.start.y, roi.width, roi.height,
-                      roi.color, roi.image_height, roi.image_width);
-  }
+void
+VisualPositionThread::printRoi(firevision::ROI roi)
+{
+	if (cfg_debugMessagesActivated_) {
+		logger->log_debug(name(),
+		                  "x: %i y: %i width: %i height: %i color: %i image_hight: "
+		                  "%i image_width: %i",
+		                  roi.start.x,
+		                  roi.start.y,
+		                  roi.width,
+		                  roi.height,
+		                  roi.color,
+		                  roi.image_height,
+		                  roi.image_width);
+	}
 }
 
-std::list<firevision::ROI> *splitROI(firevision::ROI bigroi,
-                                     firevision::ROI cut) {
-  std::list<firevision::ROI> *rois = new std::list<firevision::ROI>();
+std::list<firevision::ROI> *
+splitROI(firevision::ROI bigroi, firevision::ROI cut)
+{
+	std::list<firevision::ROI> *rois = new std::list<firevision::ROI>();
 
-  //	unsigned int center_x = cut.start.x+cut.width/2;
-  //	unsigned int center_y = cut.start.y+cut.height/2;
-  //	if(bigroi.contains(center_x, center_y)){
-  //		if( (bigroi.width - cut.width) > 50){ //check if roi width makes
-  // sense to cut
-  //
-  //			firevision::ROI roi(bigroi);
-  //			int posx = bigroi.start.x - cut.start.x;
-  //			if( posx > 0 ){ //cut left from roi
-  //				//change width
-  //			}
-  //			else{
-  //				//change width and start
-  //
-  //			}
-  //		}
-  //	}
+	//	unsigned int center_x = cut.start.x+cut.width/2;
+	//	unsigned int center_y = cut.start.y+cut.height/2;
+	//	if(bigroi.contains(center_x, center_y)){
+	//		if( (bigroi.width - cut.width) > 50){ //check if roi width makes
+	// sense to cut
+	//
+	//			firevision::ROI roi(bigroi);
+	//			int posx = bigroi.start.x - cut.start.x;
+	//			if( posx > 0 ){ //cut left from roi
+	//				//change width
+	//			}
+	//			else{
+	//				//change width and start
+	//
+	//			}
+	//		}
+	//	}
 
-  return rois;
+	return rois;
 }
 
-void VisualPositionThread::fitROI(firevision::ROI &roi, int x, int y, int w,
-                                  int h) {
-  // Check x position in in image range
-  if (cfg_debugMessagesActivated_) {
-    logger->log_debug(name(), "Fit puck %i %i %i %i", x, y, w, h);
-    printRoi(roi);
-  }
+void
+VisualPositionThread::fitROI(firevision::ROI &roi, int x, int y, int w, int h)
+{
+	// Check x position in in image range
+	if (cfg_debugMessagesActivated_) {
+		logger->log_debug(name(), "Fit puck %i %i %i %i", x, y, w, h);
+		printRoi(roi);
+	}
 
-  firevision::ROI old(roi);
+	firevision::ROI old(roi);
 
-  roi.start.x = std::max(0, (std::min((int)roi.image_width, x)));
-  roi.start.y = std::max(0, (std::min((int)roi.image_height, y)));
+	roi.start.x = std::max(0, (std::min((int)roi.image_width, x)));
+	roi.start.y = std::max(0, (std::min((int)roi.image_height, y)));
 
-  roi.width = std::max(0, (std::min((int)roi.image_width, w)));
-  roi.height = std::max(0, (std::min((int)roi.image_height, h)));
+	roi.width  = std::max(0, (std::min((int)roi.image_width, w)));
+	roi.height = std::max(0, (std::min((int)roi.image_height, h)));
 
-  if (roi.start.x + roi.width > roi.image_width) {
-    roi.width = roi.image_width - roi.start.x;
-  }
+	if (roi.start.x + roi.width > roi.image_width) {
+		roi.width = roi.image_width - roi.start.x;
+	}
 
-  if (roi.start.y + roi.height > roi.image_height) {
-    roi.height = roi.image_height - roi.start.y;
-  }
+	if (roi.start.y + roi.height > roi.image_height) {
+		roi.height = roi.image_height - roi.start.y;
+	}
 
-  if (roi.start.y + roi.height > roi.image_height ||
-      roi.start.x + roi.width > roi.image_width) {
-    logger->log_error(
-        name(),
-        "Failed fitRoi(x: %i y: %i w: %i h: %i) with roi: x: %i y:%i width: %i "
-        "height: %i , image_width: %i image_height: %i",
-        x, y, w, h, old.start.x, old.start.y, old.width, old.height,
-        old.image_width, old.image_height);
-    logger->log_error(name(),
-                      "Results Roi: x: %i y:%i width: %i height: %i , "
-                      "image_width: %i image_height: %i",
-                      roi.start.x, roi.start.y, roi.width, roi.height,
-                      roi.image_width, roi.image_height);
-  } else if (cfg_debugMessagesActivated_) {
-    printRoi(roi);
-  }
+	if (roi.start.y + roi.height > roi.image_height || roi.start.x + roi.width > roi.image_width) {
+		logger->log_error(name(),
+		                  "Failed fitRoi(x: %i y: %i w: %i h: %i) with roi: x: %i y:%i width: %i "
+		                  "height: %i , image_width: %i image_height: %i",
+		                  x,
+		                  y,
+		                  w,
+		                  h,
+		                  old.start.x,
+		                  old.start.y,
+		                  old.width,
+		                  old.height,
+		                  old.image_width,
+		                  old.image_height);
+		logger->log_error(name(),
+		                  "Results Roi: x: %i y:%i width: %i height: %i , "
+		                  "image_width: %i image_height: %i",
+		                  roi.start.x,
+		                  roi.start.y,
+		                  roi.width,
+		                  roi.height,
+		                  roi.image_width,
+		                  roi.image_height);
+	} else if (cfg_debugMessagesActivated_) {
+		printRoi(roi);
+	}
 }
 
 firevision::ROI *
 VisualPositionThread::getRoiContainingRoi(std::list<firevision::ROI> *roiList,
-                                          firevision::ROI containing) {
-  for (std::list<firevision::ROI>::iterator it = roiList->begin();
-       it != roiList->end(); ++it) {
-    if ((*it).contains(containing.start.x + containing.width / 2,
-                       +containing.start.y + containing.height / 2)) {
-      return new firevision::ROI(*it);
-    }
-  }
-  return NULL; // getBiggestRoi(roiList);
+                                          firevision::ROI             containing)
+{
+	for (std::list<firevision::ROI>::iterator it = roiList->begin(); it != roiList->end(); ++it) {
+		if ((*it).contains(containing.start.x + containing.width / 2,
+		                   +containing.start.y + containing.height / 2)) {
+			return new firevision::ROI(*it);
+		}
+	}
+	return NULL; // getBiggestRoi(roiList);
 }
 
 firevision::ROI *
-VisualPositionThread::getBiggestRoi(std::list<firevision::ROI> *roiList) {
-  firevision::ROI *biggestRoi = NULL;
+VisualPositionThread::getBiggestRoi(std::list<firevision::ROI> *roiList)
+{
+	firevision::ROI *biggestRoi = NULL;
 
-  for (std::list<firevision::ROI>::iterator it = roiList->begin();
-       it != roiList->end(); ++it) {
-    if (biggestRoi == NULL ||
-        biggestRoi->width * biggestRoi->height < (*it).width * (*it).height) {
-      biggestRoi = &(*it);
-    }
-  }
-  if (biggestRoi != NULL) {
-    return new firevision::ROI(biggestRoi);
-  }
-  return NULL;
+	for (std::list<firevision::ROI>::iterator it = roiList->begin(); it != roiList->end(); ++it) {
+		if (biggestRoi == NULL || biggestRoi->width * biggestRoi->height < (*it).width * (*it).height) {
+			biggestRoi = &(*it);
+		}
+	}
+	if (biggestRoi != NULL) {
+		return new firevision::ROI(biggestRoi);
+	}
+	return NULL;
 }
 
-VisualPositionThread::~VisualPositionThread() {
-  // TODO Auto-generated destructor stub
+VisualPositionThread::~VisualPositionThread()
+{
+	// TODO Auto-generated destructor stub
 }
 
-void VisualPositionThread::cartToPol(fawkes::polar_coord_2d_t &pol, float x,
-                                     float y) {
-  pol.phi = atan2f(y, x);
-  pol.r = sqrtf(x * x + y * y);
+void
+VisualPositionThread::cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y)
+{
+	pol.phi = atan2f(y, x);
+	pol.r   = sqrtf(x * x + y * y);
 
-  if (cfg_debugMessagesActivated_) {
-    logger->log_debug(name(), "x: %f; y: %f", x, y);
-    logger->log_debug(name(), "Calculated r: %f; phi: %f", pol.r, pol.phi);
-  }
+	if (cfg_debugMessagesActivated_) {
+		logger->log_debug(name(), "x: %f; y: %f", x, y);
+		logger->log_debug(name(), "Calculated r: %f; phi: %f", pol.r, pol.phi);
+	}
 }
 
-void VisualPositionThread::polToCart(float &x, float &y,
-                                     fawkes::polar_coord_2d_t pol) {
-  x = pol.r * std::cos(pol.phi);
-  y = pol.r * std::sin(pol.phi);
+void
+VisualPositionThread::polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol)
+{
+	x = pol.r * std::cos(pol.phi);
+	y = pol.r * std::sin(pol.phi);
 }
 
-void VisualPositionThread::drawROIIntoBuffer(
-    firevision::ROI roi,
-    firevision::FilterROIDraw::border_style_t borderStyle) {
-  try {
-    if (cfg_paintROIsActivated_) {
-      drawer_->set_src_buffer(
-          buffer_color_,
-          firevision::ROI::full_image(camera_info_.img_width_,
-                                      camera_info_.img_height_),
-          0);
-      drawer_->set_dst_buffer(buffer_color_, &roi);
-      drawer_->set_style(borderStyle);
-      drawer_->apply();
-      if (cfg_debugMessagesActivated_) {
-        logger->log_debug(name(), "drawed element in buffer");
-      }
-    }
-  } catch (fawkes::Exception &e) {
-    logger->log_error(name(), e);
-  }
+void
+VisualPositionThread::drawROIIntoBuffer(firevision::ROI                           roi,
+                                        firevision::FilterROIDraw::border_style_t borderStyle)
+{
+	try {
+		if (cfg_paintROIsActivated_) {
+			drawer_->set_src_buffer(buffer_color_,
+			                        firevision::ROI::full_image(camera_info_.img_width_,
+			                                                    camera_info_.img_height_),
+			                        0);
+			drawer_->set_dst_buffer(buffer_color_, &roi);
+			drawer_->set_style(borderStyle);
+			drawer_->apply();
+			if (cfg_debugMessagesActivated_) {
+				logger->log_debug(name(), "drawed element in buffer");
+			}
+		}
+	} catch (fawkes::Exception &e) {
+		logger->log_error(name(), e);
+	}
 }
 
 std::list<firevision::ROI> *
-VisualPositionThread::classifyInRoi(firevision::ROI searchArea,
-                                    color_classifier_context_t_ *color_data) {
-  try {
-    color_data->scanline_grid->reset();
-    color_data->scanline_grid->set_roi(&searchArea);
-    color_data->classifier->set_src_buffer(
-        buffer_color_, camera_info_.img_width_, camera_info_.img_height_);
+VisualPositionThread::classifyInRoi(firevision::ROI              searchArea,
+                                    color_classifier_context_t_ *color_data)
+{
+	try {
+		color_data->scanline_grid->reset();
+		color_data->scanline_grid->set_roi(&searchArea);
+		color_data->classifier->set_src_buffer(buffer_color_,
+		                                       camera_info_.img_width_,
+		                                       camera_info_.img_height_);
 
-    std::list<firevision::ROI> *ROIs = color_data->classifier->classify();
+		std::list<firevision::ROI> *ROIs = color_data->classifier->classify();
 
-    return ROIs;
-  } catch (fawkes::Exception &e) {
-    logger->log_error(name(), e);
-  }
-  return new std::list<firevision::ROI>; // return a empty list if a exception
-                                         // is thrown
+		return ROIs;
+	} catch (fawkes::Exception &e) {
+		logger->log_error(name(), e);
+	}
+	return new std::list<firevision::ROI>; // return a empty list if a exception
+	                                       // is thrown
 }
 
-float VisualPositionThread::getX(firevision::ROI *roi) {
-  // Distance X
-  int roiPositionY =
-      camera_info_.img_height_ - (roi->start.y + roi->height / 2);
-  float angle = ((float)roiPositionY * camera_info_.opening_angle_vertical_) /
-                (float)camera_info_.img_height_;
-  float distance_x = camera_info_.position_z_ *
-                     (tan(angle + camera_info_.angle_horizontal_to_opening_) -
-                      tan(camera_info_.angle_horizontal_to_opening_));
+float
+VisualPositionThread::getX(firevision::ROI *roi)
+{
+	// Distance X
+	int   roiPositionY = camera_info_.img_height_ - (roi->start.y + roi->height / 2);
+	float angle =
+	  ((float)roiPositionY * camera_info_.opening_angle_vertical_) / (float)camera_info_.img_height_;
+	float distance_x = camera_info_.position_z_
+	                   * (tan(angle + camera_info_.angle_horizontal_to_opening_)
+	                      - tan(camera_info_.angle_horizontal_to_opening_));
 
-  // logger->log_debug(name(),"angle: %f, image_size x: %i y: %i,roi x: %i y:
-  // %i", (angle*180) / M_PI, img_width_, img_height_, roi->start.x,
-  // roi->start.y);
+	// logger->log_debug(name(),"angle: %f, image_size x: %i y: %i,roi x: %i y:
+	// %i", (angle*180) / M_PI, img_width_, img_height_, roi->start.x,
+	// roi->start.y);
 
-  return distance_x + camera_info_.offset_cam_x_to_groundplane_ +
-         camera_info_.position_x_;
+	return distance_x + camera_info_.offset_cam_x_to_groundplane_ + camera_info_.position_x_;
 }
 
-float VisualPositionThread::getY(firevision::ROI *roi) {
-  // Left-Right
-  int roiPositionX = (roi->start.x + roi->width / 2);
-  float alpha = ((((float)camera_info_.img_width_ / 2) - (float)roiPositionX) /
-                 ((float)camera_info_.img_width_ / 2)) *
-                (camera_info_.opening_angle_horizontal_ / 2);
-  float x = getX(roi);
-  float position_y_in_m = sin(alpha * x);
+float
+VisualPositionThread::getY(firevision::ROI *roi)
+{
+	// Left-Right
+	int   roiPositionX = (roi->start.x + roi->width / 2);
+	float alpha        = ((((float)camera_info_.img_width_ / 2) - (float)roiPositionX)
+                 / ((float)camera_info_.img_width_ / 2))
+	              * (camera_info_.opening_angle_horizontal_ / 2);
+	float x               = getX(roi);
+	float position_y_in_m = sin(alpha * x);
 
-  // logger->log_debug(name(),"angle: %f, roi pos X: %i, distance y: %f, cfg
-  // %f", alpha, roiPositionX, position_y_in_m,
-  // cfg_camera_opening_angle_horizontal_);
+	// logger->log_debug(name(),"angle: %f, roi pos X: %i, distance y: %f, cfg
+	// %f", alpha, roiPositionX, position_y_in_m,
+	// cfg_camera_opening_angle_horizontal_);
 
-  return position_y_in_m;
+	return position_y_in_m;
 }
 
-void VisualPositionThread::getPuckPosition(puck *p, firevision::ROI roi) {
-  // Left-Right
-  int roiPositionX_L = (roi.start.x);
-  int roiPositionX_R = (roi.start.x + roi.width);
-  float alpha_L =
-      ((((float)camera_info_.img_width_ / 2) - (float)roiPositionX_L) /
-       ((float)camera_info_.img_width_ / 2)) *
-      (camera_info_.opening_angle_horizontal_ / 2);
-  float alpha_R =
-      ((((float)camera_info_.img_width_ / 2) - (float)roiPositionX_R) /
-       ((float)camera_info_.img_width_ / 2)) *
-      (camera_info_.opening_angle_horizontal_ / 2);
-  float x = getX(&roi);
-  float position_y_in_m_L = sin(alpha_L * x);
-  float position_y_in_m_R = sin(alpha_R * x);
+void
+VisualPositionThread::getPuckPosition(puck *p, firevision::ROI roi)
+{
+	// Left-Right
+	int   roiPositionX_L = (roi.start.x);
+	int   roiPositionX_R = (roi.start.x + roi.width);
+	float alpha_L        = ((((float)camera_info_.img_width_ / 2) - (float)roiPositionX_L)
+                   / ((float)camera_info_.img_width_ / 2))
+	                * (camera_info_.opening_angle_horizontal_ / 2);
+	float alpha_R = ((((float)camera_info_.img_width_ / 2) - (float)roiPositionX_R)
+	                 / ((float)camera_info_.img_width_ / 2))
+	                * (camera_info_.opening_angle_horizontal_ / 2);
+	float x                 = getX(&roi);
+	float position_y_in_m_L = sin(alpha_L * x);
+	float position_y_in_m_R = sin(alpha_R * x);
 
-  p->roi = roi;
-  p->cart.x = getX(&roi);
-  p->cart.y = getY(&roi);
-  p->cart.z = 0;
-  cartToPol(p->pol, p->cart.x, p->cart.y);
-  p->visibiity_history = 1;
-  p->radius = position_y_in_m_L - position_y_in_m_R;
+	p->roi    = roi;
+	p->cart.x = getX(&roi);
+	p->cart.y = getY(&roi);
+	p->cart.z = 0;
+	cartToPol(p->pol, p->cart.x, p->cart.y);
+	p->visibiity_history = 1;
+	p->radius            = position_y_in_m_L - position_y_in_m_R;
 
-  if (cfg_debugMessagesActivated_) {
-    logger->log_info(name(), "puck: r: %f pol: phi %f, r%f", p->radius,
-                     p->pol.phi, p->pol.r);
-  }
+	if (cfg_debugMessagesActivated_) {
+		logger->log_info(name(), "puck: r: %f pol: phi %f, r%f", p->radius, p->pol.phi, p->pol.r);
+	}
 }
 
-void VisualPositionThread::updatePos3dInferface(
-    fawkes::Position3DInterface *interface, puck *p) {
-  interface->set_translation(0, p->cart.x);
-  interface->set_translation(1, p->cart.y);
-  interface->set_translation(2, p->cart.z);
-  interface->set_rotation(0, p->pol.phi);
-  interface->set_rotation(1, p->pol.r);
-  interface->set_visibility_history(p->visibiity_history);
+void
+VisualPositionThread::updatePos3dInferface(fawkes::Position3DInterface *interface, puck *p)
+{
+	interface->set_translation(0, p->cart.x);
+	interface->set_translation(1, p->cart.y);
+	interface->set_translation(2, p->cart.z);
+	interface->set_rotation(0, p->pol.phi);
+	interface->set_rotation(1, p->pol.r);
+	interface->set_visibility_history(p->visibiity_history);
 }
 
-void VisualPositionThread::updateInterface(std::vector<puck> *pucks) {
-  /* Create missing interfaces */
-  if (pucks->size() > puck_interfaces_.size()) {
-    unsigned int nr_missing_interfaces =
-        pucks->size() - puck_interfaces_.size();
-    for (unsigned int i = 0; i < nr_missing_interfaces; ++i) {
-      createPuckInterface();
-    }
-  }
+void
+VisualPositionThread::updateInterface(std::vector<puck> *pucks)
+{
+	/* Create missing interfaces */
+	if (pucks->size() > puck_interfaces_.size()) {
+		unsigned int nr_missing_interfaces = pucks->size() - puck_interfaces_.size();
+		for (unsigned int i = 0; i < nr_missing_interfaces; ++i) {
+			createPuckInterface();
+		}
+	}
 
-  if (cfg_debugMessagesActivated_) {
-    logger->log_info(name(), "Detected pucks in view:  %i", pucks->size());
-  }
+	if (cfg_debugMessagesActivated_) {
+		logger->log_info(name(), "Detected pucks in view:  %i", pucks->size());
+	}
 
-  std::vector<fawkes::Position3DInterface *>::iterator interface_it =
-      puck_interfaces_.begin();
-  std::vector<puck>::iterator puck_it = pucks->begin();
-  for (; interface_it != puck_interfaces_.end(); ++interface_it) {
-    fawkes::Position3DInterface *interface = (*interface_it);
-    if (puck_it != pucks->end()) {
-      updatePos3dInferface(interface, &(*puck_it));
-      interface->write();
-      ++puck_it;
-    } else {
-      updatePos3dInferface(interface, no_pucK_);
-      interface->write();
-    }
-  }
+	std::vector<fawkes::Position3DInterface *>::iterator interface_it = puck_interfaces_.begin();
+	std::vector<puck>::iterator                          puck_it      = pucks->begin();
+	for (; interface_it != puck_interfaces_.end(); ++interface_it) {
+		fawkes::Position3DInterface *interface = (*interface_it);
+		if (puck_it != pucks->end()) {
+			updatePos3dInferface(interface, &(*puck_it));
+			interface->write();
+			++puck_it;
+		} else {
+			updatePos3dInferface(interface, no_pucK_);
+			interface->write();
+		}
+	}
 }
 
 void VisualPositionThread::finalize() // TODO check if everthing gets deleted
 {
-  logger->log_debug(name(), "finalize starts");
+	logger->log_debug(name(), "finalize starts");
 
-  vision_master->unregister_thread(this);
-  delete shm_buffer_color_;
-  config->rem_change_handler(this);
-  delete cam_;
-  cam_ = NULL;
+	vision_master->unregister_thread(this);
+	delete shm_buffer_color_;
+	config->rem_change_handler(this);
+	delete cam_;
+	cam_ = NULL;
 
-  fawkes::Position3DInterface *interface;
-  while (!puck_interfaces_.empty()) {
-    interface = puck_interfaces_.back();
-    blackboard->close(interface);
-    puck_interfaces_.pop_back();
-  }
+	fawkes::Position3DInterface *interface;
+	while (!puck_interfaces_.empty()) {
+		interface = puck_interfaces_.back();
+		blackboard->close(interface);
+		puck_interfaces_.pop_back();
+	}
 
-  deleteClassifier(&puck_info_.main);
-  deleteClassifier(&puck_info_.top_dots);
+	deleteClassifier(&puck_info_.main);
+	deleteClassifier(&puck_info_.top_dots);
 
-  logger->log_info(name(), "finalize ends");
+	logger->log_info(name(), "finalize ends");
 }
 
-double center(double e1, double e2) {
-  double delta = e2 - e1;
-  return e1 + delta / 2;
+double
+center(double e1, double e2)
+{
+	double delta = e2 - e1;
+	return e1 + delta / 2;
 }
 
-firevision::ROI VisualPositionThread::getCenterRoi(firevision::ROI p1,
-                                                   firevision::ROI p2) {
+firevision::ROI
+VisualPositionThread::getCenterRoi(firevision::ROI p1, firevision::ROI p2)
+{
+	const char *frame_cam  = "/cam_front_puck";
+	const char *frame_base = "/base_link";
+	Point3d     stamped_p1;
+	stamped_p1[0]       = p1.start.x;
+	stamped_p1[1]       = p1.start.y;
+	stamped_p1[2]       = 0;
+	stamped_p1.frame_id = frame_cam;
+	stamped_p1          = apply_tf(frame_base, stamped_p1);
 
-  const char *frame_cam = "/cam_front_puck";
-  const char *frame_base = "/base_link";
-  Point3d stamped_p1;
-  stamped_p1[0] = p1.start.x;
-  stamped_p1[1] = p1.start.y;
-  stamped_p1[2] = 0;
-  stamped_p1.frame_id = frame_cam;
-  stamped_p1 = apply_tf(frame_base, stamped_p1);
+	Point3d stamped_p2;
+	stamped_p2[0]       = p2.start.x;
+	stamped_p2[1]       = p2.start.y;
+	stamped_p2[2]       = 0;
+	stamped_p2.frame_id = frame_cam;
 
-  Point3d stamped_p2;
-  stamped_p2[0] = p2.start.x;
-  stamped_p2[1] = p2.start.y;
-  stamped_p2[2] = 0;
-  stamped_p2.frame_id = frame_cam;
+	stamped_p2 = apply_tf(frame_base, stamped_p2);
 
-  stamped_p2 = apply_tf(frame_base, stamped_p2);
+	Point3d myCenter;
+	myCenter[0]       = center(stamped_p1[0], stamped_p2[0]);
+	myCenter[1]       = center(stamped_p1[1], stamped_p2[1]);
+	myCenter.frame_id = stamped_p2.frame_id;
 
-  Point3d myCenter;
-  myCenter[0] = center(stamped_p1[0], stamped_p2[0]);
-  myCenter[1] = center(stamped_p1[1], stamped_p2[1]);
-  myCenter.frame_id = stamped_p2.frame_id;
+	myCenter = apply_tf(frame_cam, myCenter);
 
-  myCenter = apply_tf(frame_cam, myCenter);
+	logger->log_info(name(), "x1: %f x2: %f cx:%f", stamped_p1[0], stamped_p2[0], myCenter[0]);
 
-  logger->log_info(name(), "x1: %f x2: %f cx:%f", stamped_p1[0], stamped_p2[0],
-                   myCenter[0]);
+	firevision::ROI center(p1);
+	center.height  = 2;
+	center.width   = 2;
+	center.start.x = myCenter[0];
+	center.start.y = myCenter[1];
 
-  firevision::ROI center(p1);
-  center.height = 2;
-  center.width = 2;
-  center.start.x = myCenter[0];
-  center.start.y = myCenter[1];
-
-  return center;
+	return center;
 };
 
 void VisualPositionThread::config_value_erased(const char *path){};
 void VisualPositionThread::config_tag_changed(const char *new_tag){};
-void VisualPositionThread::config_comment_changed(
-    const fawkes::Configuration::ValueIterator *v){};
-void VisualPositionThread::config_value_changed(
-    const fawkes::Configuration::ValueIterator *v) {
-
-  if (cfg_mutex_.try_lock()) {
-    try {
-      loadConfig();
-      init_with_config();
-    } catch (fawkes::Exception &e) {
-      logger->log_error(name(), e);
-    }
-  }
-  // gets called for every changed entry... so init is called once per change.
-  cfg_mutex_.unlock();
+void VisualPositionThread::config_comment_changed(const fawkes::Configuration::ValueIterator *v){};
+void
+VisualPositionThread::config_value_changed(const fawkes::Configuration::ValueIterator *v)
+{
+	if (cfg_mutex_.try_lock()) {
+		try {
+			loadConfig();
+			init_with_config();
+		} catch (fawkes::Exception &e) {
+			logger->log_error(name(), e);
+		}
+	}
+	// gets called for every changed entry... so init is called once per change.
+	cfg_mutex_.unlock();
 }
 
-Point3d VisualPositionThread::apply_tf(const char *target_frame, Point3d src) {
+Point3d
+VisualPositionThread::apply_tf(const char *target_frame, Point3d src)
+{
+	Point3d targetPoint;
+	targetPoint.frame_id     = target_frame;
+	const char *source_frame = src.frame_id.c_str();
 
-  Point3d targetPoint;
-  targetPoint.frame_id = target_frame;
-  const char *source_frame = src.frame_id.c_str();
+	bool link_frame_exists  = tf_listener->frame_exists(target_frame);
+	bool laser_frame_exists = tf_listener->frame_exists(source_frame);
 
-  bool link_frame_exists = tf_listener->frame_exists(target_frame);
-  bool laser_frame_exists = tf_listener->frame_exists(source_frame);
-
-  if (!link_frame_exists || !laser_frame_exists) {
-    logger->log_warn(name(), "Frame missing: %s %s   %s %s", source_frame,
-                     link_frame_exists ? "exists" : "missing", target_frame,
-                     laser_frame_exists ? "exists" : "missing");
-  } else {
-    try {
-      tf_listener->transform_point(target_frame, src, targetPoint);
-    } catch (fawkes::tf::ExtrapolationException &e) {
-      logger->log_debug(name(), "Extrapolation error: %s", e.what());
-      return src;
-    } catch (fawkes::tf::ConnectivityException &e) {
-      logger->log_debug(name(), "Connectivity exception: %s", e.what());
-      return src;
-    } catch (fawkes::Exception &e) {
-      logger->log_debug(name(), "Fawkes exception: %s", e.what());
-      return src;
-    } catch (std::exception &e) {
-      logger->log_debug(name(), "Generic exception: %s", e.what());
-      return src;
-    }
-    return targetPoint;
-  }
-  return src;
+	if (!link_frame_exists || !laser_frame_exists) {
+		logger->log_warn(name(),
+		                 "Frame missing: %s %s   %s %s",
+		                 source_frame,
+		                 link_frame_exists ? "exists" : "missing",
+		                 target_frame,
+		                 laser_frame_exists ? "exists" : "missing");
+	} else {
+		try {
+			tf_listener->transform_point(target_frame, src, targetPoint);
+		} catch (fawkes::tf::ExtrapolationException &e) {
+			logger->log_debug(name(), "Extrapolation error: %s", e.what());
+			return src;
+		} catch (fawkes::tf::ConnectivityException &e) {
+			logger->log_debug(name(), "Connectivity exception: %s", e.what());
+			return src;
+		} catch (fawkes::Exception &e) {
+			logger->log_debug(name(), "Fawkes exception: %s", e.what());
+			return src;
+		} catch (std::exception &e) {
+			logger->log_debug(name(), "Generic exception: %s", e.what());
+			return src;
+		}
+		return targetPoint;
+	}
+	return src;
 }

--- a/src/plugins/attic/visual_position/visual_position_thread.h
+++ b/src/plugins/attic/visual_position/visual_position_thread.h
@@ -16,24 +16,24 @@
 
 #define CFG_PREFIX "/plugins/visual_position/"
 
-#include <core/threading/mutex.h>
-#include <core/threading/thread.h>
-
 #include <aspect/blackboard.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <aspect/tf.h>
 #include <aspect/vision.h>
+#include <core/threading/mutex.h>
+#include <core/threading/thread.h>
 
 //#include <interfaces/PuckVisionInterface.h>
-#include <interfaces/Position3DInterface.h>
-
 #include <fvcams/camera.h>
+#include <interfaces/Position3DInterface.h>
 //#include <fvcams/fileloader.h>
 #include "fvutils/adapters/iplimage.h"
 #include "opencv/cv.h"
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
+
+#include <config/change_handler.h>
 #include <fvclassifiers/simple.h>
 #include <fvfilters/roidraw.h>
 #include <fvfilters/sobel.h>
@@ -46,13 +46,10 @@
 #include <fvutils/base/roi.h>
 #include <fvutils/color/conversions.h>
 #include <fvutils/ipc/shm_image.h>
-
 #include <tf/exceptions.h>
 #include <tf/transformer.h>
 #include <tf/types.h>
 #include <tf/utils.h>
-
-#include <config/change_handler.h>
 
 #include <algorithm> // sort
 #include <list>
@@ -81,120 +78,144 @@ class TransformListener;
 
 typedef fawkes::tf::Stamped<fawkes::tf::Point> Point3d;
 
-struct camera_info {
-  std::string cfg_camera_;
-  float opening_angle_horizontal_;
-  float opening_angle_vertical_;
-  unsigned int img_width_;
-  unsigned int img_height_;
-  float position_x_;
-  float position_y_;
-  float position_z_;
-  float position_pitch_;
-  float offset_cam_x_to_groundplane_;
-  float angle_horizontal_to_opening_;
-  float visible_lenght_x_in_m_;
-  float visible_lenght_y_in_m_;
-  firevision::ROI fullimage;
+struct camera_info
+{
+	std::string     cfg_camera_;
+	float           opening_angle_horizontal_;
+	float           opening_angle_vertical_;
+	unsigned int    img_width_;
+	unsigned int    img_height_;
+	float           position_x_;
+	float           position_y_;
+	float           position_z_;
+	float           position_pitch_;
+	float           offset_cam_x_to_groundplane_;
+	float           angle_horizontal_to_opening_;
+	float           visible_lenght_x_in_m_;
+	float           visible_lenght_y_in_m_;
+	firevision::ROI fullimage;
 };
 
-typedef struct {
-  firevision::ColorModel *colormodel;
-  firevision::SimpleColorClassifier *classifier;
-  std::vector<firevision::ColorModelSimilarity::color_class_t *> color_classes;
-  firevision::ScanlineGrid *scanline_grid;
-  std::vector<unsigned int> cfg_ref_col;
-  int cfg_chroma_thresh;
-  int cfg_sat_thresh;
-  firevision::color_t color_expect;
-  unsigned int cfg_roi_min_points;
-  unsigned int cfg_roi_basic_size;
-  unsigned int cfg_roi_neighborhood_min_match;
-  unsigned int cfg_scangrid_x_offset;
-  unsigned int cfg_scangrid_y_offset;
+typedef struct
+{
+	firevision::ColorModel *                                       colormodel;
+	firevision::SimpleColorClassifier *                            classifier;
+	std::vector<firevision::ColorModelSimilarity::color_class_t *> color_classes;
+	firevision::ScanlineGrid *                                     scanline_grid;
+	std::vector<unsigned int>                                      cfg_ref_col;
+	int                                                            cfg_chroma_thresh;
+	int                                                            cfg_sat_thresh;
+	firevision::color_t                                            color_expect;
+	unsigned int                                                   cfg_roi_min_points;
+	unsigned int                                                   cfg_roi_basic_size;
+	unsigned int                                                   cfg_roi_neighborhood_min_match;
+	unsigned int                                                   cfg_scangrid_x_offset;
+	unsigned int                                                   cfg_scangrid_y_offset;
 } color_classifier_context_t_;
 
-struct puck_features {
-  float radius;
-  float height;
-  color_classifier_context_t_ main;
-  color_classifier_context_t_ top_dots;
-  // color holes;
-  // color top_center;
+struct puck_features
+{
+	float                       radius;
+	float                       height;
+	color_classifier_context_t_ main;
+	color_classifier_context_t_ top_dots;
+	// color holes;
+	// color top_center;
 };
 
-struct myLine {
-  firevision::ROI lower_point;
-  firevision::ROI upper_point;
-  double angle;
-  myLine(firevision::ROI p1, firevision::ROI p2, unsigned int size = 2) {
-    set(p1, p2, size);
-  }
-  myLine(cv::Vec4i vec4, unsigned int size = 2) { set(vec4, size); }
-  void set(firevision::ROI p1, firevision::ROI p2, unsigned int size = 2) {
-    if (p1.start.y > p2.start.y) {
-      lower_point = p1;
-      upper_point = p2;
-    } else {
-      lower_point = p2;
-      upper_point = p1;
-    }
-    calculateAngle();
-    setDefaultColors();
-    setSize(size, size);
-  }
-  void set(cv::Vec4i vec4, unsigned int size = 2) {
-    if (vec4.val[1] > vec4.val[3]) { // verify that the lower point is in p1
-      // val 1 is bigger... so it is the lower point
-      lower_point.start.x = vec4.val[0];
-      lower_point.start.y = vec4.val[1];
-      upper_point.start.x = vec4.val[2];
-      upper_point.start.y = vec4.val[3];
-    } else {
-      upper_point.start.x = vec4.val[0];
-      upper_point.start.y = vec4.val[1];
-      lower_point.start.x = vec4.val[2];
-      lower_point.start.y = vec4.val[3];
-    }
-    calculateAngle();
-    setDefaultColors();
-    setSize(size, size);
-  }
+struct myLine
+{
+	firevision::ROI lower_point;
+	firevision::ROI upper_point;
+	double          angle;
+	myLine(firevision::ROI p1, firevision::ROI p2, unsigned int size = 2)
+	{
+		set(p1, p2, size);
+	}
+	myLine(cv::Vec4i vec4, unsigned int size = 2)
+	{
+		set(vec4, size);
+	}
+	void
+	set(firevision::ROI p1, firevision::ROI p2, unsigned int size = 2)
+	{
+		if (p1.start.y > p2.start.y) {
+			lower_point = p1;
+			upper_point = p2;
+		} else {
+			lower_point = p2;
+			upper_point = p1;
+		}
+		calculateAngle();
+		setDefaultColors();
+		setSize(size, size);
+	}
+	void
+	set(cv::Vec4i vec4, unsigned int size = 2)
+	{
+		if (vec4.val[1] > vec4.val[3]) { // verify that the lower point is in p1
+			// val 1 is bigger... so it is the lower point
+			lower_point.start.x = vec4.val[0];
+			lower_point.start.y = vec4.val[1];
+			upper_point.start.x = vec4.val[2];
+			upper_point.start.y = vec4.val[3];
+		} else {
+			upper_point.start.x = vec4.val[0];
+			upper_point.start.y = vec4.val[1];
+			lower_point.start.x = vec4.val[2];
+			lower_point.start.y = vec4.val[3];
+		}
+		calculateAngle();
+		setDefaultColors();
+		setSize(size, size);
+	}
 
-  void setDefaultColors() { //
-    lower_point.color = firevision::C_BLUE;
-    upper_point.color = firevision::C_RED;
-  }
+	void
+	setDefaultColors()
+	{ //
+		lower_point.color = firevision::C_BLUE;
+		upper_point.color = firevision::C_RED;
+	}
 
-  void setSize(unsigned int h, unsigned int w) {
-    lower_point.width = w;
-    lower_point.height = h;
-    upper_point.width = w;
-    upper_point.height = h;
-  }
+	void
+	setSize(unsigned int h, unsigned int w)
+	{
+		lower_point.width  = w;
+		lower_point.height = h;
+		upper_point.width  = w;
+		upper_point.height = h;
+	}
 
-  double calculateAngle() {
-    int deltaX = lower_point.start.x - upper_point.start.x;
-    int deltaY = lower_point.start.y - upper_point.start.y;
-    angle = atan2(deltaY, deltaX) * 180 / M_PI;
-    return angle;
-  }
+	double
+	calculateAngle()
+	{
+		int deltaX = lower_point.start.x - upper_point.start.x;
+		int deltaY = lower_point.start.y - upper_point.start.y;
+		angle      = atan2(deltaY, deltaX) * 180 / M_PI;
+		return angle;
+	}
 
-  void drawCV(cv::Mat image, cv::Scalar color = cv::Scalar(0, 0, 255)) {
-    cv::line(image, cv::Point(upper_point.start.x, upper_point.start.y),
-             cv::Point(lower_point.start.x, lower_point.start.y), color, 3,
-             CV_AA);
-  }
+	void
+	drawCV(cv::Mat image, cv::Scalar color = cv::Scalar(0, 0, 255))
+	{
+		cv::line(image,
+		         cv::Point(upper_point.start.x, upper_point.start.y),
+		         cv::Point(lower_point.start.x, lower_point.start.y),
+		         color,
+		         3,
+		         CV_AA);
+	}
 };
 
 firevision::ROI getCenterRoi(firevision::ROI p1, firevision::ROI p2);
 
-struct puck {
-  fawkes::cart_coord_3d_t cart;
-  fawkes::polar_coord_2d_t pol;
-  double radius;
-  int visibiity_history;
-  firevision::ROI roi;
+struct puck
+{
+	fawkes::cart_coord_3d_t  cart;
+	fawkes::polar_coord_2d_t pol;
+	double                   radius;
+	int                      visibiity_history;
+	firevision::ROI          roi;
 };
 
 class VisualPositionThread : public fawkes::Thread,
@@ -203,107 +224,109 @@ class VisualPositionThread : public fawkes::Thread,
                              public fawkes::VisionAspect,
                              public fawkes::BlackBoardAspect,
                              public fawkes::TransformAspect,
-                             public fawkes::ConfigurationChangeHandler {
+                             public fawkes::ConfigurationChangeHandler
+{
 public:
-  VisualPositionThread();
-  virtual ~VisualPositionThread();
+	VisualPositionThread();
+	virtual ~VisualPositionThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  fawkes::Mutex cfg_mutex_;
+	fawkes::Mutex cfg_mutex_;
 
-  std::string cfg_prefix_;
-  std::string cfg_prefix_static_transforms_;
-  std::string cfg_colormodel_mode_;
+	std::string cfg_prefix_;
+	std::string cfg_prefix_static_transforms_;
+	std::string cfg_colormodel_mode_;
 
-  // Camera
-  camera_info camera_info_;
-  puck_features puck_info_;
+	// Camera
+	camera_info   camera_info_;
+	puck_features puck_info_;
 
-  bool cfg_debugMessagesActivated_;
-  bool cfg_paintROIsActivated_;
-  bool cfg_changed_;
+	bool cfg_debugMessagesActivated_;
+	bool cfg_paintROIsActivated_;
+	bool cfg_changed_;
 
-  std::string cfg_frame_camera_pos_;
+	std::string cfg_frame_camera_pos_;
 
-  firevision::Camera *cam_;
-  puck *no_pucK_;
-  firevision::SharedMemoryImageBuffer *shm_buffer_color_;
-  firevision::SharedMemoryImageBuffer *shm_buffer_gray_;
-  firevision::SharedMemoryImageBuffer *shm_buffer_gray_edgy_;
+	firevision::Camera *                 cam_;
+	puck *                               no_pucK_;
+	firevision::SharedMemoryImageBuffer *shm_buffer_color_;
+	firevision::SharedMemoryImageBuffer *shm_buffer_gray_;
+	firevision::SharedMemoryImageBuffer *shm_buffer_gray_edgy_;
 
-  // interfaces
-  std::vector<fawkes::Position3DInterface *> puck_interfaces_;
-  std::vector<firevision::ROI> detected_pucks;
-  fawkes::SwitchInterface *switchInterface_;
+	// interfaces
+	std::vector<fawkes::Position3DInterface *> puck_interfaces_;
+	std::vector<firevision::ROI>               detected_pucks;
+	fawkes::SwitchInterface *                  switchInterface_;
 
-  unsigned char *buffer_color_; // reference to the buffer of shm_buffer_YCbCr
-                                // (to use in code)
-  unsigned char *buffer_gray_;  // reference to the buffer of shm_buffer_YCbCr
-                                // (to use in code)
-  unsigned char *buffer_gray_edgy_;
+	unsigned char *buffer_color_; // reference to the buffer of shm_buffer_YCbCr
+	                              // (to use in code)
+	unsigned char *buffer_gray_;  // reference to the buffer of shm_buffer_YCbCr
+	                              // (to use in code)
+	unsigned char *buffer_gray_edgy_;
 
-  firevision::colorspace_t cspaceFrom_;
-  firevision::colorspace_t cspaceTo_;
+	firevision::colorspace_t cspaceFrom_;
+	firevision::colorspace_t cspaceTo_;
 
-  firevision::FilterROIDraw *drawer_;
+	firevision::FilterROIDraw *drawer_;
 
-  firevision::ROI search_area;
+	firevision::ROI search_area;
 
-  // Helper functions
-  float getX(firevision::ROI *roi);
-  float getY(firevision::ROI *roi);
+	// Helper functions
+	float getX(firevision::ROI *roi);
+	float getY(firevision::ROI *roi);
 
-  firevision::ROI *getBiggestRoi(std::list<firevision::ROI> *roiList);
-  firevision::ROI *getRoiContainingRoi(std::list<firevision::ROI> *roiList,
-                                       firevision::ROI containing);
-  void mergeWithColorInformation(firevision::color_t color,
-                                 std::list<firevision::ROI> *rois_color_,
-                                 std::list<firevision::ROI> *rois_all);
+	firevision::ROI *getBiggestRoi(std::list<firevision::ROI> *roiList);
+	firevision::ROI *getRoiContainingRoi(std::list<firevision::ROI> *roiList,
+	                                     firevision::ROI             containing);
+	void             mergeWithColorInformation(firevision::color_t         color,
+	                                           std::list<firevision::ROI> *rois_color_,
+	                                           std::list<firevision::ROI> *rois_all);
 
-  void setup_color_classifier(color_classifier_context_t_ *color_data,
-                              const char *prefix, firevision::color_t expected);
+	void setup_color_classifier(color_classifier_context_t_ *color_data,
+	                            const char *                 prefix,
+	                            firevision::color_t          expected);
 
-  Point3d apply_tf(const char *target_frame, Point3d src_point);
+	Point3d apply_tf(const char *target_frame, Point3d src_point);
 
-  std::list<firevision::ROI> *
-  classifyInRoi(firevision::ROI searchArea,
-                color_classifier_context_t_ *color_data);
+	std::list<firevision::ROI> *classifyInRoi(firevision::ROI              searchArea,
+	                                          color_classifier_context_t_ *color_data);
 
-  void printRoi(firevision::ROI roi);
-  void fitROI(firevision::ROI &roi, int x, int y, int w, int h);
-  firevision::ROI getCenterRoi(firevision::ROI p1, firevision::ROI p2);
+	void            printRoi(firevision::ROI roi);
+	void            fitROI(firevision::ROI &roi, int x, int y, int w, int h);
+	firevision::ROI getCenterRoi(firevision::ROI p1, firevision::ROI p2);
 
-  void loadConfig();
-  void polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol);
-  void createPuckInterface();
-  void cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y);
-  void drawRois(std::list<firevision::ROI> *rois_red_);
-  void drawROIIntoBuffer(firevision::ROI roi,
-                         firevision::FilterROIDraw::border_style_t borderStyle =
-                             firevision::FilterROIDraw::DASHED_HINT);
-  void calculatePuckPositions(std::vector<puck> *pucks,
-                              std::list<firevision::ROI> pucks_in_view);
-  void getPuckPosition(puck *p, firevision::ROI roi);
-  void sortPucks(std::vector<puck> *pucks);
+	void loadConfig();
+	void polToCart(float &x, float &y, fawkes::polar_coord_2d_t pol);
+	void createPuckInterface();
+	void cartToPol(fawkes::polar_coord_2d_t &pol, float x, float y);
+	void drawRois(std::list<firevision::ROI> *rois_red_);
+	void drawROIIntoBuffer(
+	  firevision::ROI                           roi,
+	  firevision::FilterROIDraw::border_style_t borderStyle = firevision::FilterROIDraw::DASHED_HINT);
+	void calculatePuckPositions(std::vector<puck> *pucks, std::list<firevision::ROI> pucks_in_view);
+	void getPuckPosition(puck *p, firevision::ROI roi);
+	void sortPucks(std::vector<puck> *pucks);
 
-  void updatePos3dInferface(fawkes::Position3DInterface *interface, puck *p);
-  void updateInterface(std::vector<puck> *puck);
-  void init_with_config();
+	void updatePos3dInferface(fawkes::Position3DInterface *interface, puck *p);
+	void updateInterface(std::vector<puck> *puck);
+	void init_with_config();
 
-  virtual void config_value_erased(const char *path);
-  virtual void config_tag_changed(const char *new_tag);
-  virtual void
-  config_comment_changed(const fawkes::Configuration::ValueIterator *v);
-  virtual void
-  config_value_changed(const fawkes::Configuration::ValueIterator *v);
-  void deleteClassifier(color_classifier_context_t_ *color_data);
+	virtual void config_value_erased(const char *path);
+	virtual void config_tag_changed(const char *new_tag);
+	virtual void config_comment_changed(const fawkes::Configuration::ValueIterator *v);
+	virtual void config_value_changed(const fawkes::Configuration::ValueIterator *v);
+	void         deleteClassifier(color_classifier_context_t_ *color_data);
 
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 };
 
 #endif /* visual_position_THREAD_H_ */

--- a/src/plugins/attic/webview-refbox/webview-refbox-plugin.cpp
+++ b/src/plugins/attic/webview-refbox/webview-refbox-plugin.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "webview-refbox-thread.h"
+
 #include <core/plugin.h>
 
 using namespace fawkes;
@@ -28,14 +29,16 @@ using namespace fawkes;
 /** RCLL refbox webview plugin.
  * @author Tim Niemueller
  */
-class WebviewRCLLRefBoxPlugin : public fawkes::Plugin {
+class WebviewRCLLRefBoxPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  WebviewRCLLRefBoxPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new WebviewRCLLRefBoxThread());
-  }
+	WebviewRCLLRefBoxPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new WebviewRCLLRefBoxThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("RCLL refbox log data")

--- a/src/plugins/attic/webview-refbox/webview-refbox-processor.cpp
+++ b/src/plugins/attic/webview-refbox/webview-refbox-processor.cpp
@@ -23,11 +23,10 @@
 
 #include <core/exception.h>
 #include <core/threading/mutex_locker.h>
+#include <mongo/client/dbclient.h>
 #include <webview/error_reply.h>
 #include <webview/page_reply.h>
 #include <webview/redirect_reply.h>
-
-#include <mongo/client/dbclient.h>
 
 #include <cstring>
 #include <memory>
@@ -57,310 +56,325 @@ using namespace mongo;
  * @param logger logger to report problems
  */
 WebviewRCLLRefBoxRequestProcessor::WebviewRCLLRefBoxRequestProcessor(
-    std::string base_url, mongo::DBClientBase *mongodb_client) {
-  mongodb_ = mongodb_client;
+  std::string          base_url,
+  mongo::DBClientBase *mongodb_client)
+{
+	mongodb_ = mongodb_client;
 }
 
 /** Destructor. */
-WebviewRCLLRefBoxRequestProcessor::~WebviewRCLLRefBoxRequestProcessor() {}
-
-std::string
-WebviewRCLLRefBoxRequestProcessor::gen_orders_table(const mongo::BSONObj *doc) {
-  std::string rv = "<table>"
-                   "<tr><th>ID</th><th>Product</th>"
-                   "<th>Requested</th><th>Delivered</th><th "
-                   "colspan=\"2\">Period</th></tr>\n";
-
-  std::vector<BSONElement> orders = (*doc)["orders"].Array();
-  for (const BSONElement &o : orders) {
-    std::vector<BSONElement> del_period = o["delivery-period"].Array();
-    std::vector<BSONElement> quant_deliv = o["quantity-delivered"].Array();
-    std::string base_color = o["base-color"].String().substr(5);
-    std::transform(base_color.begin(), base_color.end(), base_color.begin(),
-                   ::tolower);
-    std::string cap_color = o["cap-color"].String().substr(4);
-    std::transform(cap_color.begin(), cap_color.end(), cap_color.begin(),
-                   ::tolower);
-    std::string prod_string = std::string("<div>") +
-                              "<div style=\"float: left; width: 8px; "
-                              "height:12px; background-color: " +
-                              base_color + "\"></div>";
-
-    if (o.Obj().hasField("ring-colors")) {
-      std::vector<BSONElement> rings = o["ring-colors"].Array();
-      for (const BSONElement &r : rings) {
-        const std::string ring_color = r.String().substr(5);
-        prod_string += "<div style=\"float: left; margin-left: 1px; "
-                       "width: 6px; height:12px; background-color: " +
-                       ring_color + "\"></div>" + "</div>";
-      }
-    }
-
-    prod_string += "<div style=\"float: left; margin-left: 1px; "
-                   "width: 4px; height:12px; background-color: " +
-                   cap_color + "\"></div>" + "</div>";
-
-    rv += "<tr><td>" + std::to_string(o["id"].Long()) + "</td><td>" +
-          prod_string + "</td>" + "<td>" +
-          std::to_string(o["quantity-requested"].Long()) + "</td>" +
-          "<td><span style=\"color: #88ffff; weight: bold;\">" +
-          std::to_string(quant_deliv[0].Long()) +
-          "</span> / "
-          "<span style=\"color: #ff88ff; weight: bold;\">" +
-          std::to_string(quant_deliv[1].Long()) + "</span></td>" + "<td>" +
-          std::to_string(del_period[0].Long()) + "-" +
-          std::to_string(del_period[1].Long()) + "</td>" + "<td>(Act. " +
-          std::to_string(o["activate-at"].Long()) + ")</td></tr>";
-  }
-  rv += "</table>";
-  return rv;
+WebviewRCLLRefBoxRequestProcessor::~WebviewRCLLRefBoxRequestProcessor()
+{
 }
 
-WebReply *WebviewRCLLRefBoxRequestProcessor::process_request(
-    const fawkes::WebRequest *request) {
-  if (request->url().find(baseurl_) == 0) {
-    std::string subpath = request->url().substr(baseurl_.length());
+std::string
+WebviewRCLLRefBoxRequestProcessor::gen_orders_table(const mongo::BSONObj *doc)
+{
+	std::string rv = "<table>"
+	                 "<tr><th>ID</th><th>Product</th>"
+	                 "<th>Requested</th><th>Delivered</th><th "
+	                 "colspan=\"2\">Period</th></tr>\n";
 
-    WebPageReply *r = new WebPageReply("RCLL RefBox");
-    r->set_html_header("  <link type=\"text/css\" href=\"/static/css/jqtheme/"
-                       "jquery-ui.custom.css\" rel=\"stylesheet\" />\n"
-                       "  <script type=\"text/javascript\" src=\"/static/js/"
-                       "jquery.min.js\"></script>\n"
-                       "  <script type=\"text/javascript\" src=\"/static/js/"
-                       "jquery-ui.custom.min.js\"></script>\n");
-    *r += "<style type=\"text/css\">\n"
-          "  .game-link { color: black; }\n"
-          "</style>";
+	std::vector<BSONElement> orders = (*doc)["orders"].Array();
+	for (const BSONElement &o : orders) {
+		std::vector<BSONElement> del_period  = o["delivery-period"].Array();
+		std::vector<BSONElement> quant_deliv = o["quantity-delivered"].Array();
+		std::string              base_color  = o["base-color"].String().substr(5);
+		std::transform(base_color.begin(), base_color.end(), base_color.begin(), ::tolower);
+		std::string cap_color = o["cap-color"].String().substr(4);
+		std::transform(cap_color.begin(), cap_color.end(), cap_color.begin(), ::tolower);
+		std::string prod_string = std::string("<div>")
+		                          + "<div style=\"float: left; width: 8px; "
+		                            "height:12px; background-color: "
+		                          + base_color + "\"></div>";
 
-    *r += "<h2>RCLL RefBox Database Report</h2>\n";
+		if (o.Obj().hasField("ring-colors")) {
+			std::vector<BSONElement> rings = o["ring-colors"].Array();
+			for (const BSONElement &r : rings) {
+				const std::string ring_color = r.String().substr(5);
+				prod_string += "<div style=\"float: left; margin-left: 1px; "
+				               "width: 6px; height:12px; background-color: "
+				               + ring_color + "\"></div>" + "</div>";
+			}
+		}
 
-    time_t query_time = time(0);
-    query_time -= 24 * 3600;
+		prod_string += "<div style=\"float: left; margin-left: 1px; "
+		               "width: 4px; height:12px; background-color: "
+		               + cap_color + "\"></div>" + "</div>";
 
-    BSONObj query = BSON(
-        "start-time" << BSONObjBuilder().appendTimeT("$gt", query_time).obj()
-                     << "end-time" << BSON("$exists" << false));
+		rv += "<tr><td>" + std::to_string(o["id"].Long()) + "</td><td>" + prod_string + "</td>" + "<td>"
+		      + std::to_string(o["quantity-requested"].Long()) + "</td>"
+		      + "<td><span style=\"color: #88ffff; weight: bold;\">"
+		      + std::to_string(quant_deliv[0].Long())
+		      + "</span> / "
+		        "<span style=\"color: #ff88ff; weight: bold;\">"
+		      + std::to_string(quant_deliv[1].Long()) + "</span></td>" + "<td>"
+		      + std::to_string(del_period[0].Long()) + "-" + std::to_string(del_period[1].Long())
+		      + "</td>" + "<td>(Act. " + std::to_string(o["activate-at"].Long()) + ")</td></tr>";
+	}
+	rv += "</table>";
+	return rv;
+}
 
-    // check if there is a running game
-    std::shared_ptr<DBClientCursor> cursor = mongodb_->query(
-        "llsfrb.game_report", Query(query).sort("start-time", -1), 1);
+WebReply *
+WebviewRCLLRefBoxRequestProcessor::process_request(const fawkes::WebRequest *request)
+{
+	if (request->url().find(baseurl_) == 0) {
+		std::string subpath = request->url().substr(baseurl_.length());
 
-    if (cursor->more()) {
-      BSONObj doc = cursor->next();
-      std::vector<BSONElement> teams = doc["teams"].Array();
-      std::vector<BSONElement> points = doc["total-points"].Array();
-      r->append_body("<h3>Active Game %s vs. %s</h3>\n",
-                     teams[0].String().c_str(), teams[1].String().c_str());
+		WebPageReply *r = new WebPageReply("RCLL RefBox");
+		r->set_html_header("  <link type=\"text/css\" href=\"/static/css/jqtheme/"
+		                   "jquery-ui.custom.css\" rel=\"stylesheet\" />\n"
+		                   "  <script type=\"text/javascript\" src=\"/static/js/"
+		                   "jquery.min.js\"></script>\n"
+		                   "  <script type=\"text/javascript\" src=\"/static/js/"
+		                   "jquery-ui.custom.min.js\"></script>\n");
+		*r += "<style type=\"text/css\">\n"
+		      "  .game-link { color: black; }\n"
+		      "</style>";
 
-      *r += "<table>\n";
-      r->append_body("<tr><td><b>Started at:</b></td>\n"
-                     "<td>%s</td></tr>\n",
-                     doc["start-time"].Date().toString().c_str());
-      r->append_body(
-          "<tr><td><b>Points:</b></td>\n"
-          "<td><span style=\"background-color: #88ffff\">%u</span> "
-          ": <span style=\"background-color: #ff88ff\">%u</span></td></tr>\n",
-          points[0].Long(), points[1].Long());
+		*r += "<h2>RCLL RefBox Database Report</h2>\n";
 
-      r->append_body("<tr><td><b>Points Cyan:</b></td>\n"
-                     "<td><i>Exploration:</i> %ld</td></tr>\n",
-                     doc["phase-points-cyan"]["EXPLORATION"].numberLong());
-      r->append_body("<tr><td></td>\n"
-                     "<td><i>Production:</i> %ld</td></tr>\n",
-                     doc["phase-points-cyan"]["PRODUCTION"].numberLong());
+		time_t query_time = time(0);
+		query_time -= 24 * 3600;
 
-      r->append_body("<tr><td><b>Points Magenta:</b></td>\n"
-                     "<td><i>Exploration:</i> %ld</td></tr>\n",
-                     doc["phase-points-magenta"]["EXPLORATION"].numberLong());
-      r->append_body("<tr><td></td>\n"
-                     "<td><i>Production:</i> %ld</td></tr>\n",
-                     doc["phase-points-magenta"]["PRODUCTION"].numberLong());
+		BSONObj query = BSON("start-time" << BSONObjBuilder().appendTimeT("$gt", query_time).obj()
+		                                  << "end-time" << BSON("$exists" << false));
 
-      r->append_body("<tr><td><b>Orders:</b></td>\n"
-                     "<td>%s</td></tr>\n",
-                     gen_orders_table(&doc).c_str());
+		// check if there is a running game
+		std::shared_ptr<DBClientCursor> cursor =
+		  mongodb_->query("llsfrb.game_report", Query(query).sort("start-time", -1), 1);
 
-      *r += "</table>\n";
-    }
+		if (cursor->more()) {
+			BSONObj                  doc    = cursor->next();
+			std::vector<BSONElement> teams  = doc["teams"].Array();
+			std::vector<BSONElement> points = doc["total-points"].Array();
+			r->append_body("<h3>Active Game %s vs. %s</h3>\n",
+			               teams[0].String().c_str(),
+			               teams[1].String().c_str());
 
-    *r += "<h3>Previous Games</h3>\n";
+			*r += "<table>\n";
+			r->append_body("<tr><td><b>Started at:</b></td>\n"
+			               "<td>%s</td></tr>\n",
+			               doc["start-time"].Date().toString().c_str());
+			r->append_body("<tr><td><b>Points:</b></td>\n"
+			               "<td><span style=\"background-color: #88ffff\">%u</span> "
+			               ": <span style=\"background-color: #ff88ff\">%u</span></td></tr>\n",
+			               points[0].Long(),
+			               points[1].Long());
 
-    // check if there is a running game
-    cursor = mongodb_->query(
-        "llsfrb.game_report",
-        QUERY("end-time" << BSON("$exists" << true)).sort("start-time"));
+			r->append_body("<tr><td><b>Points Cyan:</b></td>\n"
+			               "<td><i>Exploration:</i> %ld</td></tr>\n",
+			               doc["phase-points-cyan"]["EXPLORATION"].numberLong());
+			r->append_body("<tr><td></td>\n"
+			               "<td><i>Production:</i> %ld</td></tr>\n",
+			               doc["phase-points-cyan"]["PRODUCTION"].numberLong());
 
-    *r += "<table>\n"
-          "<tr><th>Teams</th><th colspan=\"2\">Points</th><th "
-          "colspan=\"2\">Points Cyan</th>"
-          "<th colspan=\"2\">Points Magenta</th></tr>\n";
+			r->append_body("<tr><td><b>Points Magenta:</b></td>\n"
+			               "<td><i>Exploration:</i> %ld</td></tr>\n",
+			               doc["phase-points-magenta"]["EXPLORATION"].numberLong());
+			r->append_body("<tr><td></td>\n"
+			               "<td><i>Production:</i> %ld</td></tr>\n",
+			               doc["phase-points-magenta"]["PRODUCTION"].numberLong());
 
-    std::list<std::string> reports;
+			r->append_body("<tr><td><b>Orders:</b></td>\n"
+			               "<td>%s</td></tr>\n",
+			               gen_orders_table(&doc).c_str());
 
-    while (cursor->more()) {
-      BSONObj doc = cursor->next();
-      std::vector<BSONElement> teams = doc["teams"].Array();
-      std::vector<BSONElement> points = doc["total-points"].Array();
+			*r += "</table>\n";
+		}
 
-      int winner_team = -1;
-      if (points[0].numberLong() > points[1].numberLong()) {
-        winner_team = 0;
-      } else if (points[1].numberLong() > points[0].numberLong()) {
-        winner_team = 1;
-      } // else draw
+		*r += "<h3>Previous Games</h3>\n";
 
-      reports.push_back(doc["_id"].OID().str());
+		// check if there is a running game
+		cursor = mongodb_->query("llsfrb.game_report",
+		                         QUERY("end-time" << BSON("$exists" << true)).sort("start-time"));
 
-      r->append_body(
-          "<tr><td><a id=\"game-%s\" href=\"#\" class=\"game-link\">"
-          "<img id=\"game-%s-icon\" class=\"game-icon\" "
-          "src=\"/static/images/icon-triangle-e.png\" />"
-          " %s%s%s vs. %s%s%s</a></td>\n",
-          doc["_id"].OID().str().c_str(), doc["_id"].OID().str().c_str(),
-          winner_team == 0 ? "<b>" : "", teams[0].String().c_str(),
-          winner_team == 0 ? "</b>" : "", winner_team == 1 ? "<b>" : "",
-          teams[1].String().c_str(), winner_team == 1 ? "</b>" : "");
+		*r += "<table>\n"
+		      "<tr><th>Teams</th><th colspan=\"2\">Points</th><th "
+		      "colspan=\"2\">Points Cyan</th>"
+		      "<th colspan=\"2\">Points Magenta</th></tr>\n";
 
-      r->append_body(
-          "<td style=\"background-color: #88ffff; text-align: center;\">%u</td>"
-          "<td style=\"background-color: #ff88ff; text-align: "
-          "center;\">%u</td>\n",
-          points[0].numberLong(), points[1].numberLong());
+		std::list<std::string> reports;
 
-      r->append_body("<td><i>Exploration:</i> %ld</td>\n",
-                     doc["phase-points-cyan"]["EXPLORATION"].numberLong());
-      r->append_body("<td><i>Production:</i> %ld</td>\n",
-                     doc["phase-points-cyan"]["PRODUCTION"].numberLong());
+		while (cursor->more()) {
+			BSONObj                  doc    = cursor->next();
+			std::vector<BSONElement> teams  = doc["teams"].Array();
+			std::vector<BSONElement> points = doc["total-points"].Array();
 
-      r->append_body("<td><i>Exploration:</i> %ld</td>\n",
-                     doc["phase-points-magenta"]["EXPLORATION"].numberLong());
-      r->append_body("<td><i>Production:</i> %ld</td>\n",
-                     doc["phase-points-magenta"]["PRODUCTION"].numberLong());
+			int winner_team = -1;
+			if (points[0].numberLong() > points[1].numberLong()) {
+				winner_team = 0;
+			} else if (points[1].numberLong() > points[0].numberLong()) {
+				winner_team = 1;
+			} // else draw
 
-      *r += "</tr>\n";
+			reports.push_back(doc["_id"].OID().str());
 
-      r->append_body("<tr id=\"game-%s-time\">"
-                     "<td valign=\"top\">Game Time</td>"
-                     "<td colspan=\"6\">"
-                     "%s to %s</td></tr>\n",
-                     doc["_id"].OID().str().c_str(),
-                     doc["start-time"].Date().toString().c_str(),
-                     doc["end-time"].Date().toString().c_str());
+			r->append_body("<tr><td><a id=\"game-%s\" href=\"#\" class=\"game-link\">"
+			               "<img id=\"game-%s-icon\" class=\"game-icon\" "
+			               "src=\"/static/images/icon-triangle-e.png\" />"
+			               " %s%s%s vs. %s%s%s</a></td>\n",
+			               doc["_id"].OID().str().c_str(),
+			               doc["_id"].OID().str().c_str(),
+			               winner_team == 0 ? "<b>" : "",
+			               teams[0].String().c_str(),
+			               winner_team == 0 ? "</b>" : "",
+			               winner_team == 1 ? "<b>" : "",
+			               teams[1].String().c_str(),
+			               winner_team == 1 ? "</b>" : "");
 
-      r->append_body(
-          "<tr id=\"game-%s-desc\">"
-          "<td valign=\"top\"><div style=\"margin-top: 12px\">Events</div></td>"
-          "<td colspan=\"6\"><table>"
-          "<tr><th>Team</th><th>Points</th><th>Game "
-          "Time</th><th>Reason</th></tr>\n",
-          doc["_id"].OID().str().c_str());
-      std::vector<BSONElement> pointinfo = doc["points"].Array();
-      for (const BSONElement &pd : pointinfo) {
-        r->append_body(
-            "<tr><td style=\"background-color: "
-            "#%s\">%s</td><td>%lu</td><td>%.2f</td><td>%s</td></tr>\n",
-            pd["team"].String() == "CYAN" ? "88ffff" : "ff88ff",
-            pd["team"].String().c_str(), pd["points"].numberLong(),
-            pd["game-time"].Double(), pd["reason"].String().c_str());
-      }
-      *r += "</table></td></tr>\n";
+			r->append_body("<td style=\"background-color: #88ffff; text-align: center;\">%u</td>"
+			               "<td style=\"background-color: #ff88ff; text-align: "
+			               "center;\">%u</td>\n",
+			               points[0].numberLong(),
+			               points[1].numberLong());
 
-      if (doc.hasField("orders")) {
-        r->append_body("<tr id=\"game-%s-orders\">"
-                       "<td valign=\"top\"><div style=\"margin-top: "
-                       "12px\">Orders</div></td>"
-                       "<td colspan=\"6\">%s</td></tr>\n",
-                       doc["_id"].OID().str().c_str(),
-                       gen_orders_table(&doc).c_str());
-      }
+			r->append_body("<td><i>Exploration:</i> %ld</td>\n",
+			               doc["phase-points-cyan"]["EXPLORATION"].numberLong());
+			r->append_body("<td><i>Production:</i> %ld</td>\n",
+			               doc["phase-points-cyan"]["PRODUCTION"].numberLong());
 
-      if (doc.hasField("machines")) {
-        r->append_body("<tr id=\"game-%s-machines\">"
-                       "<td valign=\"top\"><div style=\"margin-top: "
-                       "12px\">Machines</div></td>"
-                       "<td colspan=\"6\"><table>"
-                       "<tr><th>Name</th><th>Type</th><th>Team</th>"
-                       "<th>Productions</th><th>Proc. Time</th></tr>\n",
-                       doc["_id"].OID().str().c_str());
-        std::vector<BSONElement> machines = doc["machines"].Array();
-        for (const BSONElement &m : machines) {
-          r->append_body("<tr><td>%s</td><td>%s</td><td>%s</td>"
-                         "<td>%lu</td><td>%lu</td></tr>",
-                         m["name"].String().c_str(), m["type"].String().c_str(),
-                         m["team"].String().c_str(), m["productions"].Long(),
-                         m.Obj().hasField("proc-time") ? m["proc-time"].Long()
-                                                       : 0);
-        }
-        *r += "</table></td></tr>\n";
-      }
-    }
-    *r += "</table>\n";
+			r->append_body("<td><i>Exploration:</i> %ld</td>\n",
+			               doc["phase-points-magenta"]["EXPLORATION"].numberLong());
+			r->append_body("<td><i>Production:</i> %ld</td>\n",
+			               doc["phase-points-magenta"]["PRODUCTION"].numberLong());
 
-    *r += "<script type=\"text/javascript\">\n"
-          "  $(function(){\n";
-    for (const std::string &gr : reports) {
-      r->append_body("    $(\"#game-%s\").click(function(){\n"
-                     "      if ( $(\"#game-%s-desc\").is(\":visible\") ) {\n"
-                     "        $(\"#game-%s-time\").hide();\n"
-                     "        $(\"#game-%s-desc\").hide();\n"
-                     "        $(\"#game-%s-orders\").hide();\n"
-                     "        $(\"#game-%s-machines\").hide();\n"
-                     "        $(\"#game-%s-icon\").attr(\"src\", "
-                     "\"/static/images/icon-triangle-e.png\");\n"
-                     "      } else {\n"
-                     "        $(\"#game-%s-time\").show();\n"
-                     "        $(\"#game-%s-desc\").show();\n"
-                     "        $(\"#game-%s-orders\").show();\n"
-                     "        $(\"#game-%s-machines\").show();\n"
-                     "        $(\"#game-%s-icon\").attr(\"src\", "
-                     "\"/static/images/icon-triangle-s.png\");\n"
-                     "      }\n"
-                     "    });\n"
-                     "    $(\"#game-%s-time\").hide();\n"
-                     "    $(\"#game-%s-desc\").hide();\n"
-                     "    $(\"#game-%s-orders\").hide();\n"
-                     "    $(\"#game-%s-machines\").hide();\n",
-                     gr.c_str(), gr.c_str(), gr.c_str(), gr.c_str(), gr.c_str(),
-                     gr.c_str(), gr.c_str(), gr.c_str(), gr.c_str(), gr.c_str(),
-                     gr.c_str(), gr.c_str(), gr.c_str(), gr.c_str(), gr.c_str(),
-                     gr.c_str());
-    }
-    *r += "  });\n"
-          "</script>\n";
+			*r += "</tr>\n";
 
-    // This set of function reduces to a collection with
-    // a separate document per team
-    const char *map_func =
-        "function () {\n"
-        "  if (this.teams[0] != \"\") {\n"
-        "    emit(this.teams[0], {points: this[\"total-points\"][0],\n"
-        "			        opp_points: "
-        "this[\"total-points\"][1]});\n"
-        "  }\n"
-        "  if (this.teams[1] != \"\") {\n"
-        "    emit(this.teams[1], {points: this[\"total-points\"][1],\n"
-        "			 	opp_points: "
-        "this[\"total-points\"][0]});\n"
-        "	 }\n"
-        "}";
-    const char *red_func =
-        "function(key, values) {\n"
-        "	 rv = { games: 0, wins: 0, points: 0, opp_points: 0 };\n"
-        "	 for (var i = 0; i < values.length; ++i) {\n"
-        "	   rv.games += (\"games\" in values[i]) ? values[i].games : "
-        "1;\n"
-        "	   if (\"wins\" in values[i]) {\n"
-        "	     rv.wins += values[i].wins;\n"
-        "	   } else if (values[i].points > values[i].opp_points) {\n"
-        "	     rv.wins += 1;\n"
-        "	   }\n"
-        "	   rv.points += values[i].points;\n"
-        "	   rv.opp_points += values[i].opp_points;\n"
-        "	 }\n"
-        "	 return rv;\n"
-        "}\n";
+			r->append_body("<tr id=\"game-%s-time\">"
+			               "<td valign=\"top\">Game Time</td>"
+			               "<td colspan=\"6\">"
+			               "%s to %s</td></tr>\n",
+			               doc["_id"].OID().str().c_str(),
+			               doc["start-time"].Date().toString().c_str(),
+			               doc["end-time"].Date().toString().c_str());
 
-    /*
+			r->append_body("<tr id=\"game-%s-desc\">"
+			               "<td valign=\"top\"><div style=\"margin-top: 12px\">Events</div></td>"
+			               "<td colspan=\"6\"><table>"
+			               "<tr><th>Team</th><th>Points</th><th>Game "
+			               "Time</th><th>Reason</th></tr>\n",
+			               doc["_id"].OID().str().c_str());
+			std::vector<BSONElement> pointinfo = doc["points"].Array();
+			for (const BSONElement &pd : pointinfo) {
+				r->append_body("<tr><td style=\"background-color: "
+				               "#%s\">%s</td><td>%lu</td><td>%.2f</td><td>%s</td></tr>\n",
+				               pd["team"].String() == "CYAN" ? "88ffff" : "ff88ff",
+				               pd["team"].String().c_str(),
+				               pd["points"].numberLong(),
+				               pd["game-time"].Double(),
+				               pd["reason"].String().c_str());
+			}
+			*r += "</table></td></tr>\n";
+
+			if (doc.hasField("orders")) {
+				r->append_body("<tr id=\"game-%s-orders\">"
+				               "<td valign=\"top\"><div style=\"margin-top: "
+				               "12px\">Orders</div></td>"
+				               "<td colspan=\"6\">%s</td></tr>\n",
+				               doc["_id"].OID().str().c_str(),
+				               gen_orders_table(&doc).c_str());
+			}
+
+			if (doc.hasField("machines")) {
+				r->append_body("<tr id=\"game-%s-machines\">"
+				               "<td valign=\"top\"><div style=\"margin-top: "
+				               "12px\">Machines</div></td>"
+				               "<td colspan=\"6\"><table>"
+				               "<tr><th>Name</th><th>Type</th><th>Team</th>"
+				               "<th>Productions</th><th>Proc. Time</th></tr>\n",
+				               doc["_id"].OID().str().c_str());
+				std::vector<BSONElement> machines = doc["machines"].Array();
+				for (const BSONElement &m : machines) {
+					r->append_body("<tr><td>%s</td><td>%s</td><td>%s</td>"
+					               "<td>%lu</td><td>%lu</td></tr>",
+					               m["name"].String().c_str(),
+					               m["type"].String().c_str(),
+					               m["team"].String().c_str(),
+					               m["productions"].Long(),
+					               m.Obj().hasField("proc-time") ? m["proc-time"].Long() : 0);
+				}
+				*r += "</table></td></tr>\n";
+			}
+		}
+		*r += "</table>\n";
+
+		*r += "<script type=\"text/javascript\">\n"
+		      "  $(function(){\n";
+		for (const std::string &gr : reports) {
+			r->append_body("    $(\"#game-%s\").click(function(){\n"
+			               "      if ( $(\"#game-%s-desc\").is(\":visible\") ) {\n"
+			               "        $(\"#game-%s-time\").hide();\n"
+			               "        $(\"#game-%s-desc\").hide();\n"
+			               "        $(\"#game-%s-orders\").hide();\n"
+			               "        $(\"#game-%s-machines\").hide();\n"
+			               "        $(\"#game-%s-icon\").attr(\"src\", "
+			               "\"/static/images/icon-triangle-e.png\");\n"
+			               "      } else {\n"
+			               "        $(\"#game-%s-time\").show();\n"
+			               "        $(\"#game-%s-desc\").show();\n"
+			               "        $(\"#game-%s-orders\").show();\n"
+			               "        $(\"#game-%s-machines\").show();\n"
+			               "        $(\"#game-%s-icon\").attr(\"src\", "
+			               "\"/static/images/icon-triangle-s.png\");\n"
+			               "      }\n"
+			               "    });\n"
+			               "    $(\"#game-%s-time\").hide();\n"
+			               "    $(\"#game-%s-desc\").hide();\n"
+			               "    $(\"#game-%s-orders\").hide();\n"
+			               "    $(\"#game-%s-machines\").hide();\n",
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str(),
+			               gr.c_str());
+		}
+		*r += "  });\n"
+		      "</script>\n";
+
+		// This set of function reduces to a collection with
+		// a separate document per team
+		const char *map_func = "function () {\n"
+		                       "  if (this.teams[0] != \"\") {\n"
+		                       "    emit(this.teams[0], {points: this[\"total-points\"][0],\n"
+		                       "			        opp_points: "
+		                       "this[\"total-points\"][1]});\n"
+		                       "  }\n"
+		                       "  if (this.teams[1] != \"\") {\n"
+		                       "    emit(this.teams[1], {points: this[\"total-points\"][1],\n"
+		                       "			 	opp_points: "
+		                       "this[\"total-points\"][0]});\n"
+		                       "	 }\n"
+		                       "}";
+		const char *red_func = "function(key, values) {\n"
+		                       "	 rv = { games: 0, wins: 0, points: 0, opp_points: 0 };\n"
+		                       "	 for (var i = 0; i < values.length; ++i) {\n"
+		                       "	   rv.games += (\"games\" in values[i]) ? values[i].games : "
+		                       "1;\n"
+		                       "	   if (\"wins\" in values[i]) {\n"
+		                       "	     rv.wins += values[i].wins;\n"
+		                       "	   } else if (values[i].points > values[i].opp_points) {\n"
+		                       "	     rv.wins += 1;\n"
+		                       "	   }\n"
+		                       "	   rv.points += values[i].points;\n"
+		                       "	   rv.opp_points += values[i].opp_points;\n"
+		                       "	 }\n"
+		                       "	 return rv;\n"
+		                       "}\n";
+
+		/*
     // these functions reduce into a single document for all teams
     const char *map_func =
       "function () {\n"
@@ -402,33 +416,35 @@ WebReply *WebviewRCLLRefBoxRequestProcessor::process_request(
       "}\n";
     */
 
-    BSONObj out =
-        mongodb_->mapreduce("llsfrb.game_report", map_func, red_func,
-                            BSON("end-time" << BSON("$exists" << true)));
+		BSONObj out = mongodb_->mapreduce("llsfrb.game_report",
+		                                  map_func,
+		                                  red_func,
+		                                  BSON("end-time" << BSON("$exists" << true)));
 
-    *r += "<h4>Tournament Statistics</h4>\n"
-          "<table>\n"
-          "<tr><th>Team</th><th>Games</th><th>Wins</th><th>Points</th></tr>\n";
-    std::vector<BSONElement> teams = out["results"].Array();
-    for (const BSONElement &t : teams) {
-      BSONObj tdoc = t["value"].Obj();
-      r->append_body("<tr><td><i>%s</i></td><td>%u</td><td>%u</td><td>%d:%d "
-                     "(%d)</td></tr>\n",
-                     t["_id"].String().c_str(), tdoc["games"].numberInt(),
-                     tdoc["wins"].numberInt(), tdoc["points"].numberInt(),
-                     tdoc["opp_points"].numberInt(),
-                     tdoc["points"].numberInt() -
-                         tdoc["opp_points"].numberInt());
-    }
-    *r += "</table>\n";
+		*r += "<h4>Tournament Statistics</h4>\n"
+		      "<table>\n"
+		      "<tr><th>Team</th><th>Games</th><th>Wins</th><th>Points</th></tr>\n";
+		std::vector<BSONElement> teams = out["results"].Array();
+		for (const BSONElement &t : teams) {
+			BSONObj tdoc = t["value"].Obj();
+			r->append_body("<tr><td><i>%s</i></td><td>%u</td><td>%u</td><td>%d:%d "
+			               "(%d)</td></tr>\n",
+			               t["_id"].String().c_str(),
+			               tdoc["games"].numberInt(),
+			               tdoc["wins"].numberInt(),
+			               tdoc["points"].numberInt(),
+			               tdoc["opp_points"].numberInt(),
+			               tdoc["points"].numberInt() - tdoc["opp_points"].numberInt());
+		}
+		*r += "</table>\n";
 
-    return r;
-    /*
+		return r;
+		/*
     } else {
       return new WebErrorPageReply(WebReply::HTTP_NOT_FOUND, "Unknown request");
     }
     */
-  } else {
-    return NULL;
-  }
+	} else {
+		return NULL;
+	}
 }

--- a/src/plugins/attic/webview-refbox/webview-refbox-processor.h
+++ b/src/plugins/attic/webview-refbox/webview-refbox-processor.h
@@ -33,21 +33,21 @@ class DBClientBase;
 class BSONObj;
 } // namespace mongo
 
-class WebviewRCLLRefBoxRequestProcessor : public fawkes::WebRequestProcessor {
+class WebviewRCLLRefBoxRequestProcessor : public fawkes::WebRequestProcessor
+{
 public:
-  WebviewRCLLRefBoxRequestProcessor(std::string base_url,
-                                    mongo::DBClientBase *mongodb_client);
-  virtual ~WebviewRCLLRefBoxRequestProcessor();
+	WebviewRCLLRefBoxRequestProcessor(std::string base_url, mongo::DBClientBase *mongodb_client);
+	virtual ~WebviewRCLLRefBoxRequestProcessor();
 
-  virtual fawkes::WebReply *process_request(const fawkes::WebRequest *request);
-
-private:
-  std::string gen_orders_table(const mongo::BSONObj *doc);
+	virtual fawkes::WebReply *process_request(const fawkes::WebRequest *request);
 
 private:
-  mongo::DBClientBase *mongodb_;
+	std::string gen_orders_table(const mongo::BSONObj *doc);
 
-  std::string baseurl_;
+private:
+	mongo::DBClientBase *mongodb_;
+
+	std::string baseurl_;
 };
 
 #endif

--- a/src/plugins/attic/webview-refbox/webview-refbox-thread.cpp
+++ b/src/plugins/attic/webview-refbox/webview-refbox-thread.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "webview-refbox-thread.h"
+
 #include "webview-refbox-processor.h"
 
 #include <webview/nav_manager.h>
@@ -37,28 +38,38 @@ using namespace fawkes;
 
 /** Constructor. */
 WebviewRCLLRefBoxThread::WebviewRCLLRefBoxThread()
-    : Thread("WebviewRCLLRefBoxThread", Thread::OPMODE_WAITFORWAKEUP) {}
+: Thread("WebviewRCLLRefBoxThread", Thread::OPMODE_WAITFORWAKEUP)
+{
+}
 
 /** Destructor. */
-WebviewRCLLRefBoxThread::~WebviewRCLLRefBoxThread() {}
-
-void WebviewRCLLRefBoxThread::init() {
-  std::string nav_entry = "RCLL RefBox";
-  try {
-    nav_entry = config->get_string("/webview/refbox/nav-entry");
-  } catch (Exception &e) {
-  } // ignored, use default
-
-  web_proc_ =
-      new WebviewRCLLRefBoxRequestProcessor(REFBOX_URL_PREFIX, mongodb_client);
-  webview_url_manager->register_baseurl(REFBOX_URL_PREFIX, web_proc_);
-  webview_nav_manager->add_nav_entry(REFBOX_URL_PREFIX, nav_entry.c_str());
+WebviewRCLLRefBoxThread::~WebviewRCLLRefBoxThread()
+{
 }
 
-void WebviewRCLLRefBoxThread::finalize() {
-  webview_url_manager->unregister_baseurl(REFBOX_URL_PREFIX);
-  webview_nav_manager->remove_nav_entry(REFBOX_URL_PREFIX);
-  delete web_proc_;
+void
+WebviewRCLLRefBoxThread::init()
+{
+	std::string nav_entry = "RCLL RefBox";
+	try {
+		nav_entry = config->get_string("/webview/refbox/nav-entry");
+	} catch (Exception &e) {
+	} // ignored, use default
+
+	web_proc_ = new WebviewRCLLRefBoxRequestProcessor(REFBOX_URL_PREFIX, mongodb_client);
+	webview_url_manager->register_baseurl(REFBOX_URL_PREFIX, web_proc_);
+	webview_nav_manager->add_nav_entry(REFBOX_URL_PREFIX, nav_entry.c_str());
 }
 
-void WebviewRCLLRefBoxThread::loop() {}
+void
+WebviewRCLLRefBoxThread::finalize()
+{
+	webview_url_manager->unregister_baseurl(REFBOX_URL_PREFIX);
+	webview_nav_manager->remove_nav_entry(REFBOX_URL_PREFIX);
+	delete web_proc_;
+}
+
+void
+WebviewRCLLRefBoxThread::loop()
+{
+}

--- a/src/plugins/attic/webview-refbox/webview-refbox-thread.h
+++ b/src/plugins/attic/webview-refbox/webview-refbox-thread.h
@@ -36,21 +36,26 @@ class WebviewRCLLRefBoxThread : public fawkes::Thread,
                                 public fawkes::ClockAspect,
                                 public fawkes::ConfigurableAspect,
                                 public fawkes::MongoDBAspect,
-                                public fawkes::WebviewAspect {
+                                public fawkes::WebviewAspect
+{
 public:
-  WebviewRCLLRefBoxThread();
-  virtual ~WebviewRCLLRefBoxThread();
+	WebviewRCLLRefBoxThread();
+	virtual ~WebviewRCLLRefBoxThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  WebviewRCLLRefBoxRequestProcessor *web_proc_;
+	WebviewRCLLRefBoxRequestProcessor *web_proc_;
 };
 
 #endif

--- a/src/plugins/ax12_gripper/ax12_gripper_plugin.cpp
+++ b/src/plugins/ax12_gripper/ax12_gripper_plugin.cpp
@@ -31,27 +31,29 @@ using namespace fawkes;
 /** Plugin to control gripper using Robotis servos
  * @author Nicolas Limpert
  */
-class AX12GripperPlugin : public fawkes::Plugin {
+class AX12GripperPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  AX12GripperPlugin(Configuration *config) : Plugin(config) {
-    std::string prefix = "/hardware/ax12_gripper/";
-    bool active = true;
-    try {
-      active = config->get_bool((prefix + "active").c_str());
-    } catch (Exception &e) {
-    } // ignored, assume enabled
+	AX12GripperPlugin(Configuration *config) : Plugin(config)
+	{
+		std::string prefix = "/hardware/ax12_gripper/";
+		bool        active = true;
+		try {
+			active = config->get_bool((prefix + "active").c_str());
+		} catch (Exception &e) {
+		} // ignored, assume enabled
 
-    if (active) {
-      // GripperAX12AThread * act_thread = new GripperAX12AThread(prefix);
-      // GripperSensorThread * sensor_thread = new GripperSensorThread();
-      // sensor_thread->add_act_thread(act_thread);
-      thread_list.push_back(new GripperAX12AThread(prefix));
-      // thread_list.push_back(sensor_thread);
-    }
-  }
+		if (active) {
+			// GripperAX12AThread * act_thread = new GripperAX12AThread(prefix);
+			// GripperSensorThread * sensor_thread = new GripperSensorThread();
+			// sensor_thread->add_act_thread(act_thread);
+			thread_list.push_back(new GripperAX12AThread(prefix));
+			// thread_list.push_back(sensor_thread);
+		}
+	}
 };
 
 PLUGIN_DESCRIPTION("AX12 Gripper Plugin")

--- a/src/plugins/ax12_gripper/ax12_gripper_thread.cpp
+++ b/src/plugins/ax12_gripper/ax12_gripper_thread.cpp
@@ -23,7 +23,6 @@
 
 #include "ax12_gripper_thread.h"
 
-#include <boost/lexical_cast.hpp>
 #include <config/change_handler.h>
 #include <core/threading/mutex_locker.h>
 #include <core/threading/read_write_lock.h>
@@ -34,6 +33,7 @@
 #include <interfaces/LedInterface.h>
 #include <utils/math/angle.h>
 
+#include <boost/lexical_cast.hpp>
 #include <cmath>
 #include <cstdarg>
 #include <unistd.h>
@@ -51,517 +51,496 @@ using namespace fawkes;
  */
 
 GripperAX12AThread::GripperAX12AThread(std::string &gripper_cfg_prefix)
-    : Thread("GripperAX12AThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT_EXEC),
+: Thread("GripperAX12AThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT_EXEC),
 #ifdef HAVE_TF
-      TransformAspect(TransformAspect::ONLY_PUBLISHER,
-                      std::string("GRIPPER AX12A").c_str()),
+  TransformAspect(TransformAspect::ONLY_PUBLISHER, std::string("GRIPPER AX12A").c_str()),
 #endif
-      BlackBoardInterfaceListener("GripperAX12AThread(%s)",
-                                  gripper_cfg_prefix.c_str()),
-      ConfigurationChangeHandler(gripper_cfg_prefix.c_str()) {
-  set_name("GripperAX12AThread()");
+  BlackBoardInterfaceListener("GripperAX12AThread(%s)", gripper_cfg_prefix.c_str()),
+  ConfigurationChangeHandler(gripper_cfg_prefix.c_str())
+{
+	set_name("GripperAX12AThread()");
 
-  __gripper_cfg_prefix = gripper_cfg_prefix;
-  //  __ptu_name           = ptu_name;
+	__gripper_cfg_prefix = gripper_cfg_prefix;
+	//  __ptu_name           = ptu_name;
 
-  // __ax12a = NULL;
+	// __ax12a = NULL;
 }
 
-void GripperAX12AThread::init() {
-  // __last_left = __last_right = 0.f;
-  float init_left_velocity = 0.f;
-  float init_right_velocity = 0.f;
+void
+GripperAX12AThread::init()
+{
+	// __last_left = __last_right = 0.f;
+	float init_left_velocity  = 0.f;
+	float init_right_velocity = 0.f;
 
-  config->add_change_handler(this);
+	config->add_change_handler(this);
 
-  load_config();
+	load_config();
 
-  load_left_pending = false;
-  load_right_pending = false;
+	load_left_pending  = false;
+	load_right_pending = false;
 
-  bool left_servo_found = false, right_servo_found = false,
-       z_servo_found = false;
+	bool left_servo_found = false, right_servo_found = false, z_servo_found = false;
 
-  __servo_if_right = blackboard->open_for_reading<DynamixelServoInterface>(
-      (__cfg_driver_prefix + "/" + __cfg_right_servo_id).c_str());
-  __servo_if_left = blackboard->open_for_reading<DynamixelServoInterface>(
-      (__cfg_driver_prefix + "/" + __cfg_left_servo_id).c_str());
+	__servo_if_right = blackboard->open_for_reading<DynamixelServoInterface>(
+	  (__cfg_driver_prefix + "/" + __cfg_right_servo_id).c_str());
+	__servo_if_left = blackboard->open_for_reading<DynamixelServoInterface>(
+	  (__cfg_driver_prefix + "/" + __cfg_left_servo_id).c_str());
 
-  __servo_if_left->read();
-  __servo_if_right->read();
+	__servo_if_left->read();
+	__servo_if_right->read();
 
-  right_servo_found = __servo_if_right->has_writer();
-  left_servo_found = __servo_if_left->has_writer();
-  if (!(left_servo_found && right_servo_found)) {
-    throw Exception("Left and/or right and/or z-servo not found: left: %i  "
-                    "right: %i, z: %i",
-                    left_servo_found, right_servo_found, z_servo_found);
-  }
+	right_servo_found = __servo_if_right->has_writer();
+	left_servo_found  = __servo_if_left->has_writer();
+	if (!(left_servo_found && right_servo_found)) {
+		throw Exception("Left and/or right and/or z-servo not found: left: %i  "
+		                "right: %i, z: %i",
+		                left_servo_found,
+		                right_servo_found,
+		                z_servo_found);
+	}
 
-  joystick_if_ = blackboard->open_for_reading<JoystickInterface>(
-      "Joystick", __cfg_ifid_joystick_.c_str());
+	joystick_if_ =
+	  blackboard->open_for_reading<JoystickInterface>("Joystick", __cfg_ifid_joystick_.c_str());
 
-  DynamixelServoInterface::SetSpeedMessage *vel_left =
-      new DynamixelServoInterface::SetSpeedMessage(
-          (unsigned int)(__cfg_max_speed * 0x3ff));
-  DynamixelServoInterface::SetSpeedMessage *vel_right =
-      new DynamixelServoInterface::SetSpeedMessage(
-          (unsigned int)(__cfg_max_speed * 0x3ff));
-  __servo_if_left->msgq_enqueue(vel_left);
-  __servo_if_right->msgq_enqueue(vel_right);
+	DynamixelServoInterface::SetSpeedMessage *vel_left =
+	  new DynamixelServoInterface::SetSpeedMessage((unsigned int)(__cfg_max_speed * 0x3ff));
+	DynamixelServoInterface::SetSpeedMessage *vel_right =
+	  new DynamixelServoInterface::SetSpeedMessage((unsigned int)(__cfg_max_speed * 0x3ff));
+	__servo_if_left->msgq_enqueue(vel_left);
+	__servo_if_right->msgq_enqueue(vel_right);
 
-  // Enable PreventAlarmShutdown on both servos
-  DynamixelServoInterface::SetPreventAlarmShutdownMessage *prevent_left_msg =
-      new DynamixelServoInterface::SetPreventAlarmShutdownMessage();
-  DynamixelServoInterface::SetPreventAlarmShutdownMessage *prevent_right_msg =
-      new DynamixelServoInterface::SetPreventAlarmShutdownMessage();
-  prevent_left_msg->set_enable_prevent_alarm_shutdown(false);
-  prevent_right_msg->set_enable_prevent_alarm_shutdown(false);
-  __servo_if_left->msgq_enqueue(prevent_left_msg);
-  __servo_if_right->msgq_enqueue(prevent_right_msg);
+	// Enable PreventAlarmShutdown on both servos
+	DynamixelServoInterface::SetPreventAlarmShutdownMessage *prevent_left_msg =
+	  new DynamixelServoInterface::SetPreventAlarmShutdownMessage();
+	DynamixelServoInterface::SetPreventAlarmShutdownMessage *prevent_right_msg =
+	  new DynamixelServoInterface::SetPreventAlarmShutdownMessage();
+	prevent_left_msg->set_enable_prevent_alarm_shutdown(false);
+	prevent_right_msg->set_enable_prevent_alarm_shutdown(false);
+	__servo_if_left->msgq_enqueue(prevent_left_msg);
+	__servo_if_right->msgq_enqueue(prevent_right_msg);
 
-  DynamixelServoInterface::SetTorqueLimitMessage *torque_left_msg =
-      new DynamixelServoInterface::SetTorqueLimitMessage();
-  DynamixelServoInterface::SetTorqueLimitMessage *torque_right_msg =
-      new DynamixelServoInterface::SetTorqueLimitMessage();
-  torque_left_msg->set_torque_limit(1023);
-  torque_right_msg->set_torque_limit(1023);
-  __servo_if_left->msgq_enqueue(torque_left_msg);
-  __servo_if_right->msgq_enqueue(torque_right_msg);
+	DynamixelServoInterface::SetTorqueLimitMessage *torque_left_msg =
+	  new DynamixelServoInterface::SetTorqueLimitMessage();
+	DynamixelServoInterface::SetTorqueLimitMessage *torque_right_msg =
+	  new DynamixelServoInterface::SetTorqueLimitMessage();
+	torque_left_msg->set_torque_limit(1023);
+	torque_right_msg->set_torque_limit(1023);
+	__servo_if_left->msgq_enqueue(torque_left_msg);
+	__servo_if_right->msgq_enqueue(torque_right_msg);
 
-  // Enable autorecovery for left and right servo
-  DynamixelServoInterface::SetAutorecoverEnabledMessage *recover_left_msg =
-      new DynamixelServoInterface::SetAutorecoverEnabledMessage();
-  DynamixelServoInterface::SetAutorecoverEnabledMessage *recover_right_msg =
-      new DynamixelServoInterface::SetAutorecoverEnabledMessage();
-  recover_left_msg->set_autorecover_enabled(false);
-  recover_right_msg->set_autorecover_enabled(false);
-  __servo_if_left->msgq_enqueue(recover_left_msg);
-  __servo_if_right->msgq_enqueue(recover_right_msg);
+	// Enable autorecovery for left and right servo
+	DynamixelServoInterface::SetAutorecoverEnabledMessage *recover_left_msg =
+	  new DynamixelServoInterface::SetAutorecoverEnabledMessage();
+	DynamixelServoInterface::SetAutorecoverEnabledMessage *recover_right_msg =
+	  new DynamixelServoInterface::SetAutorecoverEnabledMessage();
+	recover_left_msg->set_autorecover_enabled(false);
+	recover_right_msg->set_autorecover_enabled(false);
+	__servo_if_left->msgq_enqueue(recover_left_msg);
+	__servo_if_right->msgq_enqueue(recover_right_msg);
 
-  // If you have more than one interface: catch exception and close them!
-  std::string bbid = "Gripper AX12";
-  __gripper_if =
-      blackboard->open_for_writing<AX12GripperInterface>(bbid.c_str());
-  __gripper_if->set_calibrated(true);
-  __gripper_if->set_min_left(__cfg_left_min);
-  __gripper_if->set_max_left(__cfg_left_max);
-  __gripper_if->set_min_right(__cfg_right_min);
-  __gripper_if->set_max_right(__cfg_right_max);
-  __gripper_if->set_left_margin(__cfg_left_margin);
-  __gripper_if->set_right_margin(__cfg_right_margin);
-  __gripper_if->set_max_left_velocity(
-      0); //__ax12a->get_max_supported_speed(__cfg_left_servo_id));
-  __gripper_if->set_max_right_velocity(
-      0); //__ax12a->get_max_supported_speed(__cfg_right_servo_id));
-  __gripper_if->set_left_velocity(init_left_velocity);
-  __gripper_if->set_right_velocity(init_right_velocity);
-  __gripper_if->write();
+	// If you have more than one interface: catch exception and close them!
+	std::string bbid = "Gripper AX12";
+	__gripper_if     = blackboard->open_for_writing<AX12GripperInterface>(bbid.c_str());
+	__gripper_if->set_calibrated(true);
+	__gripper_if->set_min_left(__cfg_left_min);
+	__gripper_if->set_max_left(__cfg_left_max);
+	__gripper_if->set_min_right(__cfg_right_min);
+	__gripper_if->set_max_right(__cfg_right_max);
+	__gripper_if->set_left_margin(__cfg_left_margin);
+	__gripper_if->set_right_margin(__cfg_right_margin);
+	__gripper_if->set_max_left_velocity(0); //__ax12a->get_max_supported_speed(__cfg_left_servo_id));
+	__gripper_if->set_max_right_velocity(
+	  0); //__ax12a->get_max_supported_speed(__cfg_right_servo_id));
+	__gripper_if->set_left_velocity(init_left_velocity);
+	__gripper_if->set_right_velocity(init_right_velocity);
+	__gripper_if->write();
 
-  __led_if = blackboard->open_for_writing<LedInterface>(bbid.c_str());
+	__led_if = blackboard->open_for_writing<LedInterface>(bbid.c_str());
 
-  std::string leftid = __cfg_gripper_name + " left";
-  __leftjoint_if = blackboard->open_for_writing<JointInterface>(leftid.c_str());
-  __leftjoint_if->set_position(__last_left);
-  __leftjoint_if->set_velocity(init_left_velocity);
-  __leftjoint_if->write();
+	std::string leftid = __cfg_gripper_name + " left";
+	__leftjoint_if     = blackboard->open_for_writing<JointInterface>(leftid.c_str());
+	__leftjoint_if->set_position(__last_left);
+	__leftjoint_if->set_velocity(init_left_velocity);
+	__leftjoint_if->write();
 
-  std::string rightid = __cfg_gripper_name + " right";
-  __rightjoint_if =
-      blackboard->open_for_writing<JointInterface>(rightid.c_str());
-  __rightjoint_if->set_position(__last_right);
-  __rightjoint_if->set_velocity(init_right_velocity);
-  __rightjoint_if->write();
+	std::string rightid = __cfg_gripper_name + " right";
+	__rightjoint_if     = blackboard->open_for_writing<JointInterface>(rightid.c_str());
+	__rightjoint_if->set_position(__last_right);
+	__rightjoint_if->set_velocity(init_right_velocity);
+	__rightjoint_if->write();
 
-  if (__cfg_goto_zero_start) {
-    goto_gripper(__cfg_left_start, __cfg_right_start);
-  }
+	if (__cfg_goto_zero_start) {
+		goto_gripper(__cfg_left_start, __cfg_right_start);
+	}
 
-  bbil_add_message_interface(__gripper_if);
-  bbil_add_message_interface(__leftjoint_if);
-  bbil_add_message_interface(__rightjoint_if);
-  blackboard->register_listener(this);
+	bbil_add_message_interface(__gripper_if);
+	bbil_add_message_interface(__leftjoint_if);
+	bbil_add_message_interface(__rightjoint_if);
+	blackboard->register_listener(this);
 
-  cur_torque_ = 1.0;
+	cur_torque_ = 1.0;
 
-  // initialize motion_start_timestamp
-  motion_start_timestamp_ = fawkes::Time();
-  slap_left_pending_ = false;
-  slap_right_pending_ = false;
+	// initialize motion_start_timestamp
+	motion_start_timestamp_ = fawkes::Time();
+	slap_left_pending_      = false;
+	slap_right_pending_     = false;
 
 #ifdef USE_TIMETRACKER
-  __tt.reset(new TimeTracker());
-  __tt_count = 0;
-  __ttc_read_sensor = __tt->add_class("Read Sensor");
+	__tt.reset(new TimeTracker());
+	__tt_count        = 0;
+	__ttc_read_sensor = __tt->add_class("Read Sensor");
 #endif
 }
 
-void GripperAX12AThread::finalize() {
-  // make sure that no servo continues movement
-  stop_motion();
-  blackboard->unregister_listener(this);
-  blackboard->close(__gripper_if);
-  blackboard->close(__led_if);
-  blackboard->close(__leftjoint_if);
-  blackboard->close(__rightjoint_if);
-  blackboard->close(__servo_if_right);
-  blackboard->close(__servo_if_left);
-  config->rem_change_handler(this);
+void
+GripperAX12AThread::finalize()
+{
+	// make sure that no servo continues movement
+	stop_motion();
+	blackboard->unregister_listener(this);
+	blackboard->close(__gripper_if);
+	blackboard->close(__led_if);
+	blackboard->close(__leftjoint_if);
+	blackboard->close(__rightjoint_if);
+	blackboard->close(__servo_if_right);
+	blackboard->close(__servo_if_left);
+	config->rem_change_handler(this);
 }
 
-void GripperAX12AThread::loop() {
-  // __gripper_if->set_final(__wt->is_final());
+void
+GripperAX12AThread::loop()
+{
+	// __gripper_if->set_final(__wt->is_final());
 
-  if (!cfg_mutex_.try_lock()) {
-    logger->log_info(name(), "Skipping loop(), mutex locked");
-    return; // If I cant lock it its locked already (config is changing/reinit
-            // in progress)
-  } else {
-    // read data from interfaces
-    __servo_if_left->read();
-    __servo_if_right->read();
+	if (!cfg_mutex_.try_lock()) {
+		logger->log_info(name(), "Skipping loop(), mutex locked");
+		return; // If I cant lock it its locked already (config is changing/reinit
+		        // in progress)
+	} else {
+		// read data from interfaces
+		__servo_if_left->read();
+		__servo_if_right->read();
 
-    fawkes::Time now(clock);
+		fawkes::Time now(clock);
 
-    // load is given in values from 0 - 1023 is ccw load, 1024 - 2047 is cw load
-    // but we are only interested in overall load
-    if (load_left_pending &&
-        (__servo_if_left->load() & 0x3ff) >= (__cfg_max_load * 0x3ff)) {
-      DynamixelServoInterface::StopMessage *stop_message =
-          new DynamixelServoInterface::StopMessage();
-      __servo_if_left->msgq_enqueue(stop_message);
-      load_left_pending = false;
-    }
-    if (load_right_pending &&
-        (__servo_if_right->load() & 0x3ff) >= (__cfg_max_load * 0x3ff)) {
-      DynamixelServoInterface::StopMessage *stop_message =
-          new DynamixelServoInterface::StopMessage();
-      __servo_if_right->msgq_enqueue(stop_message);
-      load_right_pending = false;
-    }
-    if (center_pending && __servo_if_left->is_final() &&
-        __servo_if_right->is_final()) {
-      center_pending = false;
-    }
+		// load is given in values from 0 - 1023 is ccw load, 1024 - 2047 is cw load
+		// but we are only interested in overall load
+		if (load_left_pending && (__servo_if_left->load() & 0x3ff) >= (__cfg_max_load * 0x3ff)) {
+			DynamixelServoInterface::StopMessage *stop_message =
+			  new DynamixelServoInterface::StopMessage();
+			__servo_if_left->msgq_enqueue(stop_message);
+			load_left_pending = false;
+		}
+		if (load_right_pending && (__servo_if_right->load() & 0x3ff) >= (__cfg_max_load * 0x3ff)) {
+			DynamixelServoInterface::StopMessage *stop_message =
+			  new DynamixelServoInterface::StopMessage();
+			__servo_if_right->msgq_enqueue(stop_message);
+			load_right_pending = false;
+		}
+		if (center_pending && __servo_if_left->is_final() && __servo_if_right->is_final()) {
+			center_pending = false;
+		}
 
-    bool is_final = now > (motion_start_timestamp_ + 0.5) &&
-                    __servo_if_left->is_final() &&
-                    __servo_if_right->is_final() && !z_alignment_pending;
+		bool is_final = now > (motion_start_timestamp_ + 0.5) && __servo_if_left->is_final()
+		                && __servo_if_right->is_final() && !z_alignment_pending;
 
-    if (slap_left_pending_) {
-      // the left servo is overriding the middle when it crosses the
-      // angle values from less than 0 to greater than 0
-      bool left_done = __servo_if_left->angle() >= 0.;
-      is_final &= left_done;
-      slap_left_pending_ = !left_done;
-    }
-    if (slap_right_pending_) {
-      // the right servo is overriding the middle when it crosses the
-      // angle values from greater than 0 to less than 0
-      bool right_done = __servo_if_right->angle() <= 0.;
-      is_final &= right_done;
-      slap_right_pending_ = !right_done;
-    }
+		if (slap_left_pending_) {
+			// the left servo is overriding the middle when it crosses the
+			// angle values from less than 0 to greater than 0
+			bool left_done = __servo_if_left->angle() >= 0.;
+			is_final &= left_done;
+			slap_left_pending_ = !left_done;
+		}
+		if (slap_right_pending_) {
+			// the right servo is overriding the middle when it crosses the
+			// angle values from greater than 0 to less than 0
+			bool right_done = __servo_if_right->angle() <= 0.;
+			is_final &= right_done;
+			slap_right_pending_ = !right_done;
+		}
 
-    __gripper_if->set_final(is_final);
+		__gripper_if->set_final(is_final);
 
-    // if the torque is disabled we have to track the position of the servos
-    // and constantly send it as goal poses.
-    // Otherwise resetting the torque_limit and trying to go to a new pose
-    // leads to a full speed move of the servos.
-    // This is probably a bug in the AX12 firmware.
-    if (cur_torque_ < 1.0) {
-      bool is_final = (__servo_if_left->speed() & 0x3FF) < 32;
-      is_final &= (__servo_if_right->speed() & 0x3FF) < 32;
-      is_final &= !z_alignment_pending;
-      is_final &= now > (motion_start_timestamp_ + 0.5);
-      __gripper_if->set_final(is_final);
-      if (is_final == false) {
-        goto_gripper(__servo_if_left->angle(), __servo_if_right->angle());
-      }
-    }
+		// if the torque is disabled we have to track the position of the servos
+		// and constantly send it as goal poses.
+		// Otherwise resetting the torque_limit and trying to go to a new pose
+		// leads to a full speed move of the servos.
+		// This is probably a bug in the AX12 firmware.
+		if (cur_torque_ < 1.0) {
+			bool is_final = (__servo_if_left->speed() & 0x3FF) < 32;
+			is_final &= (__servo_if_right->speed() & 0x3FF) < 32;
+			is_final &= !z_alignment_pending;
+			is_final &= now > (motion_start_timestamp_ + 0.5);
+			__gripper_if->set_final(is_final);
+			if (is_final == false) {
+				goto_gripper(__servo_if_left->angle(), __servo_if_right->angle());
+			}
+		}
 
-    while (!__gripper_if->msgq_empty()) {
-      if (__gripper_if
-              ->msgq_first_is<AX12GripperInterface::CalibrateMessage>()) {
-        // ignored
+		while (!__gripper_if->msgq_empty()) {
+			if (__gripper_if->msgq_first_is<AX12GripperInterface::CalibrateMessage>()) {
+				// ignored
 
-      } else if (__gripper_if
-                     ->msgq_first_is<AX12GripperInterface::GotoMessage>()) {
-        AX12GripperInterface::GotoMessage *msg = __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::GotoMessage>()) {
+				AX12GripperInterface::GotoMessage *msg = __gripper_if->msgq_first(msg);
 
-        goto_gripper(msg->left(), msg->right());
-        __gripper_if->set_msgid(msg->id());
-        __gripper_if->set_final(false);
+				goto_gripper(msg->left(), msg->right());
+				__gripper_if->set_msgid(msg->id());
+				__gripper_if->set_final(false);
 
-      } else if (__gripper_if->msgq_first_is<
-                     AX12GripperInterface::TimedGotoMessage>()) {
-        AX12GripperInterface::TimedGotoMessage *msg =
-            __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::TimedGotoMessage>()) {
+				AX12GripperInterface::TimedGotoMessage *msg = __gripper_if->msgq_first(msg);
 
-        goto_gripper_timed(msg->left(), msg->right(), msg->time_sec());
-        __gripper_if->set_msgid(msg->id());
-        __gripper_if->set_final(false);
+				goto_gripper_timed(msg->left(), msg->right(), msg->time_sec());
+				__gripper_if->set_msgid(msg->id());
+				__gripper_if->set_final(false);
 
-      } else if (__gripper_if
-                     ->msgq_first_is<AX12GripperInterface::ParkMessage>()) {
-        AX12GripperInterface::ParkMessage *msg = __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::ParkMessage>()) {
+				AX12GripperInterface::ParkMessage *msg = __gripper_if->msgq_first(msg);
 
-        goto_gripper(0, 0);
-        __gripper_if->set_msgid(msg->id());
-        __gripper_if->set_final(false);
+				goto_gripper(0, 0);
+				__gripper_if->set_msgid(msg->id());
+				__gripper_if->set_final(false);
 
-      } else if (__gripper_if->msgq_first_is<
-                     AX12GripperInterface::SetEnabledMessage>()) {
-        AX12GripperInterface::SetEnabledMessage *msg =
-            __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::SetEnabledMessage>()) {
+				AX12GripperInterface::SetEnabledMessage *msg = __gripper_if->msgq_first(msg);
 
-        set_enabled(msg->is_enabled());
+				set_enabled(msg->is_enabled());
 
-      } else if (__gripper_if->msgq_first_is<
-                     AX12GripperInterface::SetVelocityMessage>()) {
-        AX12GripperInterface::SetVelocityMessage *msg =
-            __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::SetVelocityMessage>()) {
+				AX12GripperInterface::SetVelocityMessage *msg = __gripper_if->msgq_first(msg);
 
-        if (msg->left_velocity() > __gripper_if->max_left_velocity()) {
-          logger->log_warn(
-              name(), "Desired left velocity %f too high, max is %f",
-              msg->left_velocity(), __gripper_if->max_left_velocity());
-        } else if (msg->right_velocity() > __gripper_if->max_right_velocity()) {
-          logger->log_warn(
-              name(), "Desired right velocity %f too high, max is %f",
-              msg->right_velocity(), __gripper_if->max_right_velocity());
-        } else {
-          set_velocities(msg->left_velocity(), msg->right_velocity());
-        }
+				if (msg->left_velocity() > __gripper_if->max_left_velocity()) {
+					logger->log_warn(name(),
+					                 "Desired left velocity %f too high, max is %f",
+					                 msg->left_velocity(),
+					                 __gripper_if->max_left_velocity());
+				} else if (msg->right_velocity() > __gripper_if->max_right_velocity()) {
+					logger->log_warn(name(),
+					                 "Desired right velocity %f too high, max is %f",
+					                 msg->right_velocity(),
+					                 __gripper_if->max_right_velocity());
+				} else {
+					set_velocities(msg->left_velocity(), msg->right_velocity());
+				}
 
-      } else if (__gripper_if
-                     ->msgq_first_is<AX12GripperInterface::OpenMessage>()) {
-        AX12GripperInterface::OpenMessage *msg = __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::OpenMessage>()) {
+				AX12GripperInterface::OpenMessage *msg = __gripper_if->msgq_first(msg);
 
-        set_torque(1.0);
-        goto_gripper(__cfg_left_open_angle + msg->offset(),
-                     __cfg_right_open_angle + msg->offset());
+				set_torque(1.0);
+				goto_gripper(__cfg_left_open_angle + msg->offset(), __cfg_right_open_angle + msg->offset());
 
-      } else if (__gripper_if->msgq_first_is<
-                     AX12GripperInterface::ModifyOpeningAngleByMessage>()) {
-        AX12GripperInterface::ModifyOpeningAngleByMessage *msg =
-            __gripper_if->msgq_first(msg);
-        const float angle_difference = msg->angle_difference();
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::ModifyOpeningAngleByMessage>()) {
+				AX12GripperInterface::ModifyOpeningAngleByMessage *msg = __gripper_if->msgq_first(msg);
+				const float angle_difference                           = msg->angle_difference();
 
-        set_torque(1.0);
-        goto_gripper(__servo_if_left->angle() - angle_difference,
-                     __servo_if_right->angle() + angle_difference);
+				set_torque(1.0);
+				goto_gripper(__servo_if_left->angle() - angle_difference,
+				             __servo_if_right->angle() + angle_difference);
 
-      } else if (__gripper_if
-                     ->msgq_first_is<AX12GripperInterface::CloseMessage>()) {
-        AX12GripperInterface::CloseMessage *msg = __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::CloseMessage>()) {
+				AX12GripperInterface::CloseMessage *msg = __gripper_if->msgq_first(msg);
 
-        goto_gripper(__cfg_left_close_angle, __cfg_right_close_angle);
-        // set_move_load_pending(true);
+				goto_gripper(__cfg_left_close_angle, __cfg_right_close_angle);
+				// set_move_load_pending(true);
 
-      } else if (__gripper_if->msgq_first_is<
-                     AX12GripperInterface::CloseLoadMessage>()) {
-        AX12GripperInterface::CloseLoadMessage *msg =
-            __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::CloseLoadMessage>()) {
+				AX12GripperInterface::CloseLoadMessage *msg = __gripper_if->msgq_first(msg);
 
-        goto_gripper_load(__cfg_left_close_load_angle,
-                          __cfg_right_close_load_angle);
-        // set_move_load_pending(true);
+				goto_gripper_load(__cfg_left_close_load_angle, __cfg_right_close_load_angle);
+				// set_move_load_pending(true);
 
-      } else if (__gripper_if->msgq_first_is<
-                     AX12GripperInterface::Open_AngleMessage>()) {
-        AX12GripperInterface::Open_AngleMessage *msg =
-            __gripper_if->msgq_first(msg);
-        float angle_part = msg->angle() / 2.;
-        goto_gripper(-angle_part, angle_part);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::Open_AngleMessage>()) {
+				AX12GripperInterface::Open_AngleMessage *msg        = __gripper_if->msgq_first(msg);
+				float                                    angle_part = msg->angle() / 2.;
+				goto_gripper(-angle_part, angle_part);
 
-      } else if (__gripper_if->msgq_first_is<
-                     AX12GripperInterface::SetMarginMessage>()) {
-        AX12GripperInterface::SetMarginMessage *msg =
-            __gripper_if->msgq_first(msg);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::SetMarginMessage>()) {
+				AX12GripperInterface::SetMarginMessage *msg = __gripper_if->msgq_first(msg);
 
-        set_margins(msg->left_margin(), msg->right_margin());
-        __gripper_if->set_left_margin(msg->left_margin());
-        __gripper_if->set_right_margin(msg->right_margin());
+				set_margins(msg->left_margin(), msg->right_margin());
+				__gripper_if->set_left_margin(msg->left_margin());
+				__gripper_if->set_right_margin(msg->right_margin());
 
-      } else if (__gripper_if
-                     ->msgq_first_is<AX12GripperInterface::CenterMessage>()) {
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::CenterMessage>()) {
+				// The target_opening_angle has to be smaller than the opening_angle
+				// because the servos tend to open a little when only the opening_angle
+				// is used.
+				float target_opening_angle_per_servo =
+				  (get_opening_angle() - __cfg_center_angle_correction_amount) / 2.;
 
-        // The target_opening_angle has to be smaller than the opening_angle
-        // because the servos tend to open a little when only the opening_angle
-        // is used.
-        float target_opening_angle_per_servo =
-            (get_opening_angle() - __cfg_center_angle_correction_amount) / 2.;
+				goto_gripper(__servo_if_left->angle()
+				               - (__servo_if_left->angle() + target_opening_angle_per_servo),
+				             __servo_if_right->angle()
+				               - (__servo_if_right->angle() - target_opening_angle_per_servo));
+				center_pending = true;
 
-        goto_gripper(
-            __servo_if_left->angle() -
-                (__servo_if_left->angle() + target_opening_angle_per_servo),
-            __servo_if_right->angle() -
-                (__servo_if_right->angle() - target_opening_angle_per_servo));
-        center_pending = true;
+				motion_start_timestamp_ = fawkes::Time(clock);
 
-        motion_start_timestamp_ = fawkes::Time(clock);
+				__gripper_if->set_final(false);
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::SetTorqueMessage>()) {
+				AX12GripperInterface::SetTorqueMessage *msg = __gripper_if->msgq_first(msg);
 
-        __gripper_if->set_final(false);
-      } else if (__gripper_if->msgq_first_is<
-                     AX12GripperInterface::SetTorqueMessage>()) {
-        AX12GripperInterface::SetTorqueMessage *msg =
-            __gripper_if->msgq_first(msg);
+				motion_start_timestamp_ = fawkes::Time(clock);
+				set_torque(msg->torque());
 
-        motion_start_timestamp_ = fawkes::Time(clock);
-        set_torque(msg->torque());
+			} else if (__gripper_if->msgq_first_is<AX12GripperInterface::SlapMessage>()) {
+				AX12GripperInterface::SlapMessage *msg = __gripper_if->msgq_first(msg);
 
-      } else if (__gripper_if
-                     ->msgq_first_is<AX12GripperInterface::SlapMessage>()) {
-        AX12GripperInterface::SlapMessage *msg = __gripper_if->msgq_first(msg);
+				if (msg->slapmode() == AX12GripperInterface::SlapMode::LEFT) {
+					// open the gripper and disable torque on the left
+					DynamixelServoInterface::SetTorqueLimitMessage *torque_left_msg =
+					  new DynamixelServoInterface::SetTorqueLimitMessage();
+					DynamixelServoInterface::SetTorqueLimitMessage *torque_right_msg =
+					  new DynamixelServoInterface::SetTorqueLimitMessage();
+					torque_left_msg->set_torque_limit(0);
+					torque_right_msg->set_torque_limit(1023);
+					__servo_if_left->msgq_enqueue(torque_left_msg);
+					__servo_if_right->msgq_enqueue(torque_right_msg);
 
-        if (msg->slapmode() == AX12GripperInterface::SlapMode::LEFT) {
-          // open the gripper and disable torque on the left
-          DynamixelServoInterface::SetTorqueLimitMessage *torque_left_msg =
-              new DynamixelServoInterface::SetTorqueLimitMessage();
-          DynamixelServoInterface::SetTorqueLimitMessage *torque_right_msg =
-              new DynamixelServoInterface::SetTorqueLimitMessage();
-          torque_left_msg->set_torque_limit(0);
-          torque_right_msg->set_torque_limit(1023);
-          __servo_if_left->msgq_enqueue(torque_left_msg);
-          __servo_if_right->msgq_enqueue(torque_right_msg);
+					goto_gripper(__cfg_left_open_angle, __cfg_right_open_angle);
 
-          goto_gripper(__cfg_left_open_angle, __cfg_right_open_angle);
+					motion_start_timestamp_ = fawkes::Time(clock);
+					slap_left_pending_      = true;
 
-          motion_start_timestamp_ = fawkes::Time(clock);
-          slap_left_pending_ = true;
+				} else if (msg->slapmode() == AX12GripperInterface::SlapMode::RIGHT) {
+					DynamixelServoInterface::SetTorqueLimitMessage *torque_left_msg =
+					  new DynamixelServoInterface::SetTorqueLimitMessage();
+					DynamixelServoInterface::SetTorqueLimitMessage *torque_right_msg =
+					  new DynamixelServoInterface::SetTorqueLimitMessage();
+					torque_left_msg->set_torque_limit(1023);
+					torque_right_msg->set_torque_limit(0);
+					__servo_if_left->msgq_enqueue(torque_left_msg);
+					__servo_if_right->msgq_enqueue(torque_right_msg);
+					// open the gripper and disable torque on the right
+					goto_gripper(__cfg_left_open_angle, __cfg_right_open_angle);
 
-        } else if (msg->slapmode() == AX12GripperInterface::SlapMode::RIGHT) {
-          DynamixelServoInterface::SetTorqueLimitMessage *torque_left_msg =
-              new DynamixelServoInterface::SetTorqueLimitMessage();
-          DynamixelServoInterface::SetTorqueLimitMessage *torque_right_msg =
-              new DynamixelServoInterface::SetTorqueLimitMessage();
-          torque_left_msg->set_torque_limit(1023);
-          torque_right_msg->set_torque_limit(0);
-          __servo_if_left->msgq_enqueue(torque_left_msg);
-          __servo_if_right->msgq_enqueue(torque_right_msg);
-          // open the gripper and disable torque on the right
-          goto_gripper(__cfg_left_open_angle, __cfg_right_open_angle);
+					motion_start_timestamp_ = fawkes::Time(clock);
+					slap_right_pending_     = true;
 
-          motion_start_timestamp_ = fawkes::Time(clock);
-          slap_right_pending_ = true;
+				} else {
+					logger->log_error(name(), "SlapMessage received but no side given.");
+				}
 
-        } else {
-          logger->log_error(name(), "SlapMessage received but no side given.");
-        }
+			} else {
+				logger->log_warn(name(), "Unknown message received");
+			}
 
-      } else {
-        logger->log_warn(name(), "Unknown message received");
-      }
+			__gripper_if->msgq_pop();
+		}
 
-      __gripper_if->msgq_pop();
-    }
+		joystick_if_->read();
 
-    joystick_if_->read();
+		if (joystick_if_->pressed_buttons() & JoystickInterface::BUTTON_13) {
+			set_torque(1);
+			goto_gripper(__cfg_left_open_angle, __cfg_right_open_angle);
+		} else if (joystick_if_->pressed_buttons() & JoystickInterface::BUTTON_12) {
+			set_torque(0);
+			//        goto_gripper(__cfg_left_close_angle, __cfg_right_close_angle);
+		}
+		__gripper_if->set_angle(get_opening_angle());
+		__gripper_if->set_holds_puck(holds_puck());
 
-    if (joystick_if_->pressed_buttons() & JoystickInterface::BUTTON_13) {
-      set_torque(1);
-      goto_gripper(__cfg_left_open_angle, __cfg_right_open_angle);
-    } else if (joystick_if_->pressed_buttons() & JoystickInterface::BUTTON_12) {
-      set_torque(0);
-      //        goto_gripper(__cfg_left_close_angle, __cfg_right_close_angle);
-    }
-    __gripper_if->set_angle(get_opening_angle());
-    __gripper_if->set_holds_puck(holds_puck());
-
-    unsigned int left_load, right_load;
-    get_loads(left_load, right_load);
-    __gripper_if->set_left_load(left_load & 0x400 ? -((int)left_load & 0x3ff)
-                                                  : (int)left_load);
-    __gripper_if->set_right_load(right_load & 0x400 ? -((int)right_load & 0x3ff)
-                                                    : (int)right_load);
-    __gripper_if->write();
-  }
-  cfg_mutex_.unlock();
+		unsigned int left_load, right_load;
+		get_loads(left_load, right_load);
+		__gripper_if->set_left_load(left_load & 0x400 ? -((int)left_load & 0x3ff) : (int)left_load);
+		__gripper_if->set_right_load(right_load & 0x400 ? -((int)right_load & 0x3ff) : (int)right_load);
+		__gripper_if->write();
+	}
+	cfg_mutex_.unlock();
 }
 
-bool GripperAX12AThread::bb_interface_message_received(
-    Interface *interface, Message *message) throw() {
-  if (message->is_of_type<AX12GripperInterface::StopLeftMessage>()) {
-    stop_left();
-    return false; // do not enqueue StopMessage
-  } else if (message->is_of_type<AX12GripperInterface::StopRightMessage>()) {
-    stop_right();
-    return false; // do not enqueue StopMessage
-  } else if (message->is_of_type<AX12GripperInterface::StopMessage>()) {
-    stop_motion();
-    return false; // do not enqueue StopMessage
-  } else if (message->is_of_type<AX12GripperInterface::FlushMessage>()) {
-    stop_motion();
-    logger->log_info(name(), "Flushing message queue");
-    __gripper_if->msgq_flush();
-    return false;
-  } else {
-    logger->log_info(name(), "Received message of type %s, enqueueing",
-                     message->type());
-    return true;
-  }
-  return true;
+bool
+GripperAX12AThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+{
+	if (message->is_of_type<AX12GripperInterface::StopLeftMessage>()) {
+		stop_left();
+		return false; // do not enqueue StopMessage
+	} else if (message->is_of_type<AX12GripperInterface::StopRightMessage>()) {
+		stop_right();
+		return false; // do not enqueue StopMessage
+	} else if (message->is_of_type<AX12GripperInterface::StopMessage>()) {
+		stop_motion();
+		return false; // do not enqueue StopMessage
+	} else if (message->is_of_type<AX12GripperInterface::FlushMessage>()) {
+		stop_motion();
+		logger->log_info(name(), "Flushing message queue");
+		__gripper_if->msgq_flush();
+		return false;
+	} else {
+		logger->log_info(name(), "Received message of type %s, enqueueing", message->type());
+		return true;
+	}
+	return true;
 }
 
 /** Enable or disable servo.
  * @param enabled true to enable servos, false to turn them off
  */
-void GripperAX12AThread::set_enabled(bool enabled) {
-  DynamixelServoInterface::SetEnabledMessage *ena_left =
-      new DynamixelServoInterface::SetEnabledMessage(enabled);
-  DynamixelServoInterface::SetEnabledMessage *ena_right =
-      new DynamixelServoInterface::SetEnabledMessage(enabled);
-  __servo_if_right->msgq_enqueue(ena_left);
-  __servo_if_left->msgq_enqueue(ena_right);
+void
+GripperAX12AThread::set_enabled(bool enabled)
+{
+	DynamixelServoInterface::SetEnabledMessage *ena_left =
+	  new DynamixelServoInterface::SetEnabledMessage(enabled);
+	DynamixelServoInterface::SetEnabledMessage *ena_right =
+	  new DynamixelServoInterface::SetEnabledMessage(enabled);
+	__servo_if_right->msgq_enqueue(ena_left);
+	__servo_if_left->msgq_enqueue(ena_right);
 }
 
 /** Stop currently running left motion. */
-void GripperAX12AThread::stop_left() {
-  DynamixelServoInterface::StopMessage *stop_message =
-      new DynamixelServoInterface::StopMessage();
-  __servo_if_left->msgq_enqueue(stop_message);
+void
+GripperAX12AThread::stop_left()
+{
+	DynamixelServoInterface::StopMessage *stop_message = new DynamixelServoInterface::StopMessage();
+	__servo_if_left->msgq_enqueue(stop_message);
 }
 
 /** Stop currently running right motion. */
-void GripperAX12AThread::stop_right() {
-  DynamixelServoInterface::StopMessage *stop_message =
-      new DynamixelServoInterface::StopMessage();
-  __servo_if_left->msgq_enqueue(stop_message);
+void
+GripperAX12AThread::stop_right()
+{
+	DynamixelServoInterface::StopMessage *stop_message = new DynamixelServoInterface::StopMessage();
+	__servo_if_left->msgq_enqueue(stop_message);
 }
 
 /** Stop currently running motion. */
-void GripperAX12AThread::stop_motion() {
-  stop_left();
-  stop_right();
+void
+GripperAX12AThread::stop_motion()
+{
+	stop_left();
+	stop_right();
 }
 
 /** Goto desired left/right values.
  * @param left left in radians
  * @param right right in radians
  */
-void GripperAX12AThread::goto_gripper(float left, float right) {
-  __target_left = left;
-  __target_right = right;
-  DynamixelServoInterface::GotoMessage *goto_left =
-      new DynamixelServoInterface::GotoMessage(left);
-  DynamixelServoInterface::GotoMessage *goto_right =
-      new DynamixelServoInterface::GotoMessage(right);
+void
+GripperAX12AThread::goto_gripper(float left, float right)
+{
+	__target_left                                   = left;
+	__target_right                                  = right;
+	DynamixelServoInterface::GotoMessage *goto_left = new DynamixelServoInterface::GotoMessage(left);
+	DynamixelServoInterface::GotoMessage *goto_right =
+	  new DynamixelServoInterface::GotoMessage(right);
 
-  __servo_if_left->msgq_enqueue(goto_left);
-  __servo_if_right->msgq_enqueue(goto_right);
+	__servo_if_left->msgq_enqueue(goto_left);
+	__servo_if_right->msgq_enqueue(goto_right);
 }
 
 /** Goto desired left/right values until given max_load (by config).
  * @param left left in radians
  * @param right right in radians
  */
-void GripperAX12AThread::goto_gripper_load(float left, float right) {
-  goto_gripper(left, right);
-  load_left_pending = true;
-  load_right_pending = true;
+void
+GripperAX12AThread::goto_gripper_load(float left, float right)
+{
+	goto_gripper(left, right);
+	load_left_pending  = true;
+	load_right_pending = true;
 }
 
 /** Goto desired left/right values in a specified time.
@@ -569,29 +548,32 @@ void GripperAX12AThread::goto_gripper_load(float left, float right) {
  * @param right right in radians
  * @param time_sec time when to reach the desired left/right values
  */
-void GripperAX12AThread::goto_gripper_timed(float left, float right,
-                                            float time_sec) {
-  DynamixelServoInterface::TimedGotoMessage *goto_timed_left =
-      new DynamixelServoInterface::TimedGotoMessage(time_sec, left);
-  DynamixelServoInterface::TimedGotoMessage *goto_timed_right =
-      new DynamixelServoInterface::TimedGotoMessage(time_sec, right);
+void
+GripperAX12AThread::goto_gripper_timed(float left, float right, float time_sec)
+{
+	DynamixelServoInterface::TimedGotoMessage *goto_timed_left =
+	  new DynamixelServoInterface::TimedGotoMessage(time_sec, left);
+	DynamixelServoInterface::TimedGotoMessage *goto_timed_right =
+	  new DynamixelServoInterface::TimedGotoMessage(time_sec, right);
 
-  __servo_if_left->msgq_enqueue(goto_timed_left);
-  __servo_if_right->msgq_enqueue(goto_timed_right);
+	__servo_if_left->msgq_enqueue(goto_timed_left);
+	__servo_if_right->msgq_enqueue(goto_timed_right);
 }
 
 /** Set desired velocities.
  * @param left_vel left velocity
  * @param right_vel right velocity
  */
-void GripperAX12AThread::set_velocities(float left_vel, float right_vel) {
-  DynamixelServoInterface::SetVelocityMessage *left_vel_message =
-      new DynamixelServoInterface::SetVelocityMessage(left_vel);
-  DynamixelServoInterface::SetVelocityMessage *right_vel_message =
-      new DynamixelServoInterface::SetVelocityMessage(right_vel);
+void
+GripperAX12AThread::set_velocities(float left_vel, float right_vel)
+{
+	DynamixelServoInterface::SetVelocityMessage *left_vel_message =
+	  new DynamixelServoInterface::SetVelocityMessage(left_vel);
+	DynamixelServoInterface::SetVelocityMessage *right_vel_message =
+	  new DynamixelServoInterface::SetVelocityMessage(right_vel);
 
-  __servo_if_left->msgq_enqueue(left_vel_message);
-  __servo_if_right->msgq_enqueue(right_vel_message);
+	__servo_if_left->msgq_enqueue(left_vel_message);
+	__servo_if_right->msgq_enqueue(right_vel_message);
 }
 
 // /** Set desired velocities normalized.
@@ -608,259 +590,254 @@ void GripperAX12AThread::set_velocities(float left_vel, float right_vel) {
 
 /** Get current loads.
  */
-void GripperAX12AThread::get_loads(unsigned int &left, unsigned int &right) {
-  left = __servo_if_left->load();
-  right = __servo_if_right->load();
+void
+GripperAX12AThread::get_loads(unsigned int &left, unsigned int &right)
+{
+	left  = __servo_if_left->load();
+	right = __servo_if_right->load();
 }
 
 /** Get current velocities.
  * @param left_vel upon return contains current left velocity
  * @param right_vel upon return contains current right velocity
  */
-void GripperAX12AThread::get_velocities(float &left_vel, float &right_vel) {
-  left_vel = __servo_if_left->goal_speed();
-  right_vel = __servo_if_right->goal_speed();
+void
+GripperAX12AThread::get_velocities(float &left_vel, float &right_vel)
+{
+	left_vel  = __servo_if_left->goal_speed();
+	right_vel = __servo_if_right->goal_speed();
 }
 
 /** Set desired velocities.
  * @param left_margin left margin
  * @param right_margin right margin
  */
-void GripperAX12AThread::set_margins(float left_margin, float right_margin) {
-  if (left_margin > 0.0) {
-    DynamixelServoInterface::SetMarginMessage *margin_left_message =
-        new DynamixelServoInterface::SetMarginMessage(left_margin);
-    __servo_if_left->msgq_enqueue(margin_left_message);
-    __left_margin = left_margin;
-  }
-  if (right_margin > 0.0) {
-    DynamixelServoInterface::SetMarginMessage *margin_right_message =
-        new DynamixelServoInterface::SetMarginMessage(right_margin);
-    __servo_if_right->msgq_enqueue(margin_right_message);
-    __right_margin = right_margin;
-  }
-  //__logger->log_warn(name(), "Margins set to %f, %f", __left_margin,
-  //__right_margin);
+void
+GripperAX12AThread::set_margins(float left_margin, float right_margin)
+{
+	if (left_margin > 0.0) {
+		DynamixelServoInterface::SetMarginMessage *margin_left_message =
+		  new DynamixelServoInterface::SetMarginMessage(left_margin);
+		__servo_if_left->msgq_enqueue(margin_left_message);
+		__left_margin = left_margin;
+	}
+	if (right_margin > 0.0) {
+		DynamixelServoInterface::SetMarginMessage *margin_right_message =
+		  new DynamixelServoInterface::SetMarginMessage(right_margin);
+		__servo_if_right->msgq_enqueue(margin_right_message);
+		__right_margin = right_margin;
+	}
+	//__logger->log_warn(name(), "Margins set to %f, %f", __left_margin,
+	//__right_margin);
 }
 
 /** Set desired torque in a range of 0 - 1.
  * @param torque torque from 0 - 1
  */
-void GripperAX12AThread::set_torque(float torque) {
-  if (torque >= 0. && torque <= 1.0) {
-    set_torque_left((unsigned int)(torque * 1023));
-    set_torque_right((unsigned int)(torque * 1023));
-  }
+void
+GripperAX12AThread::set_torque(float torque)
+{
+	if (torque >= 0. && torque <= 1.0) {
+		set_torque_left((unsigned int)(torque * 1023));
+		set_torque_right((unsigned int)(torque * 1023));
+	}
 }
 
 /** Set desired left servo torque in a range of 0 - 1.
  * @param torque torque from 0 - 1
  */
-void GripperAX12AThread::set_torque_left(unsigned int torque) {
-  if (torque >= 0 && torque <= 1023) {
-    cur_torque_ = torque;
-    logger->log_debug(name(), "Set left torque to %u", torque);
+void
+GripperAX12AThread::set_torque_left(unsigned int torque)
+{
+	if (torque >= 0 && torque <= 1023) {
+		cur_torque_ = torque;
+		logger->log_debug(name(), "Set left torque to %u", torque);
 
-    DynamixelServoInterface::SetTorqueLimitMessage *torque_left_message =
-        new DynamixelServoInterface::SetTorqueLimitMessage(torque);
-    __servo_if_left->msgq_enqueue(torque_left_message);
-  } else {
-    logger->log_error(name(),
-                      "Unable to set left torque to %u - value out of range!",
-                      torque);
-  }
+		DynamixelServoInterface::SetTorqueLimitMessage *torque_left_message =
+		  new DynamixelServoInterface::SetTorqueLimitMessage(torque);
+		__servo_if_left->msgq_enqueue(torque_left_message);
+	} else {
+		logger->log_error(name(), "Unable to set left torque to %u - value out of range!", torque);
+	}
 }
 
 /** Set desired left servo torque in a range of 0 - 1.
  * @param torque torque from 0 - 1
  */
-void GripperAX12AThread::set_torque_right(unsigned int torque) {
-  if (torque >= 0 && torque <= 1023) {
-    cur_torque_ = torque;
-    logger->log_debug(name(), "Set right torque to %u", torque);
+void
+GripperAX12AThread::set_torque_right(unsigned int torque)
+{
+	if (torque >= 0 && torque <= 1023) {
+		cur_torque_ = torque;
+		logger->log_debug(name(), "Set right torque to %u", torque);
 
-    DynamixelServoInterface::SetTorqueLimitMessage *torque_right_message =
-        new DynamixelServoInterface::SetTorqueLimitMessage(torque);
-    __servo_if_right->msgq_enqueue(torque_right_message);
-  } else {
-    logger->log_error(name(),
-                      "Unable to set right torque to %u - value out of range!",
-                      torque);
-  }
+		DynamixelServoInterface::SetTorqueLimitMessage *torque_right_message =
+		  new DynamixelServoInterface::SetTorqueLimitMessage(torque);
+		__servo_if_right->msgq_enqueue(torque_right_message);
+	} else {
+		logger->log_error(name(), "Unable to set right torque to %u - value out of range!", torque);
+	}
 }
 
 /** Get left/right value.
  * @param left upon return contains the current left value
  * @param right upon return contains the current right value
  */
-void GripperAX12AThread::get_gripper(float &left, float &right) {
-  left = __servo_if_left->angle();
-  right = __servo_if_right->angle();
+void
+GripperAX12AThread::get_gripper(float &left, float &right)
+{
+	left  = __servo_if_left->angle();
+	right = __servo_if_right->angle();
 }
 
 /** Check if motion is final.
  * @return true if motion is final, false otherwise
  */
-bool GripperAX12AThread::is_final() {
-  float left, right;
-  get_gripper(left, right);
+bool
+GripperAX12AThread::is_final()
+{
+	float left, right;
+	get_gripper(left, right);
 
-  return ((fabs(left - __target_left) <= __left_margin) &&
-          (fabs(right - __target_right) <= __right_margin)) ||
-         (!__servo_if_left->is_final() && !__servo_if_right->is_final());
+	return ((fabs(left - __target_left) <= __left_margin)
+	        && (fabs(right - __target_right) <= __right_margin))
+	       || (!__servo_if_left->is_final() && !__servo_if_right->is_final());
 }
 
 /** Check if Gripper is enabled.
  * @return true if torque is enabled for both servos, false otherwise
  */
-bool GripperAX12AThread::is_enabled() {
-  return __servo_if_left->is_enabled() && __servo_if_right->is_enabled();
+bool
+GripperAX12AThread::is_enabled()
+{
+	return __servo_if_left->is_enabled() && __servo_if_right->is_enabled();
 }
 
 /** Get opening angle of gripper
  * @return angle as float
  */
-float GripperAX12AThread::get_opening_angle() {
-  return -__servo_if_left->angle() + __servo_if_right->angle();
+float
+GripperAX12AThread::get_opening_angle()
+{
+	return -__servo_if_left->angle() + __servo_if_right->angle();
 }
 
 /** Check if gripper holds a puck.
  * @return true if load and opening angle indicate that
  * the gripper probably holds a puck
  */
-bool GripperAX12AThread::holds_puck() {
-  return get_opening_angle() >= __cfg_angle_for_holds_puck_min &&
-         get_opening_angle() <= __cfg_angle_for_holds_puck_max;
+bool
+GripperAX12AThread::holds_puck()
+{
+	return get_opening_angle() >= __cfg_angle_for_holds_puck_min
+	       && get_opening_angle() <= __cfg_angle_for_holds_puck_max;
 }
 
 /** Handle config changes
  */
 void GripperAX12AThread::config_value_erased(const char *path){};
 void GripperAX12AThread::config_tag_changed(const char *new_tag){};
-void GripperAX12AThread::config_comment_changed(
-    const fawkes::Configuration::ValueIterator *v){};
-void GripperAX12AThread::config_value_changed(
-    const fawkes::Configuration::ValueIterator *v) {
-  if (cfg_mutex_.try_lock()) {
-    try {
-      load_config();
-    } catch (fawkes::Exception &e) {
-      logger->log_error(name(), e);
-    }
-  }
-  cfg_mutex_.unlock();
+void GripperAX12AThread::config_comment_changed(const fawkes::Configuration::ValueIterator *v){};
+void
+GripperAX12AThread::config_value_changed(const fawkes::Configuration::ValueIterator *v)
+{
+	if (cfg_mutex_.try_lock()) {
+		try {
+			load_config();
+		} catch (fawkes::Exception &e) {
+			logger->log_error(name(), e);
+		}
+	}
+	cfg_mutex_.unlock();
 }
 
-void GripperAX12AThread::load_config() {
-  logger->log_info(name(), "load config");
-  // Note: due to the use of auto_ptr and RefPtr resources are automatically
-  // freed on destruction, therefore no special handling is necessary in init()
-  // itself!
-  __cfg_driver_prefix =
-      config->get_string((__gripper_cfg_prefix + "driver_prefix").c_str());
-  __cfg_left_servo_id =
-      config->get_string((__gripper_cfg_prefix + "left_servo_id").c_str());
-  __cfg_right_servo_id =
-      config->get_string((__gripper_cfg_prefix + "right_servo_id").c_str());
-  // __cfg_cw_compl_margin  = config->get_uint((__gripper_cfg_prefix +
-  // "cw_compl_margin").c_str());
-  // __cfg_ccw_compl_margin = config->get_uint((__gripper_cfg_prefix +
-  // "ccw_compl_margin").c_str());
-  // __cfg_cw_compl_slope   = config->get_uint((__gripper_cfg_prefix +
-  // "cw_compl_slope").c_str());
-  // __cfg_ccw_compl_slope  = config->get_uint((__gripper_cfg_prefix +
-  // "ccw_compl_slope").c_str());
-  __cfg_left_min =
-      config->get_float((__gripper_cfg_prefix + "left_min").c_str());
-  __cfg_left_max =
-      config->get_float((__gripper_cfg_prefix + "left_max").c_str());
-  __cfg_right_min =
-      config->get_float((__gripper_cfg_prefix + "right_min").c_str());
-  __cfg_right_max =
-      config->get_float((__gripper_cfg_prefix + "right_max").c_str());
-  __cfg_left_torque =
-      config->get_float((__gripper_cfg_prefix + "left_torque").c_str());
-  __cfg_right_torque =
-      config->get_float((__gripper_cfg_prefix + "right_torque").c_str());
-  __cfg_goto_zero_start =
-      config->get_bool((__gripper_cfg_prefix + "goto_zero_start").c_str());
-  __cfg_turn_off =
-      config->get_bool((__gripper_cfg_prefix + "turn_off").c_str());
+void
+GripperAX12AThread::load_config()
+{
+	logger->log_info(name(), "load config");
+	// Note: due to the use of auto_ptr and RefPtr resources are automatically
+	// freed on destruction, therefore no special handling is necessary in init()
+	// itself!
+	__cfg_driver_prefix  = config->get_string((__gripper_cfg_prefix + "driver_prefix").c_str());
+	__cfg_left_servo_id  = config->get_string((__gripper_cfg_prefix + "left_servo_id").c_str());
+	__cfg_right_servo_id = config->get_string((__gripper_cfg_prefix + "right_servo_id").c_str());
+	// __cfg_cw_compl_margin  = config->get_uint((__gripper_cfg_prefix +
+	// "cw_compl_margin").c_str());
+	// __cfg_ccw_compl_margin = config->get_uint((__gripper_cfg_prefix +
+	// "ccw_compl_margin").c_str());
+	// __cfg_cw_compl_slope   = config->get_uint((__gripper_cfg_prefix +
+	// "cw_compl_slope").c_str());
+	// __cfg_ccw_compl_slope  = config->get_uint((__gripper_cfg_prefix +
+	// "ccw_compl_slope").c_str());
+	__cfg_left_min        = config->get_float((__gripper_cfg_prefix + "left_min").c_str());
+	__cfg_left_max        = config->get_float((__gripper_cfg_prefix + "left_max").c_str());
+	__cfg_right_min       = config->get_float((__gripper_cfg_prefix + "right_min").c_str());
+	__cfg_right_max       = config->get_float((__gripper_cfg_prefix + "right_max").c_str());
+	__cfg_left_torque     = config->get_float((__gripper_cfg_prefix + "left_torque").c_str());
+	__cfg_right_torque    = config->get_float((__gripper_cfg_prefix + "right_torque").c_str());
+	__cfg_goto_zero_start = config->get_bool((__gripper_cfg_prefix + "goto_zero_start").c_str());
+	__cfg_turn_off        = config->get_bool((__gripper_cfg_prefix + "turn_off").c_str());
 
-  __cfg_left_margin =
-      config->get_float((__gripper_cfg_prefix + "left_margin").c_str());
-  __cfg_right_margin =
-      config->get_float((__gripper_cfg_prefix + "right_margin").c_str());
-  __cfg_left_start =
-      config->get_float((__gripper_cfg_prefix + "left_start").c_str());
-  __cfg_right_start =
-      config->get_float((__gripper_cfg_prefix + "right_start").c_str());
-  __cfg_left_open_angle =
-      config->get_float((__gripper_cfg_prefix + "left_open").c_str());
-  __cfg_left_close_angle =
-      config->get_float((__gripper_cfg_prefix + "left_close").c_str());
-  __cfg_left_close_load_angle =
-      config->get_float((__gripper_cfg_prefix + "left_close_load").c_str());
-  __cfg_right_open_angle =
-      config->get_float((__gripper_cfg_prefix + "right_open").c_str());
-  __cfg_right_close_angle =
-      config->get_float((__gripper_cfg_prefix + "right_close").c_str());
-  __cfg_right_close_load_angle =
-      config->get_float((__gripper_cfg_prefix + "right_close_load").c_str());
-  __cfg_max_speed =
-      config->get_float((__gripper_cfg_prefix + "max_speed").c_str());
-  __cfg_max_load =
-      config->get_float((__gripper_cfg_prefix + "max_load").c_str());
-  __cfg_max_torque =
-      config->get_float((__gripper_cfg_prefix + "max_torque").c_str());
-  __cfg_load_for_holds_puck = config->get_uint(
-      (__gripper_cfg_prefix + "load_for_holds_puck_threshold").c_str());
-  __cfg_angle_for_holds_puck_min = config->get_float(
-      (__gripper_cfg_prefix + "angle_for_holds_puck_min").c_str());
-  __cfg_angle_for_holds_puck_max = config->get_float(
-      (__gripper_cfg_prefix + "angle_for_holds_puck_max").c_str());
-  __cfg_center_angle_correction_amount = config->get_float(
-      (__gripper_cfg_prefix + "center_angle_correction_amount").c_str());
-  __cfg_ifid_joystick_ =
-      config->get_string(__gripper_cfg_prefix + "joystick_interface_id");
+	__cfg_left_margin      = config->get_float((__gripper_cfg_prefix + "left_margin").c_str());
+	__cfg_right_margin     = config->get_float((__gripper_cfg_prefix + "right_margin").c_str());
+	__cfg_left_start       = config->get_float((__gripper_cfg_prefix + "left_start").c_str());
+	__cfg_right_start      = config->get_float((__gripper_cfg_prefix + "right_start").c_str());
+	__cfg_left_open_angle  = config->get_float((__gripper_cfg_prefix + "left_open").c_str());
+	__cfg_left_close_angle = config->get_float((__gripper_cfg_prefix + "left_close").c_str());
+	__cfg_left_close_load_angle =
+	  config->get_float((__gripper_cfg_prefix + "left_close_load").c_str());
+	__cfg_right_open_angle  = config->get_float((__gripper_cfg_prefix + "right_open").c_str());
+	__cfg_right_close_angle = config->get_float((__gripper_cfg_prefix + "right_close").c_str());
+	__cfg_right_close_load_angle =
+	  config->get_float((__gripper_cfg_prefix + "right_close_load").c_str());
+	__cfg_max_speed  = config->get_float((__gripper_cfg_prefix + "max_speed").c_str());
+	__cfg_max_load   = config->get_float((__gripper_cfg_prefix + "max_load").c_str());
+	__cfg_max_torque = config->get_float((__gripper_cfg_prefix + "max_torque").c_str());
+	__cfg_load_for_holds_puck =
+	  config->get_uint((__gripper_cfg_prefix + "load_for_holds_puck_threshold").c_str());
+	__cfg_angle_for_holds_puck_min =
+	  config->get_float((__gripper_cfg_prefix + "angle_for_holds_puck_min").c_str());
+	__cfg_angle_for_holds_puck_max =
+	  config->get_float((__gripper_cfg_prefix + "angle_for_holds_puck_max").c_str());
+	__cfg_center_angle_correction_amount =
+	  config->get_float((__gripper_cfg_prefix + "center_angle_correction_amount").c_str());
+	__cfg_ifid_joystick_ = config->get_string(__gripper_cfg_prefix + "joystick_interface_id");
 
 #ifdef HAVE_TF
-  __cfg_publish_transforms =
-      config->get_bool((__gripper_cfg_prefix + "publish_transforms").c_str());
+	__cfg_publish_transforms =
+	  config->get_bool((__gripper_cfg_prefix + "publish_transforms").c_str());
 #endif
 
 #ifdef HAVE_TF
-  if (__cfg_publish_transforms) {
-    // float left_trans_x  =
-    //     config->get_float((__gripper_cfg_prefix + "left_trans_x").c_str());
-    // float left_trans_y  =
-    //     config->get_float((__gripper_cfg_prefix + "left_trans_y").c_str());
-    // float left_trans_z  =
-    //     config->get_float((__gripper_cfg_prefix + "left_trans_z").c_str());
-    // float right_trans_x =
-    //     config->get_float((__gripper_cfg_prefix + "right_trans_x").c_str());
-    // float right_trans_y =
-    //     config->get_float((__gripper_cfg_prefix + "right_trans_y").c_str());
-    // float right_trans_z =
-    //     config->get_float((__gripper_cfg_prefix + "right_trans_z").c_str());
+	if (__cfg_publish_transforms) {
+		// float left_trans_x  =
+		//     config->get_float((__gripper_cfg_prefix + "left_trans_x").c_str());
+		// float left_trans_y  =
+		//     config->get_float((__gripper_cfg_prefix + "left_trans_y").c_str());
+		// float left_trans_z  =
+		//     config->get_float((__gripper_cfg_prefix + "left_trans_z").c_str());
+		// float right_trans_x =
+		//     config->get_float((__gripper_cfg_prefix + "right_trans_x").c_str());
+		// float right_trans_y =
+		//     config->get_float((__gripper_cfg_prefix + "right_trans_y").c_str());
+		// float right_trans_z =
+		//     config->get_float((__gripper_cfg_prefix + "right_trans_z").c_str());
 
-    __cfg_gripper_name =
-        config->get_string((__gripper_cfg_prefix + "name").c_str());
+		__cfg_gripper_name = config->get_string((__gripper_cfg_prefix + "name").c_str());
 
-    std::string frame_id_prefix = std::string("/") + __cfg_gripper_name;
-    try {
-      frame_id_prefix = config->get_string(
-          (__gripper_cfg_prefix + "frame_id_prefix").c_str());
-    } catch (Exception &e) {
-    } // ignore, use default
+		std::string frame_id_prefix = std::string("/") + __cfg_gripper_name;
+		try {
+			frame_id_prefix = config->get_string((__gripper_cfg_prefix + "frame_id_prefix").c_str());
+		} catch (Exception &e) {
+		} // ignore, use default
 
-    __cfg_base_frame = frame_id_prefix + "/base";
-    __cfg_left_link = frame_id_prefix + "/left";
-    __cfg_right_link = frame_id_prefix + "/right";
+		__cfg_base_frame = frame_id_prefix + "/base";
+		__cfg_left_link  = frame_id_prefix + "/left";
+		__cfg_right_link = frame_id_prefix + "/right";
 
-    // __translation_left.setValue(left_trans_x, left_trans_y, left_trans_z);
-    // __translation_right.setValue(right_trans_x, right_trans_y,
-    // right_trans_z);
-  }
+		// __translation_left.setValue(left_trans_x, left_trans_y, left_trans_z);
+		// __translation_right.setValue(right_trans_x, right_trans_y,
+		// right_trans_z);
+	}
 #endif
 }

--- a/src/plugins/ax12_gripper/ax12_gripper_thread.h
+++ b/src/plugins/ax12_gripper/ax12_gripper_thread.h
@@ -25,7 +25,7 @@
 #define __PLUGINS_GRIPPER_ROBOTIS_AX12_THREAD_H_
 
 #ifdef HAVE_TF
-#include <aspect/tf.h>
+#	include <aspect/tf.h>
 #endif
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
@@ -40,7 +40,7 @@
 #include <utils/time/time.h>
 
 #ifdef USE_TIMETRACKER
-#include <utils/time/tracker.h>
+#	include <utils/time/tracker.h>
 #endif
 #include <memory>
 #include <string>
@@ -69,134 +69,138 @@ class GripperAX12AThread : public fawkes::Thread,
 
 {
 public:
-  GripperAX12AThread(std::string &gripper_cfg_prefix);
+	GripperAX12AThread(std::string &gripper_cfg_prefix);
 
-  virtual void init();
-  /* virtual bool prepare_finalize_user(); */
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	/* virtual bool prepare_finalize_user(); */
+	virtual void finalize();
+	virtual void loop();
 
-  // For BlackBoardInterfaceListener
-  virtual bool bb_interface_message_received(fawkes::Interface *interface,
-                                             fawkes::Message *message) throw();
+	// For BlackBoardInterfaceListener
+	virtual bool bb_interface_message_received(fawkes::Interface *interface,
+	                                           fawkes::Message *  message) throw();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  fawkes::AX12GripperInterface *__gripper_if;
-  fawkes::LedInterface *__led_if;
-  fawkes::JointInterface *__leftjoint_if;
-  fawkes::JointInterface *__rightjoint_if;
-  fawkes::DynamixelServoInterface *__servo_if_left;
-  fawkes::DynamixelServoInterface *__servo_if_right;
-  fawkes::JoystickInterface *joystick_if_;
+	fawkes::AX12GripperInterface *   __gripper_if;
+	fawkes::LedInterface *           __led_if;
+	fawkes::JointInterface *         __leftjoint_if;
+	fawkes::JointInterface *         __rightjoint_if;
+	fawkes::DynamixelServoInterface *__servo_if_left;
+	fawkes::DynamixelServoInterface *__servo_if_right;
+	fawkes::JoystickInterface *      joystick_if_;
 
-  /* fawkes::RefPtr<RobotisAX12A> __ax12a; */
-  std::string __gripper_cfg_prefix;
-  std::string __cfg_gripper_name;
-  std::string __cfg_driver_prefix;
-  std::string __cfg_left_servo_id;
-  std::string __cfg_right_servo_id;
-  /* unsigned char __cfg_left_servo_id; */
-  /* unsigned char __cfg_right_servo_id; */
-  /* unsigned int __cfg_cw_compl_margin; */
-  /* unsigned int __cfg_ccw_compl_margin; */
-  /* unsigned int __cfg_cw_compl_slope; */
-  /* unsigned int __cfg_ccw_compl_slope; */
-  bool __cfg_goto_zero_start;
-  bool __cfg_turn_off;
-  float __cfg_left_min;
-  float __cfg_left_max;
-  float __cfg_right_min;
-  float __cfg_right_max;
-  float __cfg_left_margin;
-  float __cfg_right_margin;
-  float __cfg_left_offset;
-  float __cfg_right_offset;
-  float __cfg_left_start;
-  float __cfg_right_start;
-  float __cfg_left_torque;
-  float __cfg_right_torque;
-  float __cfg_left_open_angle;
-  float __cfg_left_close_angle;
-  float __cfg_left_close_load_angle;
-  float __cfg_right_open_angle;
-  float __cfg_right_close_angle;
-  float __cfg_right_close_load_angle;
-  float __cfg_max_speed;
-  float __cfg_max_torque;
-  float __cfg_max_load;
-  unsigned int __cfg_load_for_holds_puck;
-  float __cfg_angle_for_holds_puck_min;
-  float __cfg_angle_for_holds_puck_max;
-  float __cfg_center_angle_correction_amount;
-  std::string __cfg_ifid_joystick_;
+	/* fawkes::RefPtr<RobotisAX12A> __ax12a; */
+	std::string __gripper_cfg_prefix;
+	std::string __cfg_gripper_name;
+	std::string __cfg_driver_prefix;
+	std::string __cfg_left_servo_id;
+	std::string __cfg_right_servo_id;
+	/* unsigned char __cfg_left_servo_id; */
+	/* unsigned char __cfg_right_servo_id; */
+	/* unsigned int __cfg_cw_compl_margin; */
+	/* unsigned int __cfg_ccw_compl_margin; */
+	/* unsigned int __cfg_cw_compl_slope; */
+	/* unsigned int __cfg_ccw_compl_slope; */
+	bool         __cfg_goto_zero_start;
+	bool         __cfg_turn_off;
+	float        __cfg_left_min;
+	float        __cfg_left_max;
+	float        __cfg_right_min;
+	float        __cfg_right_max;
+	float        __cfg_left_margin;
+	float        __cfg_right_margin;
+	float        __cfg_left_offset;
+	float        __cfg_right_offset;
+	float        __cfg_left_start;
+	float        __cfg_right_start;
+	float        __cfg_left_torque;
+	float        __cfg_right_torque;
+	float        __cfg_left_open_angle;
+	float        __cfg_left_close_angle;
+	float        __cfg_left_close_load_angle;
+	float        __cfg_right_open_angle;
+	float        __cfg_right_close_angle;
+	float        __cfg_right_close_load_angle;
+	float        __cfg_max_speed;
+	float        __cfg_max_torque;
+	float        __cfg_max_load;
+	unsigned int __cfg_load_for_holds_puck;
+	float        __cfg_angle_for_holds_puck_min;
+	float        __cfg_angle_for_holds_puck_max;
+	float        __cfg_center_angle_correction_amount;
+	std::string  __cfg_ifid_joystick_;
 
-  float __target_left;
-  float __target_right;
-  float __left_margin;
-  float __right_margin;
+	float __target_left;
+	float __target_right;
+	float __left_margin;
+	float __right_margin;
 
-  bool load_left_pending;
-  bool load_right_pending;
-  bool center_pending;
-  unsigned int cur_z_goal_speed;
-  bool z_alignment_pending;
-  fawkes::Time time_to_stop_z_align;
+	bool         load_left_pending;
+	bool         load_right_pending;
+	bool         center_pending;
+	unsigned int cur_z_goal_speed;
+	bool         z_alignment_pending;
+	fawkes::Time time_to_stop_z_align;
 
-  float cur_torque_;
-  fawkes::Time motion_start_timestamp_;
-  bool slap_left_pending_;
-  bool slap_right_pending_;
+	float        cur_torque_;
+	fawkes::Time motion_start_timestamp_;
+	bool         slap_left_pending_;
+	bool         slap_right_pending_;
 
 #ifdef HAVE_TF
-  std::string __cfg_base_frame;
-  std::string __cfg_left_link;
-  std::string __cfg_right_link;
+	std::string __cfg_base_frame;
+	std::string __cfg_left_link;
+	std::string __cfg_right_link;
 
-  fawkes::tf::Vector3 __translation_left;
-  fawkes::tf::Vector3 __translation_right;
+	fawkes::tf::Vector3 __translation_left;
+	fawkes::tf::Vector3 __translation_right;
 
-  fawkes::Mutex cfg_mutex_;
+	fawkes::Mutex cfg_mutex_;
 
-  bool __cfg_publish_transforms;
+	bool __cfg_publish_transforms;
 #endif
 
-  float __last_left;
-  float __last_right;
-  void goto_gripper(float left, float right);
-  void goto_gripper_load(float left, float right);
-  void goto_gripper_timed(float left, float right, float time_sec);
-  void rel_goto_z(int rel_z);
-  void get_gripper(float &left, float &right);
-  void get_gripper(float &left, float &right, fawkes::Time &time);
-  void set_velocities(float left_vel, float right_vel);
-  void set_velocities_normalized(float left_vel, float right_vel);
-  void get_velocities(float &left_vel, float &right_vel);
-  void get_loads(unsigned int &left, unsigned int &right);
-  void set_margins(float left_margin, float right_margin);
-  void set_torque(float torque);
-  void set_torque_left(unsigned int torque);
-  void set_torque_right(unsigned int torque);
-  bool is_final();
-  bool is_enabled();
-  void set_enabled(bool enabled);
-  void set_led_enabled(bool enabled);
-  float get_opening_angle();
-  bool holds_puck();
-  void stop_motion();
-  /* bool has_fresh_data(); */
-  /* void wait_for_fresh_data(); */
-  void stop_left();
-  void stop_right();
-  /* void set_servo_angle(unsigned int servo_id, float servo_angle); */
-  void load_config();
-  void config_value_erased(const char *path);
-  void config_tag_changed(const char *new_tag);
-  void config_comment_changed(const fawkes::Configuration::ValueIterator *v);
-  void config_value_changed(const fawkes::Configuration::ValueIterator *v);
+	float __last_left;
+	float __last_right;
+	void  goto_gripper(float left, float right);
+	void  goto_gripper_load(float left, float right);
+	void  goto_gripper_timed(float left, float right, float time_sec);
+	void  rel_goto_z(int rel_z);
+	void  get_gripper(float &left, float &right);
+	void  get_gripper(float &left, float &right, fawkes::Time &time);
+	void  set_velocities(float left_vel, float right_vel);
+	void  set_velocities_normalized(float left_vel, float right_vel);
+	void  get_velocities(float &left_vel, float &right_vel);
+	void  get_loads(unsigned int &left, unsigned int &right);
+	void  set_margins(float left_margin, float right_margin);
+	void  set_torque(float torque);
+	void  set_torque_left(unsigned int torque);
+	void  set_torque_right(unsigned int torque);
+	bool  is_final();
+	bool  is_enabled();
+	void  set_enabled(bool enabled);
+	void  set_led_enabled(bool enabled);
+	float get_opening_angle();
+	bool  holds_puck();
+	void  stop_motion();
+	/* bool has_fresh_data(); */
+	/* void wait_for_fresh_data(); */
+	void stop_left();
+	void stop_right();
+	/* void set_servo_angle(unsigned int servo_id, float servo_angle); */
+	void load_config();
+	void config_value_erased(const char *path);
+	void config_tag_changed(const char *new_tag);
+	void config_comment_changed(const fawkes::Configuration::ValueIterator *v);
+	void config_value_changed(const fawkes::Configuration::ValueIterator *v);
 };
 
 #endif

--- a/src/plugins/clips-motor-switch/clips-motor-switch-plugin.cpp
+++ b/src/plugins/clips-motor-switch/clips-motor-switch-plugin.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "clips-motor-switch-thread.h"
+
 #include <core/plugin.h>
 
 using namespace fawkes;
@@ -28,14 +29,16 @@ using namespace fawkes;
 /** CLIPS motor switching plugin.
  * @author Tim Niemueller
  */
-class ClipsMotorSwitchPlugin : public fawkes::Plugin {
+class ClipsMotorSwitchPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  ClipsMotorSwitchPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new ClipsMotorSwitchThread());
-  }
+	ClipsMotorSwitchPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new ClipsMotorSwitchThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Motor switching from CLIPS")

--- a/src/plugins/clips-motor-switch/clips-motor-switch-thread.cpp
+++ b/src/plugins/clips-motor-switch/clips-motor-switch-thread.cpp
@@ -35,60 +35,78 @@ using namespace fawkes;
 
 /** Constructor. */
 ClipsMotorSwitchThread::ClipsMotorSwitchThread()
-    : Thread("ClipsMotorSwitchThread", Thread::OPMODE_WAITFORWAKEUP),
-      CLIPSFeature("motor-switch"), CLIPSFeatureAspect(this) {}
+: Thread("ClipsMotorSwitchThread", Thread::OPMODE_WAITFORWAKEUP),
+  CLIPSFeature("motor-switch"),
+  CLIPSFeatureAspect(this)
+{
+}
 
 /** Destructor. */
-ClipsMotorSwitchThread::~ClipsMotorSwitchThread() { envs_.clear(); }
-
-void ClipsMotorSwitchThread::init() {
-  cfg_iface_id_ = config->get_string("/clips-motor-switch/interface-id");
-  motor_if_ =
-      blackboard->open_for_reading<MotorInterface>(cfg_iface_id_.c_str());
+ClipsMotorSwitchThread::~ClipsMotorSwitchThread()
+{
+	envs_.clear();
 }
 
-void ClipsMotorSwitchThread::finalize() { blackboard->close(motor_if_); }
-
-void ClipsMotorSwitchThread::clips_context_init(
-    const std::string &env_name, LockPtr<CLIPS::Environment> &clips) {
-  envs_[env_name] = clips;
-
-  clips->add_function(
-      "motor-enable",
-      sigc::slot<void>(sigc::bind<0>(
-          sigc::mem_fun(*this, &ClipsMotorSwitchThread::clips_motor_enable),
-          env_name)));
-  clips->add_function(
-      "motor-disable",
-      sigc::slot<void>(sigc::bind<0>(
-          sigc::mem_fun(*this, &ClipsMotorSwitchThread::clips_motor_disable),
-          env_name)));
+void
+ClipsMotorSwitchThread::init()
+{
+	cfg_iface_id_ = config->get_string("/clips-motor-switch/interface-id");
+	motor_if_     = blackboard->open_for_reading<MotorInterface>(cfg_iface_id_.c_str());
 }
 
-void ClipsMotorSwitchThread::clips_context_destroyed(
-    const std::string &env_name) {
-  envs_.erase(env_name);
+void
+ClipsMotorSwitchThread::finalize()
+{
+	blackboard->close(motor_if_);
 }
 
-void ClipsMotorSwitchThread::loop() {}
+void
+ClipsMotorSwitchThread::clips_context_init(const std::string &          env_name,
+                                           LockPtr<CLIPS::Environment> &clips)
+{
+	envs_[env_name] = clips;
 
-void ClipsMotorSwitchThread::clips_motor_enable(std::string env_name) {
-  try {
-    MotorInterface::SetMotorStateMessage *msg =
-        new MotorInterface::SetMotorStateMessage(MotorInterface::MOTOR_ENABLED);
-    motor_if_->msgq_enqueue(msg);
-  } catch (Exception &e) {
-    logger->log_warn(name(), "Cannot enable motor");
-  }
+	clips->add_function(
+	  "motor-enable",
+	  sigc::slot<void>(
+	    sigc::bind<0>(sigc::mem_fun(*this, &ClipsMotorSwitchThread::clips_motor_enable), env_name)));
+	clips->add_function(
+	  "motor-disable",
+	  sigc::slot<void>(
+	    sigc::bind<0>(sigc::mem_fun(*this, &ClipsMotorSwitchThread::clips_motor_disable), env_name)));
 }
 
-void ClipsMotorSwitchThread::clips_motor_disable(std::string env_name) {
-  try {
-    MotorInterface::SetMotorStateMessage *msg =
-        new MotorInterface::SetMotorStateMessage(
-            MotorInterface::MOTOR_DISABLED);
-    motor_if_->msgq_enqueue(msg);
-  } catch (Exception &e) {
-    logger->log_warn(name(), "Cannot disable motor");
-  }
+void
+ClipsMotorSwitchThread::clips_context_destroyed(const std::string &env_name)
+{
+	envs_.erase(env_name);
+}
+
+void
+ClipsMotorSwitchThread::loop()
+{
+}
+
+void
+ClipsMotorSwitchThread::clips_motor_enable(std::string env_name)
+{
+	try {
+		MotorInterface::SetMotorStateMessage *msg =
+		  new MotorInterface::SetMotorStateMessage(MotorInterface::MOTOR_ENABLED);
+		motor_if_->msgq_enqueue(msg);
+	} catch (Exception &e) {
+		logger->log_warn(name(), "Cannot enable motor");
+	}
+}
+
+void
+ClipsMotorSwitchThread::clips_motor_disable(std::string env_name)
+{
+	try {
+		MotorInterface::SetMotorStateMessage *msg =
+		  new MotorInterface::SetMotorStateMessage(MotorInterface::MOTOR_DISABLED);
+		motor_if_->msgq_enqueue(msg);
+	} catch (Exception &e) {
+		logger->log_warn(name(), "Cannot disable motor");
+	}
 }

--- a/src/plugins/clips-motor-switch/clips-motor-switch-thread.h
+++ b/src/plugins/clips-motor-switch/clips-motor-switch-thread.h
@@ -40,33 +40,38 @@ class ClipsMotorSwitchThread : public fawkes::Thread,
                                public fawkes::ConfigurableAspect,
                                public fawkes::BlackBoardAspect,
                                public fawkes::CLIPSFeature,
-                               public fawkes::CLIPSFeatureAspect {
+                               public fawkes::CLIPSFeatureAspect
+{
 public:
-  ClipsMotorSwitchThread();
-  virtual ~ClipsMotorSwitchThread();
+	ClipsMotorSwitchThread();
+	virtual ~ClipsMotorSwitchThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  // for CLIPSFeature
-  virtual void clips_context_init(const std::string &env_name,
-                                  fawkes::LockPtr<CLIPS::Environment> &clips);
-  virtual void clips_context_destroyed(const std::string &env_name);
+	// for CLIPSFeature
+	virtual void clips_context_init(const std::string &                  env_name,
+	                                fawkes::LockPtr<CLIPS::Environment> &clips);
+	virtual void clips_context_destroyed(const std::string &env_name);
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  void clips_motor_enable(std::string env_name);
-  void clips_motor_disable(std::string env_name);
+	void clips_motor_enable(std::string env_name);
+	void clips_motor_disable(std::string env_name);
 
-  std::map<std::string, fawkes::LockPtr<CLIPS::Environment>> envs_;
+	std::map<std::string, fawkes::LockPtr<CLIPS::Environment>> envs_;
 
 private:
-  std::string cfg_iface_id_;
-  fawkes::MotorInterface *motor_if_;
+	std::string             cfg_iface_id_;
+	fawkes::MotorInterface *motor_if_;
 };
 
 #endif

--- a/src/plugins/conveyor_plane/conveyor_plane_plugin.cpp
+++ b/src/plugins/conveyor_plane/conveyor_plane_plugin.cpp
@@ -20,9 +20,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "conveyor_plane_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -30,14 +30,16 @@ using namespace fawkes;
  * intel real sense)
  * @author Tobias Neumann
  */
-class ConveyorPlanePlugin : public fawkes::Plugin {
+class ConveyorPlanePlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  ConveyorPlanePlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new ConveyorPlaneThread());
-  }
+	ConveyorPlanePlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new ConveyorPlaneThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Plugin to detec the conveyor beld from a pointcloud")

--- a/src/plugins/conveyor_plane/conveyor_plane_thread.cpp
+++ b/src/plugins/conveyor_plane/conveyor_plane_thread.cpp
@@ -22,35 +22,25 @@
 #include "conveyor_plane_thread.h"
 
 #include <pcl/ModelCoefficients.h>
-#include <pcl/features/normal_3d.h>
-#include <pcl/filters/approximate_voxel_grid.h>
-#include <pcl/filters/voxel_grid.h>
-#include <pcl/sample_consensus/method_types.h>
-#include <pcl/sample_consensus/model_types.h>
-#include <pcl/segmentation/sac_segmentation.h>
-
-#include <pcl/ModelCoefficients.h>
-#include <pcl/common/centroid.h>
-#include <pcl/filters/extract_indices.h>
-#include <pcl/filters/passthrough.h>
-#include <pcl/sample_consensus/method_types.h>
-#include <pcl/sample_consensus/model_types.h>
-
 #include <pcl/common/centroid.h>
 #include <pcl/common/distances.h>
 #include <pcl/common/transforms.h>
+#include <pcl/features/normal_3d.h>
 #include <pcl/features/normal_3d_omp.h>
+#include <pcl/filters/approximate_voxel_grid.h>
 #include <pcl/filters/conditional_removal.h>
 #include <pcl/filters/extract_indices.h>
+#include <pcl/filters/passthrough.h>
 #include <pcl/filters/project_inliers.h>
+#include <pcl/filters/voxel_grid.h>
 #include <pcl/kdtree/kdtree.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/registration/distances.h>
 #include <pcl/sample_consensus/method_types.h>
 #include <pcl/sample_consensus/model_types.h>
 #include <pcl/segmentation/extract_clusters.h>
+#include <pcl/segmentation/sac_segmentation.h>
 #include <pcl/surface/convex_hull.h>
-
 #include <tf/types.h>
 #include <utils/math/angle.h>
 
@@ -66,955 +56,950 @@ using namespace fawkes;
 
 /** Constructor. */
 ConveyorPlaneThread::ConveyorPlaneThread()
-    : Thread("ConveyorPlaneThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS),
-      fawkes::TransformAspect(fawkes::TransformAspect::BOTH, "conveyor_plane"),
-      realsense_switch_(NULL) {}
-
-void ConveyorPlaneThread::init() {
-  const std::string cfg_prefix = "/conveyor_plane/";
-
-  cfg_debug_mode_ = config->get_bool((cfg_prefix + "debug").c_str());
-
-  cloud_in_name_ = config->get_string((cfg_prefix + "cloud_in").c_str());
-
-  const std::string if_prefix =
-      config->get_string((cfg_prefix + "if/prefix").c_str()) + "/";
-
-  cloud_out_inter_1_name_ =
-      if_prefix +
-      config->get_string((cfg_prefix + "if/cloud_out_intermediet").c_str());
-  cloud_out_result_name_ =
-      if_prefix +
-      config->get_string((cfg_prefix + "if/cloud_out_result").c_str());
-  cfg_bb_conveyor_plane_name_ =
-      if_prefix + config->get_string((cfg_prefix + "if/pose_of_beld").c_str());
-  cfg_bb_switch_name_ =
-      if_prefix + config->get_string((cfg_prefix + "if/switch").c_str());
-
-  laserlines_names_ =
-      config->get_strings((cfg_prefix + "if/laser_lines").c_str());
-
-  cfg_pose_close_if_no_new_pointclouds_ =
-      config->get_bool((cfg_prefix + "if/pose_close_if_new_pc").c_str());
-
-  conveyor_frame_id_ =
-      config->get_string((cfg_prefix + "conveyor_frame_id").c_str());
-  cfg_pose_diff_ =
-      config->get_float((cfg_prefix + "vis_hist/diff_pose").c_str());
-  vis_hist_angle_diff_ =
-      config->get_float((cfg_prefix + "vis_hist/diff_angle").c_str());
-  cfg_pose_avg_hist_size_ =
-      config->get_uint((cfg_prefix + "vis_hist/average/size").c_str());
-  cfg_pose_avg_min_ =
-      config->get_uint((cfg_prefix + "vis_hist/average/used_min").c_str());
-  cfg_allow_invalid_poses_ =
-      config->get_uint((cfg_prefix + "vis_hist/allow_invalid_poses").c_str());
-
-  cfg_enable_switch_ =
-      config->get_bool((cfg_prefix + "switch_default").c_str());
-  cfg_use_visualisation_ =
-      config->get_bool((cfg_prefix + "use_visualisation").c_str());
-
-  cfg_gripper_y_min_ =
-      config->get_float((cfg_prefix + "gripper/y_min").c_str());
-  cfg_gripper_y_max_ =
-      config->get_float((cfg_prefix + "gripper/y_max").c_str());
-  cfg_gripper_z_max_ =
-      config->get_float((cfg_prefix + "gripper/z_max").c_str());
-  cfg_gripper_slice_y_min_ =
-      config->get_float((cfg_prefix + "gripper/slice/y_min").c_str());
-  cfg_gripper_slice_y_max_ =
-      config->get_float((cfg_prefix + "gripper/slice/y_max").c_str());
-
-  cfg_front_space_ = config->get_float((cfg_prefix + "front/space").c_str());
-  cfg_front_offset_ = config->get_float((cfg_prefix + "front/offset").c_str());
-
-  cfg_left_cut_ =
-      config->get_float((cfg_prefix + "left_right/left_cut").c_str());
-  cfg_right_cut_ =
-      config->get_float((cfg_prefix + "left_right/right_cut").c_str());
-  cfg_left_cut_no_ll_ =
-      config->get_float((cfg_prefix + "left_right/left_cut_no_ll").c_str());
-  cfg_right_cut_no_ll_ =
-      config->get_float((cfg_prefix + "left_right/right_cut_no_ll").c_str());
-
-  cfg_plane_dist_threshold_ =
-      config->get_float((cfg_prefix + "plane/dist_threshold").c_str());
-  cfg_normal_z_minimum_ =
-      config->get_float((cfg_prefix + "plane/normal_z_minimum").c_str());
-  cfg_plane_height_minimum_ =
-      config->get_float((cfg_prefix + "plane/height_minimum").c_str());
-  cfg_plane_width_minimum_ =
-      config->get_float((cfg_prefix + "plane/width_minimum").c_str());
-
-  cfg_cluster_tolerance_ =
-      config->get_float((cfg_prefix + "cluster/tolerance").c_str());
-  cfg_cluster_size_min_ =
-      config->get_float((cfg_prefix + "cluster/size_min").c_str());
-  cfg_cluster_size_max_ =
-      config->get_float((cfg_prefix + "cluster/size_max").c_str());
-
-  cfg_voxel_grid_leave_size_ =
-      config->get_float((cfg_prefix + "voxel_grid/leave_size").c_str());
-
-  cfg_bb_realsense_switch_name_ = "realsense";
-  try {
-    cfg_bb_realsense_switch_name_ =
-        config->get_string((cfg_prefix + "realsense_switch").c_str());
-  } catch (Exception &e) {
-  } // ignore, use default
-  try {
-    wait_time_ =
-        Time(config->get_float((cfg_prefix + "realsense_wait_time").c_str()));
-  } catch (Exception &e) {
-    wait_time_ = Time(1.);
-  } // ignore, use default
-
-  cloud_in_registered_ = false;
-
-  cloud_out_inter_1_ = new Cloud();
-  cloud_out_result_ = new Cloud();
-  pcl_manager->add_pointcloud(cloud_out_inter_1_name_.c_str(),
-                              cloud_out_inter_1_);
-  pcl_manager->add_pointcloud(cloud_out_result_name_.c_str(),
-                              cloud_out_result_);
-
-  for (std::string ll : laserlines_names_) {
-    laserlines_.push_back(
-        blackboard->open_for_reading<fawkes::LaserLineInterface>(ll.c_str()));
-  }
-
-  enable_pose_ = false;
-  if (!cfg_pose_close_if_no_new_pointclouds_) {
-    bb_pose_conditional_open();
-  }
-
-  bb_enable_switch_ = blackboard->open_for_writing<SwitchInterface>(
-      cfg_bb_switch_name_.c_str());
-  bb_enable_switch_->set_enabled(
-      cfg_debug_mode_ ||
-      cfg_enable_switch_); // ignore cfg_enable_switch_ and set to true if debug
-                           // mode is used
-  bb_enable_switch_->write();
-
-  realsense_switch_ = blackboard->open_for_reading<SwitchInterface>(
-      cfg_bb_realsense_switch_name_.c_str());
-
-  visualisation_ = new Visualisation(rosnode);
+: Thread("ConveyorPlaneThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS),
+  fawkes::TransformAspect(fawkes::TransformAspect::BOTH, "conveyor_plane"),
+  realsense_switch_(NULL)
+{
 }
 
-void ConveyorPlaneThread::finalize() {
-  pcl_manager->remove_pointcloud(cloud_out_inter_1_name_.c_str());
-  pcl_manager->remove_pointcloud(cloud_out_result_name_.c_str());
-  delete visualisation_;
-  blackboard->close(bb_enable_switch_);
-  logger->log_info(name(), "Unloading, disabling %s",
-                   cfg_bb_realsense_switch_name_.c_str());
-  realsense_switch_->msgq_enqueue(new SwitchInterface::DisableSwitchMessage());
-  blackboard->close(realsense_switch_);
-  bb_pose_conditional_close();
+void
+ConveyorPlaneThread::init()
+{
+	const std::string cfg_prefix = "/conveyor_plane/";
+
+	cfg_debug_mode_ = config->get_bool((cfg_prefix + "debug").c_str());
+
+	cloud_in_name_ = config->get_string((cfg_prefix + "cloud_in").c_str());
+
+	const std::string if_prefix = config->get_string((cfg_prefix + "if/prefix").c_str()) + "/";
+
+	cloud_out_inter_1_name_ =
+	  if_prefix + config->get_string((cfg_prefix + "if/cloud_out_intermediet").c_str());
+	cloud_out_result_name_ =
+	  if_prefix + config->get_string((cfg_prefix + "if/cloud_out_result").c_str());
+	cfg_bb_conveyor_plane_name_ =
+	  if_prefix + config->get_string((cfg_prefix + "if/pose_of_beld").c_str());
+	cfg_bb_switch_name_ = if_prefix + config->get_string((cfg_prefix + "if/switch").c_str());
+
+	laserlines_names_ = config->get_strings((cfg_prefix + "if/laser_lines").c_str());
+
+	cfg_pose_close_if_no_new_pointclouds_ =
+	  config->get_bool((cfg_prefix + "if/pose_close_if_new_pc").c_str());
+
+	conveyor_frame_id_      = config->get_string((cfg_prefix + "conveyor_frame_id").c_str());
+	cfg_pose_diff_          = config->get_float((cfg_prefix + "vis_hist/diff_pose").c_str());
+	vis_hist_angle_diff_    = config->get_float((cfg_prefix + "vis_hist/diff_angle").c_str());
+	cfg_pose_avg_hist_size_ = config->get_uint((cfg_prefix + "vis_hist/average/size").c_str());
+	cfg_pose_avg_min_       = config->get_uint((cfg_prefix + "vis_hist/average/used_min").c_str());
+	cfg_allow_invalid_poses_ =
+	  config->get_uint((cfg_prefix + "vis_hist/allow_invalid_poses").c_str());
+
+	cfg_enable_switch_     = config->get_bool((cfg_prefix + "switch_default").c_str());
+	cfg_use_visualisation_ = config->get_bool((cfg_prefix + "use_visualisation").c_str());
+
+	cfg_gripper_y_min_       = config->get_float((cfg_prefix + "gripper/y_min").c_str());
+	cfg_gripper_y_max_       = config->get_float((cfg_prefix + "gripper/y_max").c_str());
+	cfg_gripper_z_max_       = config->get_float((cfg_prefix + "gripper/z_max").c_str());
+	cfg_gripper_slice_y_min_ = config->get_float((cfg_prefix + "gripper/slice/y_min").c_str());
+	cfg_gripper_slice_y_max_ = config->get_float((cfg_prefix + "gripper/slice/y_max").c_str());
+
+	cfg_front_space_  = config->get_float((cfg_prefix + "front/space").c_str());
+	cfg_front_offset_ = config->get_float((cfg_prefix + "front/offset").c_str());
+
+	cfg_left_cut_        = config->get_float((cfg_prefix + "left_right/left_cut").c_str());
+	cfg_right_cut_       = config->get_float((cfg_prefix + "left_right/right_cut").c_str());
+	cfg_left_cut_no_ll_  = config->get_float((cfg_prefix + "left_right/left_cut_no_ll").c_str());
+	cfg_right_cut_no_ll_ = config->get_float((cfg_prefix + "left_right/right_cut_no_ll").c_str());
+
+	cfg_plane_dist_threshold_ = config->get_float((cfg_prefix + "plane/dist_threshold").c_str());
+	cfg_normal_z_minimum_     = config->get_float((cfg_prefix + "plane/normal_z_minimum").c_str());
+	cfg_plane_height_minimum_ = config->get_float((cfg_prefix + "plane/height_minimum").c_str());
+	cfg_plane_width_minimum_  = config->get_float((cfg_prefix + "plane/width_minimum").c_str());
+
+	cfg_cluster_tolerance_ = config->get_float((cfg_prefix + "cluster/tolerance").c_str());
+	cfg_cluster_size_min_  = config->get_float((cfg_prefix + "cluster/size_min").c_str());
+	cfg_cluster_size_max_  = config->get_float((cfg_prefix + "cluster/size_max").c_str());
+
+	cfg_voxel_grid_leave_size_ = config->get_float((cfg_prefix + "voxel_grid/leave_size").c_str());
+
+	cfg_bb_realsense_switch_name_ = "realsense";
+	try {
+		cfg_bb_realsense_switch_name_ = config->get_string((cfg_prefix + "realsense_switch").c_str());
+	} catch (Exception &e) {
+	} // ignore, use default
+	try {
+		wait_time_ = Time(config->get_float((cfg_prefix + "realsense_wait_time").c_str()));
+	} catch (Exception &e) {
+		wait_time_ = Time(1.);
+	} // ignore, use default
+
+	cloud_in_registered_ = false;
+
+	cloud_out_inter_1_ = new Cloud();
+	cloud_out_result_  = new Cloud();
+	pcl_manager->add_pointcloud(cloud_out_inter_1_name_.c_str(), cloud_out_inter_1_);
+	pcl_manager->add_pointcloud(cloud_out_result_name_.c_str(), cloud_out_result_);
+
+	for (std::string ll : laserlines_names_) {
+		laserlines_.push_back(blackboard->open_for_reading<fawkes::LaserLineInterface>(ll.c_str()));
+	}
+
+	enable_pose_ = false;
+	if (!cfg_pose_close_if_no_new_pointclouds_) {
+		bb_pose_conditional_open();
+	}
+
+	bb_enable_switch_ = blackboard->open_for_writing<SwitchInterface>(cfg_bb_switch_name_.c_str());
+	bb_enable_switch_->set_enabled(
+	  cfg_debug_mode_ || cfg_enable_switch_); // ignore cfg_enable_switch_ and set to true if debug
+	                                          // mode is used
+	bb_enable_switch_->write();
+
+	realsense_switch_ =
+	  blackboard->open_for_reading<SwitchInterface>(cfg_bb_realsense_switch_name_.c_str());
+
+	visualisation_ = new Visualisation(rosnode);
 }
 
-void ConveyorPlaneThread::bb_pose_conditional_open() {
-  if (!enable_pose_) {
-    enable_pose_ = true;
-    bb_pose_ = blackboard->open_for_writing<fawkes::Position3DInterface>(
-        cfg_bb_conveyor_plane_name_.c_str());
-  }
+void
+ConveyorPlaneThread::finalize()
+{
+	pcl_manager->remove_pointcloud(cloud_out_inter_1_name_.c_str());
+	pcl_manager->remove_pointcloud(cloud_out_result_name_.c_str());
+	delete visualisation_;
+	blackboard->close(bb_enable_switch_);
+	logger->log_info(name(), "Unloading, disabling %s", cfg_bb_realsense_switch_name_.c_str());
+	realsense_switch_->msgq_enqueue(new SwitchInterface::DisableSwitchMessage());
+	blackboard->close(realsense_switch_);
+	bb_pose_conditional_close();
 }
 
-void ConveyorPlaneThread::bb_pose_conditional_close() {
-  if (enable_pose_) {
-    enable_pose_ = false;
-    blackboard->close(bb_pose_);
-  }
+void
+ConveyorPlaneThread::bb_pose_conditional_open()
+{
+	if (!enable_pose_) {
+		enable_pose_ = true;
+		bb_pose_     = blackboard->open_for_writing<fawkes::Position3DInterface>(
+      cfg_bb_conveyor_plane_name_.c_str());
+	}
 }
 
-void ConveyorPlaneThread::loop() {
-  if_read();
-  // logger->log_debug(name(),"CONVEYOR-POSE 1: Interface read");
-  realsense_switch_->read();
-
-  if (bb_enable_switch_->is_enabled()) {
-    if (realsense_switch_->has_writer()) {
-      if (!realsense_switch_->is_enabled()) {
-        logger->log_info(name(), "Camera %s is disabled, enabling",
-                         cfg_bb_realsense_switch_name_.c_str());
-        realsense_switch_->msgq_enqueue(
-            new SwitchInterface::EnableSwitchMessage());
-        start_waiting();
-        return;
-      }
-    } else {
-      logger->log_error(name(), "No writer for camera %s",
-                        cfg_bb_realsense_switch_name_.c_str());
-      return;
-    }
-  } else if (realsense_switch_->has_writer() &&
-             realsense_switch_->is_enabled()) {
-    logger->log_info(name(), "Disabling %s",
-                     cfg_bb_realsense_switch_name_.c_str());
-    realsense_switch_->msgq_enqueue(
-        new SwitchInterface::DisableSwitchMessage());
-  }
-
-  if (!pc_in_check() || !bb_enable_switch_->is_enabled()) {
-    if (enable_pose_) {
-      vis_hist_ = -1;
-      pose trash;
-      trash.valid = false;
-      pose_write(trash);
-    }
-    if (cfg_pose_close_if_no_new_pointclouds_) {
-      bb_pose_conditional_close();
-    }
-    return;
-  }
-  if (need_to_wait()) {
-    logger->log_debug(
-        name(), "Waiting for %s for %f sec, still %f sec remaining",
-        cfg_bb_realsense_switch_name_.c_str(), wait_time_.in_sec(),
-        (wait_start_ + wait_time_ - Time()).in_sec());
-    return;
-  }
-  // logger->log_info(name(),"CONVEYOR-POSE 2: Added Trash if no point cloud or
-  // not enabled and pose enabled");
-  bb_pose_conditional_open();
-
-  pose pose_average;
-  bool pose_average_availabe = pose_get_avg(pose_average);
-  // logger->log_info(name(),"CONVEYOR-POSE 3: set average");
-  if (pose_average_availabe) {
-    vis_hist_ = std::max(1, vis_hist_ + 1);
-    pose_write(pose_average);
-
-    pose_publish_tf(pose_average);
-
-    //    tf_send_from_pose_if(pose_current);
-    if (cfg_use_visualisation_) {
-      visualisation_->marker_draw(header_, pose_average.translation,
-                                  pose_average.rotation);
-    }
-  } else {
-    vis_hist_ = -1;
-    pose trash;
-    trash.valid = false;
-    pose_write(trash);
-  }
-  // logger->log_debug(name(),"CONVEYOR-POSE 4: checked average");
-  fawkes::LaserLineInterface *ll = NULL;
-  bool use_laserline = laserline_get_best_fit(ll);
-  // logger->log_debug(name(),"CONVEYOR-POSE 5: got laserline");
-
-  CloudPtr cloud_in(new Cloud(**cloud_in_));
-
-  uint in_size = cloud_in->points.size();
-  // logger->log_debug(name(), "Size before voxel grid: %u", in_size);
-  CloudPtr cloud_vg = cloud_voxel_grid(cloud_in);
-  uint out_size = cloud_vg->points.size();
-  // logger->log_debug(name(), "Size of voxel grid: %u", out_size);
-  if (in_size == out_size) {
-    logger->log_error(name(), "Voxel Grid failed, skipping loop!");
-    return;
-  }
-  CloudPtr cloud_gripper = cloud_remove_gripper(cloud_vg);
-  CloudPtr cloud_front =
-      cloud_remove_offset_to_front(cloud_gripper, ll, use_laserline);
-  // logger->log_debug(name(),"CONVEYOR-POSE 6: intially filtered pointcloud");
-
-  CloudPtr cloud_front_side(new Cloud);
-  cloud_front_side =
-      cloud_remove_offset_to_left_right(cloud_front, ll, use_laserline);
-
-  // logger->log_debug(name(),"CONVEYOR-POSE 7: set cut off left and rigt");
-
-  cloud_publish(cloud_front_side, cloud_out_inter_1_);
-
-  // search for best plane
-  CloudPtr cloud_choosen;
-  pcl::ModelCoefficients::Ptr coeff(new pcl::ModelCoefficients);
-  do {
-    //  logger->log_debug(name(), "In while loop");
-    CloudPtr cloud_plane = cloud_get_plane(cloud_front_side, coeff);
-    //  logger->log_debug(name(), "After getting plane");
-    if (cloud_plane == NULL || !cloud_plane) {
-      pose trash;
-      trash.valid = false;
-      pose_add_element(trash);
-      return;
-    }
-
-    size_t id;
-    //  logger->log_debug(name(), "Before clustering");
-    boost::shared_ptr<std::vector<pcl::PointIndices>> cluster_indices =
-        cloud_cluster(cloud_plane);
-    //  logger->log_debug(name(), "After clustering");
-    if (cluster_indices->size() <= 0) {
-      pose trash;
-      trash.valid = false;
-      pose_add_element(trash);
-      return;
-    }
-    // logger->log_debug(name(), "Before split");
-    std::vector<CloudPtr> clouds_cluster =
-        cluster_split(cloud_plane, cluster_indices);
-    // logger->log_debug(name(), "Before finding biggest");
-    cloud_choosen = cluster_find_biggest(clouds_cluster, id);
-    // logger->log_debug(name(), "After finding biggest");
-
-    // check if plane is ok, otherwise remove indicies
-
-    // check if the height is ok (remove shelfs)
-    float y_min = -200;
-    float y_max = 200;
-    for (Point p : *cloud_choosen) {
-      if (p.y > y_min) {
-        y_min = p.y;
-      }
-      if (p.y < y_max) {
-        y_max = p.y;
-      }
-    }
-
-    float height = y_min - y_max;
-    if (height < cfg_plane_height_minimum_) {
-      logger->log_info(
-          name(),
-          "Discard plane, because of height restriction. is: %f\tshould: %f",
-          height, cfg_plane_height_minimum_);
-
-      boost::shared_ptr<pcl::PointIndices> extract_indicies(
-          new pcl::PointIndices(cluster_indices->at(id)));
-      CloudPtr tmp(new Cloud);
-      pcl::ExtractIndices<Point> extract;
-      extract.setInputCloud(cloud_front_side);
-      extract.setIndices(extract_indicies);
-      extract.setNegative(true);
-      extract.filter(*tmp);
-      // logger->log_debug(name(), "After extraction");
-      *cloud_front_side = *tmp;
-    } else {
-      // height is ok
-      float x_min = -200;
-      float x_max = 200;
-      for (Point p : *cloud_choosen) {
-        if (p.x > x_min) {
-          x_min = p.x;
-        }
-        if (p.x < x_max) {
-          x_max = p.x;
-        }
-      }
-
-      float width = x_min - x_max;
-      if (width < cfg_plane_width_minimum_) {
-        logger->log_info(
-            name(),
-            "Discard plane, because of width restriction. is: %f\tshould: %f",
-            width, cfg_plane_width_minimum_);
-        boost::shared_ptr<pcl::PointIndices> extract_indicies(
-            new pcl::PointIndices(cluster_indices->at(id)));
-        CloudPtr tmp(new Cloud);
-        pcl::ExtractIndices<Point> extract;
-        extract.setInputCloud(cloud_front_side);
-        extract.setIndices(extract_indicies);
-        extract.setNegative(true);
-        extract.filter(*tmp);
-        *cloud_front_side = *tmp;
-
-      } else {
-        // height and width ok
-        break;
-      }
-    }
-  } while (true);
-
-  // logger->log_debug(name(),"CONVEYOR-POSE 9: left while true");
-  cloud_publish(cloud_choosen, cloud_out_result_);
-
-  // get centroid
-  Eigen::Vector4f centroid;
-  pcl::compute3DCentroid<Point, float>(*cloud_choosen, centroid);
-
-  Eigen::Vector3f normal;
-  normal(0) = coeff->values[0];
-  normal(1) = coeff->values[1];
-  normal(2) = coeff->values[2];
-  pose pose_current = calculate_pose(centroid, normal);
-  ;
-  pose_add_element(pose_current);
+void
+ConveyorPlaneThread::bb_pose_conditional_close()
+{
+	if (enable_pose_) {
+		enable_pose_ = false;
+		blackboard->close(bb_pose_);
+	}
 }
 
-bool ConveyorPlaneThread::pc_in_check() {
-  if (pcl_manager->exists_pointcloud(
-          cloud_in_name_.c_str())) { // does the pc exists
-    if (!cloud_in_registered_) {     // do I already have this pc
-      cloud_in_ = pcl_manager->get_pointcloud<Point>(cloud_in_name_.c_str());
-      if (cloud_in_->points.size() > 0) {
-        cloud_in_registered_ = true;
-      }
-    }
+void
+ConveyorPlaneThread::loop()
+{
+	if_read();
+	// logger->log_debug(name(),"CONVEYOR-POSE 1: Interface read");
+	realsense_switch_->read();
 
-    unsigned long time_old = header_.stamp;
-    header_ = cloud_in_->header;
+	if (bb_enable_switch_->is_enabled()) {
+		if (realsense_switch_->has_writer()) {
+			if (!realsense_switch_->is_enabled()) {
+				logger->log_info(name(),
+				                 "Camera %s is disabled, enabling",
+				                 cfg_bb_realsense_switch_name_.c_str());
+				realsense_switch_->msgq_enqueue(new SwitchInterface::EnableSwitchMessage());
+				start_waiting();
+				return;
+			}
+		} else {
+			logger->log_error(name(), "No writer for camera %s", cfg_bb_realsense_switch_name_.c_str());
+			return;
+		}
+	} else if (realsense_switch_->has_writer() && realsense_switch_->is_enabled()) {
+		logger->log_info(name(), "Disabling %s", cfg_bb_realsense_switch_name_.c_str());
+		realsense_switch_->msgq_enqueue(new SwitchInterface::DisableSwitchMessage());
+	}
 
-    return time_old !=
-           header_.stamp; // true, if there is a new cloud, false otherwise
+	if (!pc_in_check() || !bb_enable_switch_->is_enabled()) {
+		if (enable_pose_) {
+			vis_hist_ = -1;
+			pose trash;
+			trash.valid = false;
+			pose_write(trash);
+		}
+		if (cfg_pose_close_if_no_new_pointclouds_) {
+			bb_pose_conditional_close();
+		}
+		return;
+	}
+	if (need_to_wait()) {
+		logger->log_debug(name(),
+		                  "Waiting for %s for %f sec, still %f sec remaining",
+		                  cfg_bb_realsense_switch_name_.c_str(),
+		                  wait_time_.in_sec(),
+		                  (wait_start_ + wait_time_ - Time()).in_sec());
+		return;
+	}
+	// logger->log_info(name(),"CONVEYOR-POSE 2: Added Trash if no point cloud or
+	// not enabled and pose enabled");
+	bb_pose_conditional_open();
 
-  } else {
-    logger->log_debug(name(), "can't get pointcloud %s",
-                      cloud_in_name_.c_str());
-    cloud_in_registered_ = false;
-    return false;
-  }
+	pose pose_average;
+	bool pose_average_availabe = pose_get_avg(pose_average);
+	// logger->log_info(name(),"CONVEYOR-POSE 3: set average");
+	if (pose_average_availabe) {
+		vis_hist_ = std::max(1, vis_hist_ + 1);
+		pose_write(pose_average);
+
+		pose_publish_tf(pose_average);
+
+		//    tf_send_from_pose_if(pose_current);
+		if (cfg_use_visualisation_) {
+			visualisation_->marker_draw(header_, pose_average.translation, pose_average.rotation);
+		}
+	} else {
+		vis_hist_ = -1;
+		pose trash;
+		trash.valid = false;
+		pose_write(trash);
+	}
+	// logger->log_debug(name(),"CONVEYOR-POSE 4: checked average");
+	fawkes::LaserLineInterface *ll            = NULL;
+	bool                        use_laserline = laserline_get_best_fit(ll);
+	// logger->log_debug(name(),"CONVEYOR-POSE 5: got laserline");
+
+	CloudPtr cloud_in(new Cloud(**cloud_in_));
+
+	uint in_size = cloud_in->points.size();
+	// logger->log_debug(name(), "Size before voxel grid: %u", in_size);
+	CloudPtr cloud_vg = cloud_voxel_grid(cloud_in);
+	uint     out_size = cloud_vg->points.size();
+	// logger->log_debug(name(), "Size of voxel grid: %u", out_size);
+	if (in_size == out_size) {
+		logger->log_error(name(), "Voxel Grid failed, skipping loop!");
+		return;
+	}
+	CloudPtr cloud_gripper = cloud_remove_gripper(cloud_vg);
+	CloudPtr cloud_front   = cloud_remove_offset_to_front(cloud_gripper, ll, use_laserline);
+	// logger->log_debug(name(),"CONVEYOR-POSE 6: intially filtered pointcloud");
+
+	CloudPtr cloud_front_side(new Cloud);
+	cloud_front_side = cloud_remove_offset_to_left_right(cloud_front, ll, use_laserline);
+
+	// logger->log_debug(name(),"CONVEYOR-POSE 7: set cut off left and rigt");
+
+	cloud_publish(cloud_front_side, cloud_out_inter_1_);
+
+	// search for best plane
+	CloudPtr                    cloud_choosen;
+	pcl::ModelCoefficients::Ptr coeff(new pcl::ModelCoefficients);
+	do {
+		//  logger->log_debug(name(), "In while loop");
+		CloudPtr cloud_plane = cloud_get_plane(cloud_front_side, coeff);
+		//  logger->log_debug(name(), "After getting plane");
+		if (cloud_plane == NULL || !cloud_plane) {
+			pose trash;
+			trash.valid = false;
+			pose_add_element(trash);
+			return;
+		}
+
+		size_t id;
+		//  logger->log_debug(name(), "Before clustering");
+		boost::shared_ptr<std::vector<pcl::PointIndices>> cluster_indices = cloud_cluster(cloud_plane);
+		//  logger->log_debug(name(), "After clustering");
+		if (cluster_indices->size() <= 0) {
+			pose trash;
+			trash.valid = false;
+			pose_add_element(trash);
+			return;
+		}
+		// logger->log_debug(name(), "Before split");
+		std::vector<CloudPtr> clouds_cluster = cluster_split(cloud_plane, cluster_indices);
+		// logger->log_debug(name(), "Before finding biggest");
+		cloud_choosen = cluster_find_biggest(clouds_cluster, id);
+		// logger->log_debug(name(), "After finding biggest");
+
+		// check if plane is ok, otherwise remove indicies
+
+		// check if the height is ok (remove shelfs)
+		float y_min = -200;
+		float y_max = 200;
+		for (Point p : *cloud_choosen) {
+			if (p.y > y_min) {
+				y_min = p.y;
+			}
+			if (p.y < y_max) {
+				y_max = p.y;
+			}
+		}
+
+		float height = y_min - y_max;
+		if (height < cfg_plane_height_minimum_) {
+			logger->log_info(name(),
+			                 "Discard plane, because of height restriction. is: %f\tshould: %f",
+			                 height,
+			                 cfg_plane_height_minimum_);
+
+			boost::shared_ptr<pcl::PointIndices> extract_indicies(
+			  new pcl::PointIndices(cluster_indices->at(id)));
+			CloudPtr                   tmp(new Cloud);
+			pcl::ExtractIndices<Point> extract;
+			extract.setInputCloud(cloud_front_side);
+			extract.setIndices(extract_indicies);
+			extract.setNegative(true);
+			extract.filter(*tmp);
+			// logger->log_debug(name(), "After extraction");
+			*cloud_front_side = *tmp;
+		} else {
+			// height is ok
+			float x_min = -200;
+			float x_max = 200;
+			for (Point p : *cloud_choosen) {
+				if (p.x > x_min) {
+					x_min = p.x;
+				}
+				if (p.x < x_max) {
+					x_max = p.x;
+				}
+			}
+
+			float width = x_min - x_max;
+			if (width < cfg_plane_width_minimum_) {
+				logger->log_info(name(),
+				                 "Discard plane, because of width restriction. is: %f\tshould: %f",
+				                 width,
+				                 cfg_plane_width_minimum_);
+				boost::shared_ptr<pcl::PointIndices> extract_indicies(
+				  new pcl::PointIndices(cluster_indices->at(id)));
+				CloudPtr                   tmp(new Cloud);
+				pcl::ExtractIndices<Point> extract;
+				extract.setInputCloud(cloud_front_side);
+				extract.setIndices(extract_indicies);
+				extract.setNegative(true);
+				extract.filter(*tmp);
+				*cloud_front_side = *tmp;
+
+			} else {
+				// height and width ok
+				break;
+			}
+		}
+	} while (true);
+
+	// logger->log_debug(name(),"CONVEYOR-POSE 9: left while true");
+	cloud_publish(cloud_choosen, cloud_out_result_);
+
+	// get centroid
+	Eigen::Vector4f centroid;
+	pcl::compute3DCentroid<Point, float>(*cloud_choosen, centroid);
+
+	Eigen::Vector3f normal;
+	normal(0)         = coeff->values[0];
+	normal(1)         = coeff->values[1];
+	normal(2)         = coeff->values[2];
+	pose pose_current = calculate_pose(centroid, normal);
+	;
+	pose_add_element(pose_current);
 }
 
-void ConveyorPlaneThread::if_read() {
-  // enable switch
-  bb_enable_switch_->read();
+bool
+ConveyorPlaneThread::pc_in_check()
+{
+	if (pcl_manager->exists_pointcloud(cloud_in_name_.c_str())) { // does the pc exists
+		if (!cloud_in_registered_) {                                // do I already have this pc
+			cloud_in_ = pcl_manager->get_pointcloud<Point>(cloud_in_name_.c_str());
+			if (cloud_in_->points.size() > 0) {
+				cloud_in_registered_ = true;
+			}
+		}
 
-  bool rv = bb_enable_switch_->is_enabled();
-  while (!bb_enable_switch_->msgq_empty()) {
-    logger->log_info(name(), "RECIEVED SWITCH MESSAGE");
-    if (bb_enable_switch_
-            ->msgq_first_is<SwitchInterface::DisableSwitchMessage>()) {
-      rv = false;
-    } else if (bb_enable_switch_
-                   ->msgq_first_is<SwitchInterface::EnableSwitchMessage>()) {
-      rv = true;
-    }
+		unsigned long time_old = header_.stamp;
+		header_                = cloud_in_->header;
 
-    bb_enable_switch_->msgq_pop();
-  }
-  if (rv != bb_enable_switch_->is_enabled()) {
-    if (!cfg_debug_mode_) {
-      logger->log_info(name(), "*** enabled: %s", rv ? "yes" : "no");
-      bb_enable_switch_->set_enabled(rv);
-    } else {
-      logger->log_warn(
-          name(),
-          "*** enabled: %s, ignored because of DEBUG MODE, if will be ENABLED",
-          rv ? "yes" : "no");
-      bb_enable_switch_->set_enabled(true);
-    }
-    bb_enable_switch_->write();
-  }
+		return time_old != header_.stamp; // true, if there is a new cloud, false otherwise
 
-  // laser lines
-  for (fawkes::LaserLineInterface *ll : laserlines_) {
-    ll->read();
-  }
+	} else {
+		logger->log_debug(name(), "can't get pointcloud %s", cloud_in_name_.c_str());
+		cloud_in_registered_ = false;
+		return false;
+	}
 }
 
-void ConveyorPlaneThread::pose_add_element(pose element) {
-  // add element
-  poses_.push_front(element);
+void
+ConveyorPlaneThread::if_read()
+{
+	// enable switch
+	bb_enable_switch_->read();
 
-  // if to full, remove oldest
-  while (poses_.size() > cfg_pose_avg_hist_size_) {
-    poses_.pop_back();
-  }
+	bool rv = bb_enable_switch_->is_enabled();
+	while (!bb_enable_switch_->msgq_empty()) {
+		logger->log_info(name(), "RECIEVED SWITCH MESSAGE");
+		if (bb_enable_switch_->msgq_first_is<SwitchInterface::DisableSwitchMessage>()) {
+			rv = false;
+		} else if (bb_enable_switch_->msgq_first_is<SwitchInterface::EnableSwitchMessage>()) {
+			rv = true;
+		}
+
+		bb_enable_switch_->msgq_pop();
+	}
+	if (rv != bb_enable_switch_->is_enabled()) {
+		if (!cfg_debug_mode_) {
+			logger->log_info(name(), "*** enabled: %s", rv ? "yes" : "no");
+			bb_enable_switch_->set_enabled(rv);
+		} else {
+			logger->log_warn(name(),
+			                 "*** enabled: %s, ignored because of DEBUG MODE, if will be ENABLED",
+			                 rv ? "yes" : "no");
+			bb_enable_switch_->set_enabled(true);
+		}
+		bb_enable_switch_->write();
+	}
+
+	// laser lines
+	for (fawkes::LaserLineInterface *ll : laserlines_) {
+		ll->read();
+	}
 }
 
-bool ConveyorPlaneThread::pose_get_avg(pose &out) {
-  pose median;
+void
+ConveyorPlaneThread::pose_add_element(pose element)
+{
+	// add element
+	poses_.push_front(element);
 
-  // count invalid loops
-  unsigned int invalid = 0;
-  for (pose p : poses_) {
-    if (!p.valid) {
-      invalid++;
-    }
-  }
-
-  if (invalid > cfg_allow_invalid_poses_) {
-    logger->log_warn(name(), "view unstable, got %u invalid frames", invalid);
-  }
-
-  // Weiszfeld's algorithm to find the geometric median
-  median.translation.setValue(0, 0, 0);
-  median.rotation.setEuler(0, 0, 0);
-  unsigned int iteraterions = 20;
-  for (unsigned int i = 0; i < iteraterions; ++i) {
-
-    fawkes::tf::Vector3 numerator(0, 0, 0);
-    double divisor = 0;
-
-    for (pose p : poses_) {
-      if (p.valid) {
-        double divisor_current = (p.translation - median.translation).norm();
-        divisor += (1 / divisor_current);
-        numerator += (p.translation / divisor_current);
-        //        logger->log_info(name(), "(%lf\t%lf\t%lf) /\t%lf",
-        //        numerator.x(), numerator.y(), numerator.z(), divisor);
-      }
-    }
-    median.translation = numerator / divisor;
-  }
-
-  // remove outliers
-  std::list<pose> poses_used;
-  for (pose p : poses_) {
-    if (p.valid) {
-      double dist = (p.translation - median.translation).norm();
-
-      //      logger->log_warn(name(), "(%f\t%f\t%f)\t(%f\t%f\t%f) => %lf",
-      //          median.translation.x(), median.translation.y(),
-      //          median.translation.z(), p.translation.x(), p.translation.y(),
-      //          p.translation.z(), dist);
-      if (dist <= cfg_pose_diff_) {
-        poses_used.push_back(p);
-      }
-    }
-  }
-
-  if (poses_used.size() <= cfg_pose_avg_min_) {
-    logger->log_warn(name(), "not enough for average, got: %zu",
-                     poses_used.size());
-    return false;
-  }
-
-  // calculate average
-  //  Eigen::Quaternion<float> avgRot;
-  //  Eigen::Vector4f cumulative;
-  //  Eigen::Quaternion<float> firstRotation(poses_used.front().rotation.x(),
-  //  poses_used.front().rotation.y(), poses_used.front().rotation.z(),
-  //  poses_used.front().rotation.w()); float addDet = 1.0 /
-  //  (float)poses_used.size();
-  for (pose p : poses_used) {
-    //    Eigen::Quaternion<float> newRotation(p.rotation.x(), p.rotation.y(),
-    //    p.rotation.z(), p.rotation.w());
-
-    out.translation.setX(out.translation.x() + p.translation.x());
-    out.translation.setY(out.translation.y() + p.translation.y());
-    out.translation.setZ(out.translation.z() + p.translation.z());
-
-    //  fawkes::tf::Matrix3x3 m(p.rotation);
-    //  fawkes::tf::Scalar rc, pc, yc;
-    //  m.getEulerYPR(yc, pc, rc);
-    //  roll += fawkes::normalize_rad(rc);
-    //  pitch += fawkes::normalize_rad(pc);
-    //  yaw += fawkes::normalize_rad(yc);
-    //    avgRot = averageQuaternion(cumulative, newRotation, firstRotation,
-    //    addDet);
-  }
-
-  // normalize
-  out.translation.setX(out.translation.x() / poses_used.size());
-  out.translation.setY(out.translation.y() / poses_used.size());
-  out.translation.setZ(out.translation.z() / poses_used.size());
-
-  // roll /= poses_used.size();
-  // pitch /= poses_used.size();
-  // yaw /= poses_used.size();
-  // out.rotation.setEuler(yaw, pitch, roll);
-
-  //  logger->log_info(name(), "got %u for avg: (%f\t%f\t%f)\t(%f\t%f\t%f)",
-  //  poses_used.size(),
-  //      out.translation.x(), out.translation.y(), out.translation.z(),
-  //      roll, pitch, yaw);
-
-  return true;
+	// if to full, remove oldest
+	while (poses_.size() > cfg_pose_avg_hist_size_) {
+		poses_.pop_back();
+	}
 }
 
-bool ConveyorPlaneThread::laserline_get_best_fit(
-    fawkes::LaserLineInterface *&best_fit) {
-  best_fit = laserlines_.front();
+bool
+ConveyorPlaneThread::pose_get_avg(pose &out)
+{
+	pose median;
 
-  // get best line
-  for (fawkes::LaserLineInterface *ll : laserlines_) {
-    // just with writer
-    if (!ll->has_writer()) {
-      continue;
-    }
-    // just with history
-    if (ll->visibility_history() <= 2) {
-      continue;
-    }
-    // just if not too far away
-    Eigen::Vector3f center = laserline_get_center_transformed(ll);
+	// count invalid loops
+	unsigned int invalid = 0;
+	for (pose p : poses_) {
+		if (!p.valid) {
+			invalid++;
+		}
+	}
 
-    if (std::sqrt(center(0) * center(0) + center(2) * center(2)) > 0.8) {
-      continue;
-    }
+	if (invalid > cfg_allow_invalid_poses_) {
+		logger->log_warn(name(), "view unstable, got %u invalid frames", invalid);
+	}
 
-    // take with lowest angle
-    if (fabs(best_fit->bearing()) > fabs(ll->bearing())) {
-      best_fit = ll;
-    }
-  }
+	// Weiszfeld's algorithm to find the geometric median
+	median.translation.setValue(0, 0, 0);
+	median.rotation.setEuler(0, 0, 0);
+	unsigned int iteraterions = 20;
+	for (unsigned int i = 0; i < iteraterions; ++i) {
+		fawkes::tf::Vector3 numerator(0, 0, 0);
+		double              divisor = 0;
 
-  if (!best_fit->has_writer()) {
-    logger->log_info(name(), "no writer for laser lines");
-    best_fit = NULL;
-    return false;
-  }
-  if (best_fit->visibility_history() <= 2) {
-    best_fit = NULL;
-    return false;
-  }
-  if (fabs(best_fit->bearing()) > 0.35) {
-    best_fit = NULL;
-    return false;
-  } // ~20 deg
-  Eigen::Vector3f center = laserline_get_center_transformed(best_fit);
+		for (pose p : poses_) {
+			if (p.valid) {
+				double divisor_current = (p.translation - median.translation).norm();
+				divisor += (1 / divisor_current);
+				numerator += (p.translation / divisor_current);
+				//        logger->log_info(name(), "(%lf\t%lf\t%lf) /\t%lf",
+				//        numerator.x(), numerator.y(), numerator.z(), divisor);
+			}
+		}
+		median.translation = numerator / divisor;
+	}
 
-  if (std::sqrt(center(0) * center(0) + center(2) * center(2)) > 0.8) {
-    best_fit = NULL;
-    return false;
-  }
+	// remove outliers
+	std::list<pose> poses_used;
+	for (pose p : poses_) {
+		if (p.valid) {
+			double dist = (p.translation - median.translation).norm();
 
-  return true;
+			//      logger->log_warn(name(), "(%f\t%f\t%f)\t(%f\t%f\t%f) => %lf",
+			//          median.translation.x(), median.translation.y(),
+			//          median.translation.z(), p.translation.x(), p.translation.y(),
+			//          p.translation.z(), dist);
+			if (dist <= cfg_pose_diff_) {
+				poses_used.push_back(p);
+			}
+		}
+	}
+
+	if (poses_used.size() <= cfg_pose_avg_min_) {
+		logger->log_warn(name(), "not enough for average, got: %zu", poses_used.size());
+		return false;
+	}
+
+	// calculate average
+	//  Eigen::Quaternion<float> avgRot;
+	//  Eigen::Vector4f cumulative;
+	//  Eigen::Quaternion<float> firstRotation(poses_used.front().rotation.x(),
+	//  poses_used.front().rotation.y(), poses_used.front().rotation.z(),
+	//  poses_used.front().rotation.w()); float addDet = 1.0 /
+	//  (float)poses_used.size();
+	for (pose p : poses_used) {
+		//    Eigen::Quaternion<float> newRotation(p.rotation.x(), p.rotation.y(),
+		//    p.rotation.z(), p.rotation.w());
+
+		out.translation.setX(out.translation.x() + p.translation.x());
+		out.translation.setY(out.translation.y() + p.translation.y());
+		out.translation.setZ(out.translation.z() + p.translation.z());
+
+		//  fawkes::tf::Matrix3x3 m(p.rotation);
+		//  fawkes::tf::Scalar rc, pc, yc;
+		//  m.getEulerYPR(yc, pc, rc);
+		//  roll += fawkes::normalize_rad(rc);
+		//  pitch += fawkes::normalize_rad(pc);
+		//  yaw += fawkes::normalize_rad(yc);
+		//    avgRot = averageQuaternion(cumulative, newRotation, firstRotation,
+		//    addDet);
+	}
+
+	// normalize
+	out.translation.setX(out.translation.x() / poses_used.size());
+	out.translation.setY(out.translation.y() / poses_used.size());
+	out.translation.setZ(out.translation.z() / poses_used.size());
+
+	// roll /= poses_used.size();
+	// pitch /= poses_used.size();
+	// yaw /= poses_used.size();
+	// out.rotation.setEuler(yaw, pitch, roll);
+
+	//  logger->log_info(name(), "got %u for avg: (%f\t%f\t%f)\t(%f\t%f\t%f)",
+	//  poses_used.size(),
+	//      out.translation.x(), out.translation.y(), out.translation.z(),
+	//      roll, pitch, yaw);
+
+	return true;
 }
 
-Eigen::Vector3f ConveyorPlaneThread::laserline_get_center_transformed(
-    fawkes::LaserLineInterface *ll) {
-  fawkes::tf::Stamped<fawkes::tf::Point> tf_in, tf_out;
-  tf_in.stamp = ll->timestamp();
-  tf_in.frame_id = ll->frame_id();
-  tf_in.setX(ll->end_point_2(0) +
-             (ll->end_point_1(0) - ll->end_point_2(0)) / 2.);
-  tf_in.setY(ll->end_point_2(1) +
-             (ll->end_point_1(1) - ll->end_point_2(1)) / 2.);
-  tf_in.setZ(ll->end_point_2(2) +
-             (ll->end_point_1(2) - ll->end_point_2(2)) / 2.);
+bool
+ConveyorPlaneThread::laserline_get_best_fit(fawkes::LaserLineInterface *&best_fit)
+{
+	best_fit = laserlines_.front();
 
-  tf_listener->transform_point(header_.frame_id, tf_in, tf_out);
+	// get best line
+	for (fawkes::LaserLineInterface *ll : laserlines_) {
+		// just with writer
+		if (!ll->has_writer()) {
+			continue;
+		}
+		// just with history
+		if (ll->visibility_history() <= 2) {
+			continue;
+		}
+		// just if not too far away
+		Eigen::Vector3f center = laserline_get_center_transformed(ll);
 
-  Eigen::Vector3f out(tf_out.getX(), tf_out.getY(), tf_out.getZ());
+		if (std::sqrt(center(0) * center(0) + center(2) * center(2)) > 0.8) {
+			continue;
+		}
 
-  return out;
+		// take with lowest angle
+		if (fabs(best_fit->bearing()) > fabs(ll->bearing())) {
+			best_fit = ll;
+		}
+	}
+
+	if (!best_fit->has_writer()) {
+		logger->log_info(name(), "no writer for laser lines");
+		best_fit = NULL;
+		return false;
+	}
+	if (best_fit->visibility_history() <= 2) {
+		best_fit = NULL;
+		return false;
+	}
+	if (fabs(best_fit->bearing()) > 0.35) {
+		best_fit = NULL;
+		return false;
+	} // ~20 deg
+	Eigen::Vector3f center = laserline_get_center_transformed(best_fit);
+
+	if (std::sqrt(center(0) * center(0) + center(2) * center(2)) > 0.8) {
+		best_fit = NULL;
+		return false;
+	}
+
+	return true;
 }
 
-bool ConveyorPlaneThread::is_inbetween(double a, double b, double val) {
-  double low = std::min(a, b);
-  double up = std::max(a, b);
+Eigen::Vector3f
+ConveyorPlaneThread::laserline_get_center_transformed(fawkes::LaserLineInterface *ll)
+{
+	fawkes::tf::Stamped<fawkes::tf::Point> tf_in, tf_out;
+	tf_in.stamp    = ll->timestamp();
+	tf_in.frame_id = ll->frame_id();
+	tf_in.setX(ll->end_point_2(0) + (ll->end_point_1(0) - ll->end_point_2(0)) / 2.);
+	tf_in.setY(ll->end_point_2(1) + (ll->end_point_1(1) - ll->end_point_2(1)) / 2.);
+	tf_in.setZ(ll->end_point_2(2) + (ll->end_point_1(2) - ll->end_point_2(2)) / 2.);
 
-  if (val >= low && val <= up) {
-    return true;
-  } else {
-    return false;
-  }
+	tf_listener->transform_point(header_.frame_id, tf_in, tf_out);
+
+	Eigen::Vector3f out(tf_out.getX(), tf_out.getY(), tf_out.getZ());
+
+	return out;
 }
 
-CloudPtr ConveyorPlaneThread::cloud_remove_gripper(CloudPtr in) {
-  CloudPtr out(new Cloud);
-  for (Point p : *in) {
-    if (!(is_inbetween(cfg_gripper_y_min_, cfg_gripper_y_max_, p.y) &&
-          p.z < cfg_gripper_z_max_)) { // remove gripper
-      if (p.y < cfg_gripper_slice_y_max_ &&
-          p.y > cfg_gripper_slice_y_min_) { // leave just correct hight
-        out->push_back(p);
-      }
-    }
-  }
+bool
+ConveyorPlaneThread::is_inbetween(double a, double b, double val)
+{
+	double low = std::min(a, b);
+	double up  = std::max(a, b);
 
-  return out;
-}
-
-CloudPtr ConveyorPlaneThread::cloud_remove_offset_to_front(
-    CloudPtr in, fawkes::LaserLineInterface *ll, bool use_ll) {
-  double space = cfg_front_space_;
-  double z_min, z_max;
-  z_min = 0;
-  if (use_ll) {
-    Eigen::Vector3f c = laserline_get_center_transformed(ll);
-    z_min = c(2) + cfg_front_offset_ - (space / 2.);
-  }
-  z_max = z_min + space;
-
-  CloudPtr out(new Cloud);
-  for (Point p : *in) {
-    if (p.z >= z_min && p.z <= z_max) {
-      out->push_back(p);
-    }
-  }
-
-  return out;
-}
-
-CloudPtr ConveyorPlaneThread::cloud_remove_offset_to_left_right(
-    CloudPtr in, fawkes::LaserLineInterface *ll, bool use_ll) {
-  if (use_ll) {
-    Eigen::Vector3f c = laserline_get_center_transformed(ll);
-
-    double x_min = c(0) - cfg_left_cut_;
-    double x_max = c(0) + cfg_right_cut_;
-
-    CloudPtr out(new Cloud);
-    for (Point p : *in) {
-      if (p.x >= x_min && p.x <= x_max) {
-        out->push_back(p);
-      }
-    }
-    return out;
-  } else {
-    logger->log_info(name(), "-------------STOPPED USING LASERLINE-----------");
-    CloudPtr out(new Cloud);
-    for (Point p : *in) {
-      if (p.x >= -cfg_left_cut_no_ll_ && p.x <= cfg_right_cut_no_ll_) {
-        out->push_back(p);
-      }
-    }
-    return out;
-  }
+	if (val >= low && val <= up) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
 CloudPtr
-ConveyorPlaneThread::cloud_get_plane(CloudPtr in,
-                                     pcl::ModelCoefficients::Ptr coeff) {
-  CloudPtr out(new Cloud(*in));
+ConveyorPlaneThread::cloud_remove_gripper(CloudPtr in)
+{
+	CloudPtr out(new Cloud);
+	for (Point p : *in) {
+		if (!(is_inbetween(cfg_gripper_y_min_, cfg_gripper_y_max_, p.y)
+		      && p.z < cfg_gripper_z_max_)) { // remove gripper
+			if (p.y < cfg_gripper_slice_y_max_
+			    && p.y > cfg_gripper_slice_y_min_) { // leave just correct hight
+				out->push_back(p);
+			}
+		}
+	}
 
-  // get planes
-  pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
-  // Create the segmentation object
-  pcl::SACSegmentation<pcl::PointXYZ> seg;
-  // Optional
-  seg.setOptimizeCoefficients(true);
-  // Mandatory
-  seg.setModelType(pcl::SACMODEL_PLANE);
-  seg.setMethodType(pcl::SAC_RANSAC);
-  seg.setDistanceThreshold(cfg_plane_dist_threshold_);
+	return out;
+}
 
-  seg.setInputCloud(out);
-  seg.segment(*inliers, *coeff);
+CloudPtr
+ConveyorPlaneThread::cloud_remove_offset_to_front(CloudPtr                    in,
+                                                  fawkes::LaserLineInterface *ll,
+                                                  bool                        use_ll)
+{
+	double space = cfg_front_space_;
+	double z_min, z_max;
+	z_min = 0;
+	if (use_ll) {
+		Eigen::Vector3f c = laserline_get_center_transformed(ll);
+		z_min             = c(2) + cfg_front_offset_ - (space / 2.);
+	}
+	z_max = z_min + space;
 
-  if (inliers->indices.size() == 0) {
-    logger->log_error(
-        name(), "Could not estimate a planar model for the given dataset.");
-    return CloudPtr();
-  }
+	CloudPtr out(new Cloud);
+	for (Point p : *in) {
+		if (p.z >= z_min && p.z <= z_max) {
+			out->push_back(p);
+		}
+	}
 
-  // get inliers
-  CloudPtr tmp(new Cloud);
-  pcl::ExtractIndices<Point> extract;
-  extract.setInputCloud(out);
-  extract.setIndices(inliers);
-  extract.setNegative(false);
+	return out;
+}
 
-  extract.filter(*tmp);
-  *out = *tmp;
+CloudPtr
+ConveyorPlaneThread::cloud_remove_offset_to_left_right(CloudPtr                    in,
+                                                       fawkes::LaserLineInterface *ll,
+                                                       bool                        use_ll)
+{
+	if (use_ll) {
+		Eigen::Vector3f c = laserline_get_center_transformed(ll);
 
-  // check if cloud normal is ok
-  return out;
+		double x_min = c(0) - cfg_left_cut_;
+		double x_max = c(0) + cfg_right_cut_;
+
+		CloudPtr out(new Cloud);
+		for (Point p : *in) {
+			if (p.x >= x_min && p.x <= x_max) {
+				out->push_back(p);
+			}
+		}
+		return out;
+	} else {
+		logger->log_info(name(), "-------------STOPPED USING LASERLINE-----------");
+		CloudPtr out(new Cloud);
+		for (Point p : *in) {
+			if (p.x >= -cfg_left_cut_no_ll_ && p.x <= cfg_right_cut_no_ll_) {
+				out->push_back(p);
+			}
+		}
+		return out;
+	}
+}
+
+CloudPtr
+ConveyorPlaneThread::cloud_get_plane(CloudPtr in, pcl::ModelCoefficients::Ptr coeff)
+{
+	CloudPtr out(new Cloud(*in));
+
+	// get planes
+	pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
+	// Create the segmentation object
+	pcl::SACSegmentation<pcl::PointXYZ> seg;
+	// Optional
+	seg.setOptimizeCoefficients(true);
+	// Mandatory
+	seg.setModelType(pcl::SACMODEL_PLANE);
+	seg.setMethodType(pcl::SAC_RANSAC);
+	seg.setDistanceThreshold(cfg_plane_dist_threshold_);
+
+	seg.setInputCloud(out);
+	seg.segment(*inliers, *coeff);
+
+	if (inliers->indices.size() == 0) {
+		logger->log_error(name(), "Could not estimate a planar model for the given dataset.");
+		return CloudPtr();
+	}
+
+	// get inliers
+	CloudPtr                   tmp(new Cloud);
+	pcl::ExtractIndices<Point> extract;
+	extract.setInputCloud(out);
+	extract.setIndices(inliers);
+	extract.setNegative(false);
+
+	extract.filter(*tmp);
+	*out = *tmp;
+
+	// check if cloud normal is ok
+	return out;
 }
 
 boost::shared_ptr<std::vector<pcl::PointIndices>>
-ConveyorPlaneThread::cloud_cluster(CloudPtr in) {
-  // in = cloud_voxel_grid(in);
-  // Creating the KdTree object for the search method of the extraction
-  pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(
-      new pcl::search::KdTree<pcl::PointXYZ>);
-  tree->setInputCloud(in);
+ConveyorPlaneThread::cloud_cluster(CloudPtr in)
+{
+	// in = cloud_voxel_grid(in);
+	// Creating the KdTree object for the search method of the extraction
+	pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
+	tree->setInputCloud(in);
 
-  boost::shared_ptr<std::vector<pcl::PointIndices>> cluster_indices(
-      new std::vector<pcl::PointIndices>);
-  pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec;
-  ec.setClusterTolerance(cfg_cluster_tolerance_);
-  ec.setMinClusterSize(cfg_cluster_size_min_);
-  ec.setMaxClusterSize(cfg_cluster_size_max_);
-  ec.setSearchMethod(tree);
-  ec.setInputCloud(in);
-  ec.extract(*cluster_indices);
+	boost::shared_ptr<std::vector<pcl::PointIndices>> cluster_indices(
+	  new std::vector<pcl::PointIndices>);
+	pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec;
+	ec.setClusterTolerance(cfg_cluster_tolerance_);
+	ec.setMinClusterSize(cfg_cluster_size_min_);
+	ec.setMaxClusterSize(cfg_cluster_size_max_);
+	ec.setSearchMethod(tree);
+	ec.setInputCloud(in);
+	ec.extract(*cluster_indices);
 
-  return cluster_indices;
+	return cluster_indices;
 }
 
-std::vector<CloudPtr> ConveyorPlaneThread::cluster_split(
-    CloudPtr in,
-    boost::shared_ptr<std::vector<pcl::PointIndices>> cluster_indices) {
-  std::vector<CloudPtr> clouds_out;
-  for (std::vector<pcl::PointIndices>::const_iterator c_it =
-           cluster_indices->begin();
-       c_it != cluster_indices->end(); ++c_it) {
-    CloudPtr cloud_cluster(new Cloud);
-    for (std::vector<int>::const_iterator p_it = c_it->indices.begin();
-         p_it != c_it->indices.end(); ++p_it) {
-      cloud_cluster->points.push_back(in->points[*p_it]);
-    }
-    cloud_cluster->width = cloud_cluster->points.size();
-    cloud_cluster->height = 1;
-    cloud_cluster->is_dense = true;
+std::vector<CloudPtr>
+ConveyorPlaneThread::cluster_split(
+  CloudPtr                                          in,
+  boost::shared_ptr<std::vector<pcl::PointIndices>> cluster_indices)
+{
+	std::vector<CloudPtr> clouds_out;
+	for (std::vector<pcl::PointIndices>::const_iterator c_it = cluster_indices->begin();
+	     c_it != cluster_indices->end();
+	     ++c_it) {
+		CloudPtr cloud_cluster(new Cloud);
+		for (std::vector<int>::const_iterator p_it = c_it->indices.begin(); p_it != c_it->indices.end();
+		     ++p_it) {
+			cloud_cluster->points.push_back(in->points[*p_it]);
+		}
+		cloud_cluster->width    = cloud_cluster->points.size();
+		cloud_cluster->height   = 1;
+		cloud_cluster->is_dense = true;
 
-    clouds_out.push_back(cloud_cluster);
-  }
+		clouds_out.push_back(cloud_cluster);
+	}
 
-  return clouds_out;
+	return clouds_out;
 }
 
 CloudPtr
-ConveyorPlaneThread::cluster_find_biggest(std::vector<CloudPtr> clouds_in,
-                                          size_t &id) {
-  CloudPtr biggest(new Cloud);
-  size_t i = 0;
-  for (CloudPtr current : clouds_in) {
-    if (biggest->size() < current->size()) {
-      biggest = current;
-      id = i;
-    }
-    ++i;
-  }
+ConveyorPlaneThread::cluster_find_biggest(std::vector<CloudPtr> clouds_in, size_t &id)
+{
+	CloudPtr biggest(new Cloud);
+	size_t   i = 0;
+	for (CloudPtr current : clouds_in) {
+		if (biggest->size() < current->size()) {
+			biggest = current;
+			id      = i;
+		}
+		++i;
+	}
 
-  return biggest;
+	return biggest;
 }
 
-CloudPtr ConveyorPlaneThread::cloud_voxel_grid(CloudPtr in) {
-  float ls = cfg_voxel_grid_leave_size_;
-  pcl::ApproximateVoxelGrid<pcl::PointXYZ> vg;
-  CloudPtr out(new Cloud);
-  vg.setInputCloud(in);
-  // logger->log_debug(name(), "voxel leaf size is %f", ls);
-  vg.setLeafSize(ls, ls, ls);
-  vg.filter(*out);
-  return out;
+CloudPtr
+ConveyorPlaneThread::cloud_voxel_grid(CloudPtr in)
+{
+	float                                    ls = cfg_voxel_grid_leave_size_;
+	pcl::ApproximateVoxelGrid<pcl::PointXYZ> vg;
+	CloudPtr                                 out(new Cloud);
+	vg.setInputCloud(in);
+	// logger->log_debug(name(), "voxel leaf size is %f", ls);
+	vg.setLeafSize(ls, ls, ls);
+	vg.filter(*out);
+	return out;
 }
 
-void ConveyorPlaneThread::cloud_publish(CloudPtr cloud_in,
-                                        fawkes::RefPtr<Cloud> cloud_out) {
-  **cloud_out = *cloud_in;
-  cloud_out->header = header_;
+void
+ConveyorPlaneThread::cloud_publish(CloudPtr cloud_in, fawkes::RefPtr<Cloud> cloud_out)
+{
+	**cloud_out       = *cloud_in;
+	cloud_out->header = header_;
 }
 
 ConveyorPlaneThread::pose
-ConveyorPlaneThread::calculate_pose(Eigen::Vector4f centroid,
-                                    Eigen::Vector3f normal) {
-  Eigen::Vector3f tangent0 = normal.cross(Eigen::Vector3f(1, 0, 0));
-  if (tangent0.dot(tangent0) < 0.0001) {
-    tangent0 = normal.cross(Eigen::Vector3f(0, 1, 0));
-  }
-  tangent0.normalize();
-  Eigen::Vector3f tangent1 = normal.cross(tangent0);
-  tangent1.normalize();
-  Eigen::Matrix3f rotMatrix;
-  rotMatrix << tangent0, tangent1, normal;
-  Eigen::Quaternion<float> q(rotMatrix);
-  fawkes::tf::Vector3 origin(centroid(0), centroid(1), centroid(2));
-  fawkes::tf::Quaternion rot(q.x(), q.y(), q.z(), q.w());
+ConveyorPlaneThread::calculate_pose(Eigen::Vector4f centroid, Eigen::Vector3f normal)
+{
+	Eigen::Vector3f tangent0 = normal.cross(Eigen::Vector3f(1, 0, 0));
+	if (tangent0.dot(tangent0) < 0.0001) {
+		tangent0 = normal.cross(Eigen::Vector3f(0, 1, 0));
+	}
+	tangent0.normalize();
+	Eigen::Vector3f tangent1 = normal.cross(tangent0);
+	tangent1.normalize();
+	Eigen::Matrix3f rotMatrix;
+	rotMatrix << tangent0, tangent1, normal;
+	Eigen::Quaternion<float> q(rotMatrix);
+	fawkes::tf::Vector3      origin(centroid(0), centroid(1), centroid(2));
+	fawkes::tf::Quaternion   rot(q.x(), q.y(), q.z(), q.w());
 
-  pose ret;
-  ret.translation = origin;
-  ret.rotation = rot;
+	pose ret;
+	ret.translation = origin;
+	ret.rotation    = rot;
 
-  return ret;
+	return ret;
 }
 
-void ConveyorPlaneThread::tf_send_from_pose_if(pose pose) {
-  fawkes::tf::StampedTransform transform;
+void
+ConveyorPlaneThread::tf_send_from_pose_if(pose pose)
+{
+	fawkes::tf::StampedTransform transform;
 
-  transform.frame_id = header_.frame_id;
-  transform.child_frame_id = conveyor_frame_id_;
-  // TODO use time of header, just don't works with bagfiles
-  fawkes::Time pt;
-  pt.set_time((long)header_.stamp / 1000);
-  transform.stamp = pt;
+	transform.frame_id       = header_.frame_id;
+	transform.child_frame_id = conveyor_frame_id_;
+	// TODO use time of header, just don't works with bagfiles
+	fawkes::Time pt;
+	pt.set_time((long)header_.stamp / 1000);
+	transform.stamp = pt;
 
-  transform.setOrigin(pose.translation);
-  transform.setRotation(pose.rotation);
+	transform.setOrigin(pose.translation);
+	transform.setRotation(pose.rotation);
 
-  tf_publisher->send_transform(transform);
+	tf_publisher->send_transform(transform);
 }
 
-void ConveyorPlaneThread::pose_write(pose pose) {
-  double translation[3], rotation[4];
-  translation[0] = pose.translation.x();
-  translation[1] = pose.translation.y();
-  translation[2] = pose.translation.z();
-  rotation[0] = pose.rotation.x();
-  rotation[1] = pose.rotation.y();
-  rotation[2] = pose.rotation.z();
-  rotation[3] = pose.rotation.w();
-  bb_pose_->set_translation(translation);
-  bb_pose_->set_rotation(rotation);
+void
+ConveyorPlaneThread::pose_write(pose pose)
+{
+	double translation[3], rotation[4];
+	translation[0] = pose.translation.x();
+	translation[1] = pose.translation.y();
+	translation[2] = pose.translation.z();
+	rotation[0]    = pose.rotation.x();
+	rotation[1]    = pose.rotation.y();
+	rotation[2]    = pose.rotation.z();
+	rotation[3]    = pose.rotation.w();
+	bb_pose_->set_translation(translation);
+	bb_pose_->set_rotation(rotation);
 
-  bb_pose_->set_frame(header_.frame_id.c_str());
-  fawkes::Time stamp((long)header_.stamp);
-  bb_pose_->set_visibility_history(vis_hist_);
-  bb_pose_->write();
+	bb_pose_->set_frame(header_.frame_id.c_str());
+	fawkes::Time stamp((long)header_.stamp);
+	bb_pose_->set_visibility_history(vis_hist_);
+	bb_pose_->write();
 }
 
-void ConveyorPlaneThread::pose_publish_tf(pose pose) {
-  // transform data into gripper frame (this is better for later use)
-  tf::Stamped<tf::Pose> tf_pose_cam, tf_pose_gripper;
-  tf_pose_cam.stamp = fawkes::Time((long)header_.stamp / 1000);
-  tf_pose_cam.frame_id = header_.frame_id;
-  tf_pose_cam.setOrigin(tf::Vector3(pose.translation.x(), pose.translation.y(),
-                                    pose.translation.z()));
-  tf_pose_cam.setRotation(tf::Quaternion(pose.rotation.x(), pose.rotation.y(),
-                                         pose.rotation.z(), pose.rotation.w()));
-  tf_listener->transform_pose("gripper", tf_pose_cam, tf_pose_gripper);
+void
+ConveyorPlaneThread::pose_publish_tf(pose pose)
+{
+	// transform data into gripper frame (this is better for later use)
+	tf::Stamped<tf::Pose> tf_pose_cam, tf_pose_gripper;
+	tf_pose_cam.stamp    = fawkes::Time((long)header_.stamp / 1000);
+	tf_pose_cam.frame_id = header_.frame_id;
+	tf_pose_cam.setOrigin(
+	  tf::Vector3(pose.translation.x(), pose.translation.y(), pose.translation.z()));
+	tf_pose_cam.setRotation(
+	  tf::Quaternion(pose.rotation.x(), pose.rotation.y(), pose.rotation.z(), pose.rotation.w()));
+	tf_listener->transform_pose("gripper", tf_pose_cam, tf_pose_gripper);
 
-  // publish the transform from the gripper to the conveyor
-  tf::Transform transform(tf::create_quaternion_from_yaw(M_PI),
-                          tf_pose_gripper.getOrigin());
-  tf::StampedTransform stamped_transform(transform, tf_pose_gripper.stamp,
-                                         tf_pose_gripper.frame_id,
-                                         conveyor_frame_id_);
-  tf_publisher->send_transform(stamped_transform);
+	// publish the transform from the gripper to the conveyor
+	tf::Transform        transform(tf::create_quaternion_from_yaw(M_PI), tf_pose_gripper.getOrigin());
+	tf::StampedTransform stamped_transform(transform,
+	                                       tf_pose_gripper.stamp,
+	                                       tf_pose_gripper.frame_id,
+	                                       conveyor_frame_id_);
+	tf_publisher->send_transform(stamped_transform);
 }
-void ConveyorPlaneThread::start_waiting() { wait_start_ = Time(); }
+void
+ConveyorPlaneThread::start_waiting()
+{
+	wait_start_ = Time();
+}
 
-Eigen::Quaternion<float> ConveyorPlaneThread::averageQuaternion(
-    Eigen::Vector4f &cumulative, Eigen::Quaternion<float> newRotation,
-    Eigen::Quaternion<float> firstRotation, float addDet) {
+Eigen::Quaternion<float>
+ConveyorPlaneThread::averageQuaternion(Eigen::Vector4f &        cumulative,
+                                       Eigen::Quaternion<float> newRotation,
+                                       Eigen::Quaternion<float> firstRotation,
+                                       float                    addDet)
+{
+	float w = 0.0;
+	float x = 0.0;
+	float y = 0.0;
+	float z = 0.0;
 
-  float w = 0.0;
-  float x = 0.0;
-  float y = 0.0;
-  float z = 0.0;
+	if (!areQuaternionsClose(newRotation, firstRotation)) {
+		newRotation = inverseSignQuaternion(newRotation);
+	}
 
-  if (!areQuaternionsClose(newRotation, firstRotation)) {
-    newRotation = inverseSignQuaternion(newRotation);
-  }
+	cumulative.x() += newRotation.x();
+	x = cumulative.x() * addDet;
+	cumulative.y() += newRotation.y();
+	y = cumulative.y() * addDet;
+	cumulative.z() += newRotation.z();
+	z = cumulative.z() * addDet;
+	cumulative.w() += newRotation.w();
+	w = cumulative.w() * addDet;
 
-  cumulative.x() += newRotation.x();
-  x = cumulative.x() * addDet;
-  cumulative.y() += newRotation.y();
-  y = cumulative.y() * addDet;
-  cumulative.z() += newRotation.z();
-  z = cumulative.z() * addDet;
-  cumulative.w() += newRotation.w();
-  w = cumulative.w() * addDet;
-
-  Eigen::Quaternion<float> result = normalizeQuaternion(x, y, z, w);
-  return result;
+	Eigen::Quaternion<float> result = normalizeQuaternion(x, y, z, w);
+	return result;
 }
 Eigen::Quaternion<float>
-ConveyorPlaneThread::normalizeQuaternion(float x, float y, float z, float w) {
+ConveyorPlaneThread::normalizeQuaternion(float x, float y, float z, float w)
+{
+	float lengthD = 1.0 / (w * w + x * x + y * y + z * z);
+	w *= lengthD;
+	x *= lengthD;
+	y *= lengthD;
+	z *= lengthD;
 
-  float lengthD = 1.0 / (w * w + x * x + y * y + z * z);
-  w *= lengthD;
-  x *= lengthD;
-  y *= lengthD;
-  z *= lengthD;
-
-  Eigen::Quaternion<float> result(x, y, z, w);
-  return result;
+	Eigen::Quaternion<float> result(x, y, z, w);
+	return result;
 }
 
 // Changes the sign of the quaternion components. This is not the same as the
 // inverse.
 Eigen::Quaternion<float>
-ConveyorPlaneThread::inverseSignQuaternion(Eigen::Quaternion<float> q) {
-  Eigen::Quaternion<float> result(-q.x(), -q.y(), -q.z(), -q.w());
-  return result;
+ConveyorPlaneThread::inverseSignQuaternion(Eigen::Quaternion<float> q)
+{
+	Eigen::Quaternion<float> result(-q.x(), -q.y(), -q.z(), -q.w());
+	return result;
 }
 
 // Returns true if the two input quaternions are close to each other. This can
 // be used to check whether or not one of two quaternions which are supposed to
 // be very similar but has its component signs reversed (q has the same rotation
 // as -q)
-bool ConveyorPlaneThread::areQuaternionsClose(Eigen::Quaternion<float> q1,
-                                              Eigen::Quaternion<float> q2) {
-
-  float dot = q1.dot(q2);
-  if (dot < 0.0) {
-    return false;
-  } else {
-    return true;
-  }
+bool
+ConveyorPlaneThread::areQuaternionsClose(Eigen::Quaternion<float> q1, Eigen::Quaternion<float> q2)
+{
+	float dot = q1.dot(q2);
+	if (dot < 0.0) {
+		return false;
+	} else {
+		return true;
+	}
 }
 
-bool ConveyorPlaneThread::need_to_wait() {
-  return Time() < wait_start_ + wait_time_;
+bool
+ConveyorPlaneThread::need_to_wait()
+{
+	return Time() < wait_start_ + wait_time_;
 }

--- a/src/plugins/conveyor_plane/conveyor_plane_thread.h
+++ b/src/plugins/conveyor_plane/conveyor_plane_thread.h
@@ -23,6 +23,8 @@
 #ifndef _CONVEYOR_PLANE_THREAD_
 #define _CONVEYOR_PLANE_THREAD_
 
+#include "visualisation.hpp"
+
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/configurable.h>
@@ -30,21 +32,17 @@
 #include <aspect/pointcloud.h>
 #include <aspect/tf.h>
 #include <core/threading/thread.h>
-
-#include <plugins/ros/aspect/ros.h>
-
 #include <interfaces/LaserLineInterface.h>
 #include <interfaces/Position3DInterface.h>
 #include <interfaces/SwitchInterface.h>
-
-#include "visualisation.hpp"
+#include <plugins/ros/aspect/ros.h>
 
 #include <map>
 #include <string>
 
-typedef pcl::PointXYZ Point;
-typedef pcl::PointCloud<Point> Cloud;
-typedef typename Cloud::Ptr CloudPtr;
+typedef pcl::PointXYZ            Point;
+typedef pcl::PointCloud<Point>   Cloud;
+typedef typename Cloud::Ptr      CloudPtr;
 typedef typename Cloud::ConstPtr CloudConstPtr;
 
 class ConveyorPlaneThread : public fawkes::Thread,
@@ -54,162 +52,164 @@ class ConveyorPlaneThread : public fawkes::Thread,
                             public fawkes::BlackBoardAspect,
                             public fawkes::PointCloudAspect,
                             public fawkes::ROSAspect,
-                            public fawkes::TransformAspect {
+                            public fawkes::TransformAspect
+{
 private:
-  class pose {
-  public:
-    bool valid = true;
-    fawkes::tf::Vector3 translation;
-    fawkes::tf::Quaternion rotation;
-    pose() {
-      translation.setX(0);
-      translation.setY(0);
-      translation.setZ(0);
-      rotation.setX(0);
-      rotation.setY(0);
-      rotation.setZ(0);
-      rotation.setW(0);
-    }
-  };
-  Visualisation *visualisation_;
+	class pose
+	{
+	public:
+		bool                   valid = true;
+		fawkes::tf::Vector3    translation;
+		fawkes::tf::Quaternion rotation;
+		pose()
+		{
+			translation.setX(0);
+			translation.setY(0);
+			translation.setZ(0);
+			rotation.setX(0);
+			rotation.setY(0);
+			rotation.setZ(0);
+			rotation.setW(0);
+		}
+	};
+	Visualisation *visualisation_;
 
-  // cfg values
-  std::string cloud_in_name_;
-  std::string cloud_out_inter_1_name_;
-  std::string cloud_out_result_name_;
-  std::string cfg_bb_conveyor_plane_name_;
-  std::string cfg_bb_switch_name_;
-  std::string cfg_bb_realsense_switch_name_;
-  std::string conveyor_frame_id_;
-  std::vector<std::string> laserlines_names_;
+	// cfg values
+	std::string              cloud_in_name_;
+	std::string              cloud_out_inter_1_name_;
+	std::string              cloud_out_result_name_;
+	std::string              cfg_bb_conveyor_plane_name_;
+	std::string              cfg_bb_switch_name_;
+	std::string              cfg_bb_realsense_switch_name_;
+	std::string              conveyor_frame_id_;
+	std::vector<std::string> laserlines_names_;
 
-  bool cfg_pose_close_if_no_new_pointclouds_;
-  //  std::string bb_tag_name_;
-  float cfg_pose_diff_;
-  float vis_hist_angle_diff_;
+	bool cfg_pose_close_if_no_new_pointclouds_;
+	//  std::string bb_tag_name_;
+	float cfg_pose_diff_;
+	float vis_hist_angle_diff_;
 
-  float cfg_gripper_y_min_;
-  float cfg_gripper_y_max_;
-  float cfg_gripper_z_max_;
-  float cfg_gripper_slice_y_min_;
-  float cfg_gripper_slice_y_max_;
+	float cfg_gripper_y_min_;
+	float cfg_gripper_y_max_;
+	float cfg_gripper_z_max_;
+	float cfg_gripper_slice_y_min_;
+	float cfg_gripper_slice_y_max_;
 
-  float cfg_front_space_;
-  float cfg_front_offset_;
+	float cfg_front_space_;
+	float cfg_front_offset_;
 
-  float cfg_left_cut_;
-  float cfg_right_cut_;
-  float cfg_left_cut_no_ll_;
-  float cfg_right_cut_no_ll_;
+	float cfg_left_cut_;
+	float cfg_right_cut_;
+	float cfg_left_cut_no_ll_;
+	float cfg_right_cut_no_ll_;
 
-  float cfg_plane_dist_threshold_;
+	float cfg_plane_dist_threshold_;
 
-  float cfg_plane_height_minimum_;
-  float cfg_plane_width_minimum_;
-  float cfg_normal_z_minimum_;
+	float cfg_plane_height_minimum_;
+	float cfg_plane_width_minimum_;
+	float cfg_normal_z_minimum_;
 
-  float cfg_cluster_tolerance_;
-  float cfg_cluster_size_min_;
-  float cfg_cluster_size_max_;
+	float cfg_cluster_tolerance_;
+	float cfg_cluster_size_min_;
+	float cfg_cluster_size_max_;
 
-  float cfg_voxel_grid_leave_size_;
+	float cfg_voxel_grid_leave_size_;
 
-  uint cfg_allow_invalid_poses_;
+	uint cfg_allow_invalid_poses_;
 
-  // state vars
-  bool enable_pose_;
-  bool cfg_enable_switch_;
-  bool cfg_debug_mode_;
-  bool cfg_enable_product_removal_;
-  bool cloud_in_registered_;
-  bool cfg_use_visualisation_;
-  pcl::PCLHeader header_;
-  std::pair<fawkes::tf::Vector3, fawkes::tf::Quaternion> pose_;
-  int vis_hist_;
+	// state vars
+	bool                                                   enable_pose_;
+	bool                                                   cfg_enable_switch_;
+	bool                                                   cfg_debug_mode_;
+	bool                                                   cfg_enable_product_removal_;
+	bool                                                   cloud_in_registered_;
+	bool                                                   cfg_use_visualisation_;
+	pcl::PCLHeader                                         header_;
+	std::pair<fawkes::tf::Vector3, fawkes::tf::Quaternion> pose_;
+	int                                                    vis_hist_;
 
-  size_t cfg_pose_avg_hist_size_;
-  size_t cfg_pose_avg_min_;
+	size_t cfg_pose_avg_hist_size_;
+	size_t cfg_pose_avg_min_;
 
-  std::list<pose> poses_;
+	std::list<pose> poses_;
 
-  // point clouds from pcl_manager
-  fawkes::RefPtr<const Cloud> cloud_in_;
-  fawkes::RefPtr<Cloud> cloud_out_inter_1_;
-  fawkes::RefPtr<Cloud> cloud_out_result_;
+	// point clouds from pcl_manager
+	fawkes::RefPtr<const Cloud> cloud_in_;
+	fawkes::RefPtr<Cloud>       cloud_out_inter_1_;
+	fawkes::RefPtr<Cloud>       cloud_out_result_;
 
-  // interfaces write
-  fawkes::SwitchInterface *bb_enable_switch_;
-  fawkes::Position3DInterface *bb_pose_;
+	// interfaces write
+	fawkes::SwitchInterface *    bb_enable_switch_;
+	fawkes::Position3DInterface *bb_pose_;
 
-  // interfaces read
-  std::vector<fawkes::LaserLineInterface *> laserlines_;
-  fawkes::SwitchInterface *realsense_switch_;
-  fawkes::Time wait_start_;
-  fawkes::Time wait_time_;
-  //  fawkes::Position3DInterface * bb_tag_;
+	// interfaces read
+	std::vector<fawkes::LaserLineInterface *> laserlines_;
+	fawkes::SwitchInterface *                 realsense_switch_;
+	fawkes::Time                              wait_start_;
+	fawkes::Time                              wait_time_;
+	//  fawkes::Position3DInterface * bb_tag_;
 
-  /**
+	/**
    * check if the pointcloud is available
    */
-  bool pc_in_check();
-  void bb_pose_conditional_open();
-  void bb_pose_conditional_close();
+	bool pc_in_check();
+	void bb_pose_conditional_open();
+	void bb_pose_conditional_close();
 
-  void pose_add_element(pose element);
-  bool pose_get_avg(pose &out);
+	void pose_add_element(pose element);
+	bool pose_get_avg(pose &out);
 
-  void if_read();
-  bool laserline_get_best_fit(fawkes::LaserLineInterface *&best_fit);
-  Eigen::Vector3f
-  laserline_get_center_transformed(fawkes::LaserLineInterface *ll);
+	void            if_read();
+	bool            laserline_get_best_fit(fawkes::LaserLineInterface *&best_fit);
+	Eigen::Vector3f laserline_get_center_transformed(fawkes::LaserLineInterface *ll);
 
-  bool is_inbetween(double a, double b, double val);
+	bool is_inbetween(double a, double b, double val);
 
-  CloudPtr cloud_remove_gripper(CloudPtr in);
-  CloudPtr cloud_remove_offset_to_bottom(CloudPtr in);
-  CloudPtr cloud_remove_offset_to_front(CloudPtr in,
-                                        fawkes::LaserLineInterface *ll = NULL,
-                                        bool use_ll = false);
-  CloudPtr cloud_remove_offset_to_left_right(CloudPtr in,
-                                             fawkes::LaserLineInterface *ll,
-                                             bool use_ll);
-  CloudPtr cloud_get_plane(CloudPtr in, pcl::ModelCoefficients::Ptr coeff);
-  boost::shared_ptr<std::vector<pcl::PointIndices>> cloud_cluster(CloudPtr in);
-  CloudPtr cloud_voxel_grid(CloudPtr in);
+	CloudPtr cloud_remove_gripper(CloudPtr in);
+	CloudPtr cloud_remove_offset_to_bottom(CloudPtr in);
+	CloudPtr cloud_remove_offset_to_front(CloudPtr                    in,
+	                                      fawkes::LaserLineInterface *ll     = NULL,
+	                                      bool                        use_ll = false);
+	CloudPtr
+	         cloud_remove_offset_to_left_right(CloudPtr in, fawkes::LaserLineInterface *ll, bool use_ll);
+	CloudPtr cloud_get_plane(CloudPtr in, pcl::ModelCoefficients::Ptr coeff);
+	boost::shared_ptr<std::vector<pcl::PointIndices>> cloud_cluster(CloudPtr in);
+	CloudPtr                                          cloud_voxel_grid(CloudPtr in);
 
-  std::vector<CloudPtr> cluster_split(
-      CloudPtr in,
-      boost::shared_ptr<std::vector<pcl::PointIndices>> cluster_indices);
-  CloudPtr cluster_find_biggest(std::vector<CloudPtr> clouds_in, size_t &id);
+	std::vector<CloudPtr>
+	         cluster_split(CloudPtr in, boost::shared_ptr<std::vector<pcl::PointIndices>> cluster_indices);
+	CloudPtr cluster_find_biggest(std::vector<CloudPtr> clouds_in, size_t &id);
 
-  void cloud_publish(CloudPtr cloud_in, fawkes::RefPtr<Cloud> cloud_out);
+	void cloud_publish(CloudPtr cloud_in, fawkes::RefPtr<Cloud> cloud_out);
 
-  pose calculate_pose(Eigen::Vector4f centroid, Eigen::Vector3f normal);
-  void tf_send_from_pose_if(pose pose);
-  void pose_write(pose pose);
-  Eigen::Quaternion<float>
-  averageQuaternion(Eigen::Vector4f &cumulative,
-                    Eigen::Quaternion<float> newRotation,
-                    Eigen::Quaternion<float> firstRotation, float addDet);
-  Eigen::Quaternion<float> normalizeQuaternion(float x, float y, float z,
-                                               float w);
-  Eigen::Quaternion<float> inverseSignQuaternion(Eigen::Quaternion<float> q);
-  bool areQuaternionsClose(Eigen::Quaternion<float> q1,
-                           Eigen::Quaternion<float> q2);
+	pose                     calculate_pose(Eigen::Vector4f centroid, Eigen::Vector3f normal);
+	void                     tf_send_from_pose_if(pose pose);
+	void                     pose_write(pose pose);
+	Eigen::Quaternion<float> averageQuaternion(Eigen::Vector4f &        cumulative,
+	                                           Eigen::Quaternion<float> newRotation,
+	                                           Eigen::Quaternion<float> firstRotation,
+	                                           float                    addDet);
+	Eigen::Quaternion<float> normalizeQuaternion(float x, float y, float z, float w);
+	Eigen::Quaternion<float> inverseSignQuaternion(Eigen::Quaternion<float> q);
+	bool areQuaternionsClose(Eigen::Quaternion<float> q1, Eigen::Quaternion<float> q2);
 
-  void pose_publish_tf(pose pose);
-  void start_waiting();
-  bool need_to_wait();
+	void pose_publish_tf(pose pose);
+	void start_waiting();
+	bool need_to_wait();
 
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 public:
-  ConveyorPlaneThread();
+	ConveyorPlaneThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 };
 
 #endif

--- a/src/plugins/conveyor_pose/conveyor_pose_plugin.cpp
+++ b/src/plugins/conveyor_pose/conveyor_pose_plugin.cpp
@@ -21,10 +21,10 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "conveyor_pose_thread.h"
 #include "recognition_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -32,18 +32,20 @@ using namespace fawkes;
  * intel real sense)
  * @author Tobias Neumann
  */
-class ConveyorPosePlugin : public fawkes::Plugin {
+class ConveyorPosePlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  ConveyorPosePlugin(Configuration *config) : Plugin(config) {
-    ConveyorPoseThread *pose_thread = new ConveyorPoseThread();
-    RecognitionThread *cg_thread = new RecognitionThread(pose_thread);
-    pose_thread->set_cg_thread(cg_thread);
-    thread_list.push_back(pose_thread);
-    thread_list.push_back(cg_thread);
-  }
+	ConveyorPosePlugin(Configuration *config) : Plugin(config)
+	{
+		ConveyorPoseThread *pose_thread = new ConveyorPoseThread();
+		RecognitionThread * cg_thread   = new RecognitionThread(pose_thread);
+		pose_thread->set_cg_thread(cg_thread);
+		thread_list.push_back(pose_thread);
+		thread_list.push_back(cg_thread);
+	}
 };
 
 PLUGIN_DESCRIPTION("Detect the conveyor belt in a pointcloud")

--- a/src/plugins/conveyor_pose/conveyor_pose_thread.cpp
+++ b/src/plugins/conveyor_pose/conveyor_pose_thread.cpp
@@ -21,27 +21,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
+#include "conveyor_pose_thread.h"
+
+#include "recognition_thread.h"
+
+#include <core/exceptions/system.h>
+#include <interfaces/ConveyorPoseInterface.h>
+#include <interfaces/LaserLineInterface.h>
+#include <interfaces/SwitchInterface.h>
 #include <pcl/common/distances.h>
 #include <pcl/common/transforms.h>
 #include <pcl/conversions.h>
 #include <pcl/filters/approximate_voxel_grid.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_cloud.h>
-
 #include <tf/types.h>
 #include <utils/math/angle.h>
 
-#include <core/exceptions/system.h>
-
-#include <interfaces/ConveyorPoseInterface.h>
-#include <interfaces/LaserLineInterface.h>
-#include <interfaces/SwitchInterface.h>
-
 #include <cmath>
 #include <cstdio>
-
-#include "conveyor_pose_thread.h"
-#include "recognition_thread.h"
 
 using namespace fawkes;
 
@@ -53,1201 +51,1150 @@ using namespace fawkes;
 
 /** Constructor. */
 ConveyorPoseThread::ConveyorPoseThread()
-    : Thread("ConveyorPoseThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS),
-      ConfigurationChangeHandler(CFG_PREFIX), fawkes::TransformAspect(
-                                                  fawkes::TransformAspect::BOTH,
-                                                  "conveyor_pose"),
-      result_fitness_(std::numeric_limits<double>::min()),
-      syncpoint_clouds_ready_name_("/perception/conveyor_pose/clouds_ready"),
-      cloud_out_raw_name_("raw"), cloud_out_trimmed_name_("trimmed"),
-      current_mps_type_(ConveyorPoseInterface::DEFAULT_TYPE),
-      current_mps_target_(ConveyorPoseInterface::DEFAULT_TARGET),
-      recognition_thread_(nullptr), realsense_switch_(nullptr) {}
+: Thread("ConveyorPoseThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS),
+  ConfigurationChangeHandler(CFG_PREFIX),
+  fawkes::TransformAspect(fawkes::TransformAspect::BOTH, "conveyor_pose"),
+  result_fitness_(std::numeric_limits<double>::min()),
+  syncpoint_clouds_ready_name_("/perception/conveyor_pose/clouds_ready"),
+  cloud_out_raw_name_("raw"),
+  cloud_out_trimmed_name_("trimmed"),
+  current_mps_type_(ConveyorPoseInterface::DEFAULT_TYPE),
+  current_mps_target_(ConveyorPoseInterface::DEFAULT_TARGET),
+  recognition_thread_(nullptr),
+  realsense_switch_(nullptr)
+{
+}
 
 std::string
-ConveyorPoseThread::get_model_path(ConveyorPoseInterface *iface,
-                                   ConveyorPoseInterface::MPS_TYPE type,
-                                   ConveyorPoseInterface::MPS_TARGET target) {
-  std::string path = std::string(CFG_PREFIX "/reference_models/") +
-                     iface->enum_tostring("MPS_TYPE", type) + "_" +
-                     iface->enum_tostring("MPS_TARGET", target);
-  if (config->exists(path)) {
-    logger->log_info(name(), "Override for %s_%s: %s",
-                     iface->enum_tostring("MPS_TYPE", type),
-                     iface->enum_tostring("MPS_TARGET", target),
-                     config->get_string(path).c_str());
-    return CONFDIR "/" + config->get_string(path);
-  } else {
-    switch (target) {
-    case ConveyorPoseInterface::INPUT_CONVEYOR:
-      return CONFDIR "/" +
-             config->get_string(CFG_PREFIX "/reference_models/input_conveyor");
-    case ConveyorPoseInterface::OUTPUT_CONVEYOR:
-      return CONFDIR "/" +
-             config->get_string(CFG_PREFIX "/reference_models/output_conveyor");
-    case ConveyorPoseInterface::SHELF_LEFT:
-      return CONFDIR "/" +
-             config->get_string(CFG_PREFIX "/reference_models/shelf_left");
-    case ConveyorPoseInterface::SHELF_MIDDLE:
-      return CONFDIR "/" +
-             config->get_string(CFG_PREFIX "/reference_models/shelf_middle");
-    case ConveyorPoseInterface::SHELF_RIGHT:
-      return CONFDIR "/" +
-             config->get_string(CFG_PREFIX "/reference_models/shelf_right");
-    case ConveyorPoseInterface::SLIDE:
-      return CONFDIR "/" +
-             config->get_string(CFG_PREFIX "/reference_models/slide");
-    case ConveyorPoseInterface::DEFAULT_TARGET:
-      return CONFDIR "/" +
-             config->get_string(CFG_PREFIX "/reference_models/default");
-    case ConveyorPoseInterface::LAST_MPS_TARGET_ELEMENT:
-      return "";
-    }
-  }
+ConveyorPoseThread::get_model_path(ConveyorPoseInterface *           iface,
+                                   ConveyorPoseInterface::MPS_TYPE   type,
+                                   ConveyorPoseInterface::MPS_TARGET target)
+{
+	std::string path = std::string(CFG_PREFIX "/reference_models/")
+	                   + iface->enum_tostring("MPS_TYPE", type) + "_"
+	                   + iface->enum_tostring("MPS_TARGET", target);
+	if (config->exists(path)) {
+		logger->log_info(name(),
+		                 "Override for %s_%s: %s",
+		                 iface->enum_tostring("MPS_TYPE", type),
+		                 iface->enum_tostring("MPS_TARGET", target),
+		                 config->get_string(path).c_str());
+		return CONFDIR "/" + config->get_string(path);
+	} else {
+		switch (target) {
+		case ConveyorPoseInterface::INPUT_CONVEYOR:
+			return CONFDIR "/" + config->get_string(CFG_PREFIX "/reference_models/input_conveyor");
+		case ConveyorPoseInterface::OUTPUT_CONVEYOR:
+			return CONFDIR "/" + config->get_string(CFG_PREFIX "/reference_models/output_conveyor");
+		case ConveyorPoseInterface::SHELF_LEFT:
+			return CONFDIR "/" + config->get_string(CFG_PREFIX "/reference_models/shelf_left");
+		case ConveyorPoseInterface::SHELF_MIDDLE:
+			return CONFDIR "/" + config->get_string(CFG_PREFIX "/reference_models/shelf_middle");
+		case ConveyorPoseInterface::SHELF_RIGHT:
+			return CONFDIR "/" + config->get_string(CFG_PREFIX "/reference_models/shelf_right");
+		case ConveyorPoseInterface::SLIDE:
+			return CONFDIR "/" + config->get_string(CFG_PREFIX "/reference_models/slide");
+		case ConveyorPoseInterface::DEFAULT_TARGET:
+			return CONFDIR "/" + config->get_string(CFG_PREFIX "/reference_models/default");
+		case ConveyorPoseInterface::LAST_MPS_TARGET_ELEMENT: return "";
+		}
+	}
 
-  return "";
+	return "";
 }
 
-void ConveyorPoseThread::init() {
-  config->add_change_handler(this);
+void
+ConveyorPoseThread::init()
+{
+	config->add_change_handler(this);
 
-  syncpoint_clouds_ready =
-      syncpoint_manager->get_syncpoint(name(), syncpoint_clouds_ready_name_);
-  syncpoint_clouds_ready->register_emitter(name());
+	syncpoint_clouds_ready = syncpoint_manager->get_syncpoint(name(), syncpoint_clouds_ready_name_);
+	syncpoint_clouds_ready->register_emitter(name());
 
-  cfg_debug_mode_ = config->get_bool(CFG_PREFIX "/debug");
-  cfg_force_shelf_ = config->get_int_or_default(CFG_PREFIX "/force_shelf", -1);
-  cloud_in_name_ = config->get_string(CFG_PREFIX "/cloud_in");
+	cfg_debug_mode_  = config->get_bool(CFG_PREFIX "/debug");
+	cfg_force_shelf_ = config->get_int_or_default(CFG_PREFIX "/force_shelf", -1);
+	cloud_in_name_   = config->get_string(CFG_PREFIX "/cloud_in");
 
-  cfg_if_prefix_ = config->get_string(CFG_PREFIX "/if/prefix");
-  if (cfg_if_prefix_.back() != '/')
-    cfg_if_prefix_.append("/");
+	cfg_if_prefix_ = config->get_string(CFG_PREFIX "/if/prefix");
+	if (cfg_if_prefix_.back() != '/')
+		cfg_if_prefix_.append("/");
 
-  laserlines_names_ = config->get_strings(CFG_PREFIX "/if/laser_lines");
+	laserlines_names_ = config->get_strings(CFG_PREFIX "/if/laser_lines");
 
-  conveyor_frame_id_ = config->get_string(CFG_PREFIX "/conveyor_frame_id");
+	conveyor_frame_id_ = config->get_string(CFG_PREFIX "/conveyor_frame_id");
 
-  recognition_thread_->cfg_icp_max_corr_dist_ =
-      config->get_float(CFG_PREFIX "/icp/max_correspondence_dist");
-  recognition_thread_->cfg_icp_max_iterations_ =
-      config->get_int(CFG_PREFIX "/icp/max_iterations");
-  recognition_thread_->cfg_icp_refinement_factor_ =
-      double(config->get_float(CFG_PREFIX "/icp/refinement_factor"));
-  recognition_thread_->cfg_icp_tf_epsilon_ =
-      double(config->get_float(CFG_PREFIX "/icp/transformation_epsilon"));
-  recognition_thread_->cfg_icp_min_loops_ =
-      config->get_uint(CFG_PREFIX "/icp/min_loops");
-  recognition_thread_->cfg_icp_max_loops_ =
-      config->get_uint(CFG_PREFIX "/icp/max_loops");
-  recognition_thread_->cfg_icp_auto_restart_ =
-      config->get_bool(CFG_PREFIX "/icp/auto_restart");
+	recognition_thread_->cfg_icp_max_corr_dist_ =
+	  config->get_float(CFG_PREFIX "/icp/max_correspondence_dist");
+	recognition_thread_->cfg_icp_max_iterations_ = config->get_int(CFG_PREFIX "/icp/max_iterations");
+	recognition_thread_->cfg_icp_refinement_factor_ =
+	  double(config->get_float(CFG_PREFIX "/icp/refinement_factor"));
+	recognition_thread_->cfg_icp_tf_epsilon_ =
+	  double(config->get_float(CFG_PREFIX "/icp/transformation_epsilon"));
+	recognition_thread_->cfg_icp_min_loops_    = config->get_uint(CFG_PREFIX "/icp/min_loops");
+	recognition_thread_->cfg_icp_max_loops_    = config->get_uint(CFG_PREFIX "/icp/max_loops");
+	recognition_thread_->cfg_icp_auto_restart_ = config->get_bool(CFG_PREFIX "/icp/auto_restart");
 
-  recognition_thread_->cfg_icp_hv_inlier_thresh_ =
-      config->get_float(CFG_PREFIX "/icp/hv/inlier_threshold");
-  recognition_thread_->cfg_icp_hv_penalty_thresh_ =
-      config->get_float(CFG_PREFIX "/icp/hv/penalty_threshold");
-  recognition_thread_->cfg_icp_hv_support_thresh_ =
-      config->get_float(CFG_PREFIX "/icp/hv/support_threshold");
+	recognition_thread_->cfg_icp_hv_inlier_thresh_ =
+	  config->get_float(CFG_PREFIX "/icp/hv/inlier_threshold");
+	recognition_thread_->cfg_icp_hv_penalty_thresh_ =
+	  config->get_float(CFG_PREFIX "/icp/hv/penalty_threshold");
+	recognition_thread_->cfg_icp_hv_support_thresh_ =
+	  config->get_float(CFG_PREFIX "/icp/hv/support_threshold");
 
-  recognition_thread_->cfg_icp_shelf_hv_inlier_thresh_ =
-      config->get_float(CFG_PREFIX "/icp/hv/shelf_inlier_threshold");
-  recognition_thread_->cfg_icp_shelf_hv_penalty_thresh_ =
-      config->get_float(CFG_PREFIX "/icp/hv/shelf_penalty_threshold");
-  recognition_thread_->cfg_icp_shelf_hv_support_thresh_ =
-      config->get_float(CFG_PREFIX "/icp/hv/shelf_support_threshold");
+	recognition_thread_->cfg_icp_shelf_hv_inlier_thresh_ =
+	  config->get_float(CFG_PREFIX "/icp/hv/shelf_inlier_threshold");
+	recognition_thread_->cfg_icp_shelf_hv_penalty_thresh_ =
+	  config->get_float(CFG_PREFIX "/icp/hv/shelf_penalty_threshold");
+	recognition_thread_->cfg_icp_shelf_hv_support_thresh_ =
+	  config->get_float(CFG_PREFIX "/icp/hv/shelf_support_threshold");
 
-  bb_pose_ = blackboard->open_for_writing<ConveyorPoseInterface>(
-      (cfg_if_prefix_ + "status").c_str());
-  bb_pose_->set_current_mps_type(bb_pose_->DEFAULT_TYPE);
-  bb_pose_->set_current_mps_target(bb_pose_->DEFAULT_TARGET);
+	bb_pose_ =
+	  blackboard->open_for_writing<ConveyorPoseInterface>((cfg_if_prefix_ + "status").c_str());
+	bb_pose_->set_current_mps_type(bb_pose_->DEFAULT_TYPE);
+	bb_pose_->set_current_mps_target(bb_pose_->DEFAULT_TARGET);
 
-  bb_pose_->write();
+	bb_pose_->write();
 
-  // Init of station target hints
-  cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR];
-  cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR];
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT];
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT];
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE];
-  cfg_target_hint_[ConveyorPoseInterface::SLIDE];
-  cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET];
+	// Init of station target hints
+	cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR];
+	cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR];
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT];
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT];
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE];
+	cfg_target_hint_[ConveyorPoseInterface::SLIDE];
+	cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET];
 
-  cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][X_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/x");
-  cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][Y_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/y");
-  cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][Z_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/z");
+	cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][X_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/x");
+	cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][Y_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/y");
+	cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][Z_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/z");
 
-  cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][X_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/x");
-  // Y * -1, because it should be the opposite of the input conveyor
-  cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][Y_DIR] =
-      -config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/y");
-  cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][Z_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/z");
+	cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][X_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/x");
+	// Y * -1, because it should be the opposite of the input conveyor
+	cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][Y_DIR] =
+	  -config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/y");
+	cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][Z_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/input_conveyor/z");
 
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][X_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/left_shelf/x");
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][Y_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/left_shelf/y");
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][Z_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/left_shelf/z");
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][X_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/middle_shelf/x");
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][Y_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/middle_shelf/y");
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][Z_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/middle_shelf/z");
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][X_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/right_shelf/x");
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][Y_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/right_shelf/y");
-  cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][Z_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/right_shelf/z");
-  cfg_target_hint_[ConveyorPoseInterface::SLIDE][X_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/slide/x");
-  cfg_target_hint_[ConveyorPoseInterface::SLIDE][Y_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/slide/y");
-  cfg_target_hint_[ConveyorPoseInterface::SLIDE][Z_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/slide/z");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][X_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/left_shelf/x");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][Y_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/left_shelf/y");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][Z_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/left_shelf/z");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][X_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/middle_shelf/x");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][Y_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/middle_shelf/y");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][Z_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/middle_shelf/z");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][X_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/right_shelf/x");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][Y_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/right_shelf/y");
+	cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][Z_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/right_shelf/z");
+	cfg_target_hint_[ConveyorPoseInterface::SLIDE][X_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/slide/x");
+	cfg_target_hint_[ConveyorPoseInterface::SLIDE][Y_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/slide/y");
+	cfg_target_hint_[ConveyorPoseInterface::SLIDE][Z_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/slide/z");
 
-  cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][X_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/default/x");
-  cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][Y_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/default/y");
-  cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][Z_DIR] =
-      config->get_float(CFG_PREFIX "/icp/hint/default/z");
+	cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][X_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/default/x");
+	cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][Y_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/default/y");
+	cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][Z_DIR] =
+	  config->get_float(CFG_PREFIX "/icp/hint/default/z");
 
-  // Init of station type hints
+	// Init of station type hints
 
-  cfg_type_offset_[ConveyorPoseInterface::BASE_STATION];
-  cfg_type_offset_[ConveyorPoseInterface::CAP_STATION];
-  cfg_type_offset_[ConveyorPoseInterface::RING_STATION];
-  cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION];
-  cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION];
+	cfg_type_offset_[ConveyorPoseInterface::BASE_STATION];
+	cfg_type_offset_[ConveyorPoseInterface::CAP_STATION];
+	cfg_type_offset_[ConveyorPoseInterface::RING_STATION];
+	cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION];
+	cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION];
 
-  cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][X_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/base_station/x", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][Y_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/base_station/y", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][Z_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/base_station/z", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][X_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/cap_station/x", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][Y_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/cap_station/y", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][Z_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/cap_station/z", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::RING_STATION][X_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/ring_station/x", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::RING_STATION][Y_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/ring_station/y", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::RING_STATION][Z_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/ring_station/z", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][X_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/delivery_station/x", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][Y_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/delivery_station/y", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][Z_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/delivery_station/z", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][X_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/storage_station/x", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][Y_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/storage_station/y", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][Z_DIR] =
-      config->get_float_or_default(
-          CFG_PREFIX "/icp/conveyor_offset/storage_station/z", 0.f);
-  cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][X_DIR] =
-      config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/default/z",
-                                   0.f);
-  cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][Y_DIR] =
-      config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/default/z",
-                                   0.f);
-  cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][Z_DIR] =
-      config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/default/z",
-                                   0.f);
+	cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][X_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/base_station/x", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][Y_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/base_station/y", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][Z_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/base_station/z", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][X_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/cap_station/x", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][Y_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/cap_station/y", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][Z_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/cap_station/z", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::RING_STATION][X_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/ring_station/x", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::RING_STATION][Y_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/ring_station/y", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::RING_STATION][Z_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/ring_station/z", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][X_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/delivery_station/x", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][Y_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/delivery_station/y", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][Z_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/delivery_station/z", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][X_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/storage_station/x", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][Y_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/storage_station/y", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][Z_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/storage_station/z", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][X_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/default/z", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][Y_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/default/z", 0.f);
+	cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][Z_DIR] =
+	  config->get_float_or_default(CFG_PREFIX "/icp/conveyor_offset/default/z", 0.f);
 
-  cfg_enable_switch_ = config->get_bool(CFG_PREFIX "/switch_default");
+	cfg_enable_switch_ = config->get_bool(CFG_PREFIX "/switch_default");
 
-  // cut information
+	// cut information
 
-  cfg_left_cut_no_ll_ = config->get_float(CFG_PREFIX "/without_ll/left_cut");
-  cfg_right_cut_no_ll_ = config->get_float(CFG_PREFIX "/without_ll/right_cut");
-  cfg_top_cut_no_ll_ = config->get_float(CFG_PREFIX "/without_ll/top_cut");
-  cfg_bottom_cut_no_ll_ =
-      config->get_float(CFG_PREFIX "/without_ll/bottom_cut");
-  cfg_front_cut_no_ll_ = config->get_float(CFG_PREFIX "/without_ll/front_cut");
-  cfg_back_cut_no_ll_ = config->get_float(CFG_PREFIX "/without_ll/back_cut");
+	cfg_left_cut_no_ll_   = config->get_float(CFG_PREFIX "/without_ll/left_cut");
+	cfg_right_cut_no_ll_  = config->get_float(CFG_PREFIX "/without_ll/right_cut");
+	cfg_top_cut_no_ll_    = config->get_float(CFG_PREFIX "/without_ll/top_cut");
+	cfg_bottom_cut_no_ll_ = config->get_float(CFG_PREFIX "/without_ll/bottom_cut");
+	cfg_front_cut_no_ll_  = config->get_float(CFG_PREFIX "/without_ll/front_cut");
+	cfg_back_cut_no_ll_   = config->get_float(CFG_PREFIX "/without_ll/back_cut");
 
-  cfg_left_cut_ = config->get_float(CFG_PREFIX "/with_ll/left_cut");
-  cfg_right_cut_ = config->get_float(CFG_PREFIX "/with_ll/right_cut");
-  cfg_top_cut_ = config->get_float(CFG_PREFIX "/with_ll/top_cut");
-  cfg_bottom_cut_ = config->get_float(CFG_PREFIX "/with_ll/bottom_cut");
-  cfg_front_cut_ = config->get_float(CFG_PREFIX "/with_ll/front_cut");
-  cfg_back_cut_ = config->get_float(CFG_PREFIX "/with_ll/back_cut");
+	cfg_left_cut_   = config->get_float(CFG_PREFIX "/with_ll/left_cut");
+	cfg_right_cut_  = config->get_float(CFG_PREFIX "/with_ll/right_cut");
+	cfg_top_cut_    = config->get_float(CFG_PREFIX "/with_ll/top_cut");
+	cfg_bottom_cut_ = config->get_float(CFG_PREFIX "/with_ll/bottom_cut");
+	cfg_front_cut_  = config->get_float(CFG_PREFIX "/with_ll/front_cut");
+	cfg_back_cut_   = config->get_float(CFG_PREFIX "/with_ll/back_cut");
 
-  cfg_shelf_left_cut_no_ll_ =
-      config->get_float(CFG_PREFIX "/shelf/without_ll/left_cut");
-  cfg_shelf_right_cut_no_ll_ =
-      config->get_float(CFG_PREFIX "/shelf/without_ll/right_cut");
-  cfg_shelf_top_cut_no_ll_ =
-      config->get_float(CFG_PREFIX "/shelf/without_ll/top_cut");
-  cfg_shelf_bottom_cut_no_ll_ =
-      config->get_float(CFG_PREFIX "/shelf/without_ll/bottom_cut");
-  cfg_shelf_front_cut_no_ll_ =
-      config->get_float(CFG_PREFIX "/shelf/without_ll/front_cut");
-  cfg_shelf_back_cut_no_ll_ =
-      config->get_float(CFG_PREFIX "/shelf/without_ll/back_cut");
+	cfg_shelf_left_cut_no_ll_   = config->get_float(CFG_PREFIX "/shelf/without_ll/left_cut");
+	cfg_shelf_right_cut_no_ll_  = config->get_float(CFG_PREFIX "/shelf/without_ll/right_cut");
+	cfg_shelf_top_cut_no_ll_    = config->get_float(CFG_PREFIX "/shelf/without_ll/top_cut");
+	cfg_shelf_bottom_cut_no_ll_ = config->get_float(CFG_PREFIX "/shelf/without_ll/bottom_cut");
+	cfg_shelf_front_cut_no_ll_  = config->get_float(CFG_PREFIX "/shelf/without_ll/front_cut");
+	cfg_shelf_back_cut_no_ll_   = config->get_float(CFG_PREFIX "/shelf/without_ll/back_cut");
 
-  cfg_shelf_left_cut_ = config->get_float(CFG_PREFIX "/shelf/with_ll/left_cut");
-  cfg_shelf_right_cut_ =
-      config->get_float(CFG_PREFIX "/shelf/with_ll/right_cut");
-  cfg_shelf_top_cut_ = config->get_float(CFG_PREFIX "/shelf/with_ll/top_cut");
-  cfg_shelf_bottom_cut_ =
-      config->get_float(CFG_PREFIX "/shelf/with_ll/bottom_cut");
-  cfg_shelf_front_cut_ =
-      config->get_float(CFG_PREFIX "/shelf/with_ll/front_cut");
-  cfg_shelf_back_cut_ = config->get_float(CFG_PREFIX "/shelf/with_ll/back_cut");
+	cfg_shelf_left_cut_   = config->get_float(CFG_PREFIX "/shelf/with_ll/left_cut");
+	cfg_shelf_right_cut_  = config->get_float(CFG_PREFIX "/shelf/with_ll/right_cut");
+	cfg_shelf_top_cut_    = config->get_float(CFG_PREFIX "/shelf/with_ll/top_cut");
+	cfg_shelf_bottom_cut_ = config->get_float(CFG_PREFIX "/shelf/with_ll/bottom_cut");
+	cfg_shelf_front_cut_  = config->get_float(CFG_PREFIX "/shelf/with_ll/front_cut");
+	cfg_shelf_back_cut_   = config->get_float(CFG_PREFIX "/shelf/with_ll/back_cut");
 
-  cfg_shelf_left_off_ = config->get_float(CFG_PREFIX "/shelf/left_off");
-  cfg_shelf_middle_off_ = config->get_float(CFG_PREFIX "/shelf/middle_off");
-  cfg_shelf_right_off_ = config->get_float(CFG_PREFIX "/shelf/right_off");
+	cfg_shelf_left_off_   = config->get_float(CFG_PREFIX "/shelf/left_off");
+	cfg_shelf_middle_off_ = config->get_float(CFG_PREFIX "/shelf/middle_off");
+	cfg_shelf_right_off_  = config->get_float(CFG_PREFIX "/shelf/right_off");
 
-  cfg_voxel_grid_leaf_size_ =
-      config->get_float(CFG_PREFIX "/voxel_grid/leaf_size");
+	cfg_voxel_grid_leaf_size_ = config->get_float(CFG_PREFIX "/voxel_grid/leaf_size");
 
-  cfg_bb_realsense_switch_name_ = config->get_string_or_default(
-      CFG_PREFIX "/realsense_switch", "realsense");
-  wait_time_ = Time(double(
-      config->get_float_or_default(CFG_PREFIX "/realsense_wait_time", 1.0f)));
+	cfg_bb_realsense_switch_name_ =
+	  config->get_string_or_default(CFG_PREFIX "/realsense_switch", "realsense");
+	wait_time_ = Time(double(config->get_float_or_default(CFG_PREFIX "/realsense_wait_time", 1.0f)));
 
-  // laserline bearing threshold
-  cfg_ll_bearing_thresh_ =
-      config->get_float(CFG_PREFIX "/ll/bearing_threshold");
+	// laserline bearing threshold
+	cfg_ll_bearing_thresh_ = config->get_float(CFG_PREFIX "/ll/bearing_threshold");
 
-  // Load reference pcl for shelf, input belt (with cone for input -> output
-  // machines, without cone for output <- -> output machines), output belt
-  // (without cone) and slide
-  for (int i = ConveyorPoseInterface::DEFAULT_TYPE;
-       i != ConveyorPoseInterface::LAST_MPS_TYPE_ELEMENT; i++) {
-    ConveyorPoseInterface::MPS_TYPE mps_type =
-        static_cast<ConveyorPoseInterface::MPS_TYPE>(i);
-    for (int j = ConveyorPoseInterface::DEFAULT_TARGET;
-         j != ConveyorPoseInterface::LAST_MPS_TARGET_ELEMENT; j++) {
-      ConveyorPoseInterface::MPS_TARGET mps_target =
-          static_cast<ConveyorPoseInterface::MPS_TARGET>(j);
+	// Load reference pcl for shelf, input belt (with cone for input -> output
+	// machines, without cone for output <- -> output machines), output belt
+	// (without cone) and slide
+	for (int i = ConveyorPoseInterface::DEFAULT_TYPE;
+	     i != ConveyorPoseInterface::LAST_MPS_TYPE_ELEMENT;
+	     i++) {
+		ConveyorPoseInterface::MPS_TYPE mps_type = static_cast<ConveyorPoseInterface::MPS_TYPE>(i);
+		for (int j = ConveyorPoseInterface::DEFAULT_TARGET;
+		     j != ConveyorPoseInterface::LAST_MPS_TARGET_ELEMENT;
+		     j++) {
+			ConveyorPoseInterface::MPS_TARGET mps_target =
+			  static_cast<ConveyorPoseInterface::MPS_TARGET>(j);
 
-      type_target_to_path_[{mps_type, mps_target}] =
-          get_model_path(bb_pose_, mps_type, mps_target);
-    }
-  }
+			type_target_to_path_[{mps_type, mps_target}] = get_model_path(bb_pose_, mps_type, mps_target);
+		}
+	}
 
-  // always use the output_conveyor model for Storage station and Base station
-  type_target_to_path_[{ConveyorPoseInterface::BASE_STATION,
-                        ConveyorPoseInterface::INPUT_CONVEYOR}] =
-      type_target_to_path_[{ConveyorPoseInterface::BASE_STATION,
-                            ConveyorPoseInterface::OUTPUT_CONVEYOR}];
-  type_target_to_path_[{ConveyorPoseInterface::STORAGE_STATION,
-                        ConveyorPoseInterface::INPUT_CONVEYOR}] =
-      type_target_to_path_[{ConveyorPoseInterface::STORAGE_STATION,
-                            ConveyorPoseInterface::OUTPUT_CONVEYOR}];
+	// always use the output_conveyor model for Storage station and Base station
+	type_target_to_path_[{ConveyorPoseInterface::BASE_STATION,
+	                      ConveyorPoseInterface::INPUT_CONVEYOR}] =
+	  type_target_to_path_[{ConveyorPoseInterface::BASE_STATION,
+	                        ConveyorPoseInterface::OUTPUT_CONVEYOR}];
+	type_target_to_path_[{ConveyorPoseInterface::STORAGE_STATION,
+	                      ConveyorPoseInterface::INPUT_CONVEYOR}] =
+	  type_target_to_path_[{ConveyorPoseInterface::STORAGE_STATION,
+	                        ConveyorPoseInterface::OUTPUT_CONVEYOR}];
 
-  trimmed_scene_.reset(new Cloud());
+	trimmed_scene_.reset(new Cloud());
 
-  cfg_model_origin_frame_ =
-      config->get_string(CFG_PREFIX "/model_origin_frame");
-  cfg_record_model_ =
-      config->get_bool_or_default(CFG_PREFIX "/record_model", false);
+	cfg_model_origin_frame_ = config->get_string(CFG_PREFIX "/model_origin_frame");
+	cfg_record_model_       = config->get_bool_or_default(CFG_PREFIX "/record_model", false);
 
-  // if recording is set, a pointcloud will be written to the the
-  // cfg_record_path_ else load pcd file for every station and calculate model
-  // with normals
+	// if recording is set, a pointcloud will be written to the the
+	// cfg_record_path_ else load pcd file for every station and calculate model
+	// with normals
 
-  if (cfg_record_model_) {
+	if (cfg_record_model_) {
+		std::string reference_station =
+		  config->get_string_or_default(CFG_PREFIX "/record_path", "recorded_file.pcd");
+		cfg_record_path_            = CONFDIR "/" + reference_station;
+		std::string new_record_path = cfg_record_path_;
 
-    std::string reference_station = config->get_string_or_default(
-        CFG_PREFIX "/record_path", "recorded_file.pcd");
-    cfg_record_path_ = CONFDIR "/" + reference_station;
-    std::string new_record_path = cfg_record_path_;
+		bool   exists;
+		FILE * tmp;
+		size_t count = 0;
 
-    bool exists;
-    FILE *tmp;
-    size_t count = 0;
+		do {
+			exists = false;
+			tmp    = ::fopen(new_record_path.c_str(), "r");
+			if (tmp) {
+				exists = true;
+				::fclose(tmp);
+				if (cfg_record_path_.substr(cfg_record_path_.length() - 4) == ".pcd")
+					new_record_path = cfg_record_path_.substr(0, cfg_record_path_.length() - 4)
+					                  + std::to_string(count++) + ".pcd";
+				else
+					new_record_path = cfg_record_path_ + std::to_string(count++);
+			}
+		} while (exists);
 
-    do {
-      exists = false;
-      tmp = ::fopen(new_record_path.c_str(), "r");
-      if (tmp) {
-        exists = true;
-        ::fclose(tmp);
-        if (cfg_record_path_.substr(cfg_record_path_.length() - 4) == ".pcd")
-          new_record_path =
-              cfg_record_path_.substr(0, cfg_record_path_.length() - 4) +
-              std::to_string(count++) + ".pcd";
-        else
-          new_record_path = cfg_record_path_ + std::to_string(count++);
-      }
-    } while (exists);
+		cfg_record_path_ = new_record_path;
 
-    cfg_record_path_ = new_record_path;
+		logger->log_info(name(), "Writing point cloud to %s", cfg_record_path_.c_str());
+		model_.reset(new Cloud());
+	} else {
+		// Loading PCD file and calculation of model with normals for ALL! stations
+		for (const auto &pair : type_target_to_path_) {
+			CloudPtr model(new Cloud());
+			if (pcl::io::loadPCDFile(pair.second, *model) < 0)
+				throw fawkes::CouldNotOpenFileException(pair.second.c_str());
 
-    logger->log_info(name(), "Writing point cloud to %s",
-                     cfg_record_path_.c_str());
-    model_.reset(new Cloud());
-  } else {
-    // Loading PCD file and calculation of model with normals for ALL! stations
-    for (const auto &pair : type_target_to_path_) {
-      CloudPtr model(new Cloud());
-      if (pcl::io::loadPCDFile(pair.second, *model) < 0)
-        throw fawkes::CouldNotOpenFileException(pair.second.c_str());
+			type_target_to_model_.insert({pair.first, model});
+		}
 
-      type_target_to_model_.insert({pair.first, model});
-    }
+		model_ = type_target_to_model_[{ConveyorPoseInterface::DEFAULT_TYPE,
+		                                ConveyorPoseInterface::DEFAULT_TARGET}];
+	}
 
-    model_ = type_target_to_model_[{ConveyorPoseInterface::DEFAULT_TYPE,
-                                    ConveyorPoseInterface::DEFAULT_TARGET}];
-  }
+	cloud_in_registered_ = false;
 
-  cloud_in_registered_ = false;
+	cloud_out_raw_     = new Cloud();
+	cloud_out_trimmed_ = new Cloud();
+	cloud_out_model_   = new Cloud();
+	pcl_manager->add_pointcloud(cloud_out_raw_name_.c_str(), cloud_out_raw_);
+	pcl_manager->add_pointcloud(cloud_out_trimmed_name_.c_str(), cloud_out_trimmed_);
+	pcl_manager->add_pointcloud("model", cloud_out_model_);
 
-  cloud_out_raw_ = new Cloud();
-  cloud_out_trimmed_ = new Cloud();
-  cloud_out_model_ = new Cloud();
-  pcl_manager->add_pointcloud(cloud_out_raw_name_.c_str(), cloud_out_raw_);
-  pcl_manager->add_pointcloud(cloud_out_trimmed_name_.c_str(),
-                              cloud_out_trimmed_);
-  pcl_manager->add_pointcloud("model", cloud_out_model_);
+	for (std::string ll : laserlines_names_) {
+		laserlines_.push_back(blackboard->open_for_reading<fawkes::LaserLineInterface>(ll.c_str()));
+	}
 
-  for (std::string ll : laserlines_names_) {
-    laserlines_.push_back(
-        blackboard->open_for_reading<fawkes::LaserLineInterface>(ll.c_str()));
-  }
+	bb_enable_switch_ =
+	  blackboard->open_for_writing<SwitchInterface>((cfg_if_prefix_ + "switch").c_str());
+	bb_enable_switch_->set_enabled(
+	  cfg_debug_mode_ || cfg_enable_switch_); // ignore cfg_enable_switch_ and set to true if debug
+	                                          // mode is used
+	bb_enable_switch_->write();
 
-  bb_enable_switch_ = blackboard->open_for_writing<SwitchInterface>(
-      (cfg_if_prefix_ + "switch").c_str());
-  bb_enable_switch_->set_enabled(
-      cfg_debug_mode_ ||
-      cfg_enable_switch_); // ignore cfg_enable_switch_ and set to true if debug
-                           // mode is used
-  bb_enable_switch_->write();
+	realsense_switch_ =
+	  blackboard->open_for_reading<SwitchInterface>(cfg_bb_realsense_switch_name_.c_str());
 
-  realsense_switch_ = blackboard->open_for_reading<SwitchInterface>(
-      cfg_bb_realsense_switch_name_.c_str());
-
-  if (cfg_debug_mode_) {
-    recognition_thread_->enable();
-    switch (cfg_force_shelf_) {
-    case 0:
-      current_mps_target_ =
-          fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_LEFT;
-      break;
-    case 1:
-      current_mps_target_ =
-          fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_MIDDLE;
-      break;
-    case 2:
-      current_mps_target_ =
-          fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_RIGHT;
-      break;
-    default:
-      break;
-    }
-  }
+	if (cfg_debug_mode_) {
+		recognition_thread_->enable();
+		switch (cfg_force_shelf_) {
+		case 0: current_mps_target_ = fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_LEFT; break;
+		case 1: current_mps_target_ = fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_MIDDLE; break;
+		case 2: current_mps_target_ = fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_RIGHT; break;
+		default: break;
+		}
+	}
 }
 
-void ConveyorPoseThread::finalize() {
-  pcl_manager->remove_pointcloud(cloud_out_raw_name_.c_str());
-  pcl_manager->remove_pointcloud(cloud_out_trimmed_name_.c_str());
-  pcl_manager->remove_pointcloud("model");
-  blackboard->close(bb_enable_switch_);
-  logger->log_info(name(), "Unloading, disabling %s",
-                   cfg_bb_realsense_switch_name_.c_str());
-  realsense_switch_->msgq_enqueue(new SwitchInterface::DisableSwitchMessage());
-  blackboard->close(realsense_switch_);
-  blackboard->close(bb_pose_);
+void
+ConveyorPoseThread::finalize()
+{
+	pcl_manager->remove_pointcloud(cloud_out_raw_name_.c_str());
+	pcl_manager->remove_pointcloud(cloud_out_trimmed_name_.c_str());
+	pcl_manager->remove_pointcloud("model");
+	blackboard->close(bb_enable_switch_);
+	logger->log_info(name(), "Unloading, disabling %s", cfg_bb_realsense_switch_name_.c_str());
+	realsense_switch_->msgq_enqueue(new SwitchInterface::DisableSwitchMessage());
+	blackboard->close(realsense_switch_);
+	blackboard->close(bb_pose_);
 }
 
-void ConveyorPoseThread::loop() {
-  // Check for Messages in ConveyorPoseInterface and update information if
-  // needed
-  while (!bb_pose_->msgq_empty()) {
-    if (bb_pose_->msgq_first_is<ConveyorPoseInterface::RunICPMessage>()) {
+void
+ConveyorPoseThread::loop()
+{
+	// Check for Messages in ConveyorPoseInterface and update information if
+	// needed
+	while (!bb_pose_->msgq_empty()) {
+		if (bb_pose_->msgq_first_is<ConveyorPoseInterface::RunICPMessage>()) {
+			// Update station related information
+			logger->log_info(name(), "Received RunICPMessage");
+			ConveyorPoseInterface::RunICPMessage *msg =
+			  bb_pose_->msgq_first<ConveyorPoseInterface::RunICPMessage>();
+			update_station_information(*msg);
+			bb_pose_->write();
 
-      // Update station related information
-      logger->log_info(name(), "Received RunICPMessage");
-      ConveyorPoseInterface::RunICPMessage *msg =
-          bb_pose_->msgq_first<ConveyorPoseInterface::RunICPMessage>();
-      update_station_information(*msg);
-      bb_pose_->write();
+			result_pose_.release();
 
-      result_pose_.release();
+			// Schedule restart of recognition thread
+			recognition_thread_->restart();
+		} else {
+			logger->log_warn(name(), "Unknown message received");
+		}
+		bb_pose_->msgq_pop();
+	}
 
-      // Schedule restart of recognition thread
-      recognition_thread_->restart();
-    } else {
-      logger->log_warn(name(), "Unknown message received");
-    }
-    bb_pose_->msgq_pop();
-  }
+	bb_update_switch();
+	realsense_switch_->read();
 
-  bb_update_switch();
-  realsense_switch_->read();
+	if (bb_enable_switch_->is_enabled()) {
+		if (realsense_switch_->has_writer()) {
+			if (!realsense_switch_->is_enabled()) {
+				logger->log_info(name(),
+				                 "Camera %s is disabled, enabling",
+				                 cfg_bb_realsense_switch_name_.c_str());
+				realsense_switch_->msgq_enqueue(new SwitchInterface::EnableSwitchMessage());
+				start_waiting();
+				return;
+			}
+		} else {
+			logger->log_error(name(), "No writer for camera %s", cfg_bb_realsense_switch_name_.c_str());
+			return;
+		}
+	} else if (realsense_switch_->has_writer() && realsense_switch_->is_enabled()) {
+		logger->log_info(name(), "Disabling %s", cfg_bb_realsense_switch_name_.c_str());
+		realsense_switch_->msgq_enqueue(new SwitchInterface::DisableSwitchMessage());
+	}
 
-  if (bb_enable_switch_->is_enabled()) {
-    if (realsense_switch_->has_writer()) {
-      if (!realsense_switch_->is_enabled()) {
-        logger->log_info(name(), "Camera %s is disabled, enabling",
-                         cfg_bb_realsense_switch_name_.c_str());
-        realsense_switch_->msgq_enqueue(
-            new SwitchInterface::EnableSwitchMessage());
-        start_waiting();
-        return;
-      }
-    } else {
-      logger->log_error(name(), "No writer for camera %s",
-                        cfg_bb_realsense_switch_name_.c_str());
-      return;
-    }
-  } else if (realsense_switch_->has_writer() &&
-             realsense_switch_->is_enabled()) {
-    logger->log_info(name(), "Disabling %s",
-                     cfg_bb_realsense_switch_name_.c_str());
-    realsense_switch_->msgq_enqueue(
-        new SwitchInterface::DisableSwitchMessage());
-  }
+	if (need_to_wait()) {
+		logger->log_debug(name(),
+		                  "Waiting for %s for %f sec, still %f sec remaining",
+		                  cfg_bb_realsense_switch_name_.c_str(),
+		                  wait_time_.in_sec(),
+		                  (wait_start_ + wait_time_ - Time()).in_sec());
+		return;
+	}
 
-  if (need_to_wait()) {
-    logger->log_debug(
-        name(), "Waiting for %s for %f sec, still %f sec remaining",
-        cfg_bb_realsense_switch_name_.c_str(), wait_time_.in_sec(),
-        (wait_start_ + wait_time_ - Time()).in_sec());
-    return;
-  }
+	if (!bb_enable_switch_->is_enabled()) {
+		recognition_thread_->disable();
+		result_pose_.reset();
+	} else if (update_input_cloud()) {
+		fawkes::LaserLineInterface *ll = nullptr;
+		have_laser_line_               = laserline_get_best_fit(ll);
 
-  if (!bb_enable_switch_->is_enabled()) {
-    recognition_thread_->disable();
-    result_pose_.reset();
-  } else if (update_input_cloud()) {
-    fawkes::LaserLineInterface *ll = nullptr;
-    have_laser_line_ = laserline_get_best_fit(ll);
+		// No point in recording a model when there's no laser line
+		if (cfg_record_model_ && !have_laser_line_)
+			return;
 
-    // No point in recording a model when there's no laser line
-    if (cfg_record_model_ && !have_laser_line_)
-      return;
+		{
+			fawkes::MutexLocker locked(&cloud_mutex_);
+			try {
+				if (have_laser_line_) {
+					set_initial_tf_from_laserline(ll, current_mps_type_, current_mps_target_);
+				}
+			} catch (std::exception &e) {
+				logger->log_error(name(), "Exception generating initial transform: %s", e.what());
+			}
+		} // cloud_mutex_ lock
 
-    {
-      fawkes::MutexLocker locked(&cloud_mutex_);
-      try {
-        if (have_laser_line_) {
-          set_initial_tf_from_laserline(ll, current_mps_type_,
-                                        current_mps_target_);
-        }
-      } catch (std::exception &e) {
-        logger->log_error(name(), "Exception generating initial transform: %s",
-                          e.what());
-      }
-    } // cloud_mutex_ lock
+		CloudPtr cloud_in(new Cloud(**cloud_in_));
 
-    CloudPtr cloud_in(new Cloud(**cloud_in_));
+		size_t   in_size  = cloud_in->points.size();
+		CloudPtr cloud_vg = cloud_voxel_grid(cloud_in);
+		size_t   out_size = cloud_vg->points.size();
+		if (in_size == out_size) {
+			logger->log_error(name(), "Voxel Grid failed, skipping loop!");
+			return;
+		}
 
-    size_t in_size = cloud_in->points.size();
-    CloudPtr cloud_vg = cloud_voxel_grid(cloud_in);
-    size_t out_size = cloud_vg->points.size();
-    if (in_size == out_size) {
-      logger->log_error(name(), "Voxel Grid failed, skipping loop!");
-      return;
-    }
+		trimmed_scene_ = cloud_trim(cloud_vg, ll, have_laser_line_);
 
-    trimmed_scene_ = cloud_trim(cloud_vg, ll, have_laser_line_);
+		cloud_publish(cloud_in, cloud_out_raw_);
+		cloud_publish(trimmed_scene_, cloud_out_trimmed_);
 
-    cloud_publish(cloud_in, cloud_out_raw_);
-    cloud_publish(trimmed_scene_, cloud_out_trimmed_);
+		if (cfg_record_model_) {
+			record_model();
+			cloud_publish(model_, cloud_out_model_);
 
-    if (cfg_record_model_) {
-      record_model();
-      cloud_publish(model_, cloud_out_model_);
+			tf::Stamped<tf::Pose> initial_pose_cam;
+			try {
+				tf_listener->transform_pose(trimmed_scene_->header.frame_id,
+				                            tf::Stamped<tf::Pose>(initial_guess_laser_odom_,
+				                                                  Time(0, 0),
+				                                                  initial_guess_laser_odom_.frame_id),
+				                            initial_pose_cam);
+			} catch (tf::TransformException &e) {
+				logger->log_error(name(), e);
+				return;
+			}
+			tf_publisher->send_transform(tf::StampedTransform(initial_pose_cam,
+			                                                  initial_pose_cam.stamp,
+			                                                  initial_pose_cam.frame_id,
+			                                                  "conveyor_pose_initial_guess"));
+		} else {
+			{
+				MutexLocker locked{&bb_mutex_};
+				try {
+					if (result_pose_) {
+						pose_write();
+						pose_publish_tf(*result_pose_);
+						result_pose_.reset();
+					}
+				} catch (std::exception &e) {
+					logger->log_error(name(), "Unexpected exception: %s", e.what());
+				}
+			}
 
-      tf::Stamped<tf::Pose> initial_pose_cam;
-      try {
-        tf_listener->transform_pose(
-            trimmed_scene_->header.frame_id,
-            tf::Stamped<tf::Pose>(initial_guess_laser_odom_, Time(0, 0),
-                                  initial_guess_laser_odom_.frame_id),
-            initial_pose_cam);
-      } catch (tf::TransformException &e) {
-        logger->log_error(name(), e);
-        return;
-      }
-      tf_publisher->send_transform(tf::StampedTransform(
-          initial_pose_cam, initial_pose_cam.stamp, initial_pose_cam.frame_id,
-          "conveyor_pose_initial_guess"));
-    } else {
-      {
-        MutexLocker locked{&bb_mutex_};
-        try {
-          if (result_pose_) {
-            pose_write();
-            pose_publish_tf(*result_pose_);
-            result_pose_.reset();
-          }
-        } catch (std::exception &e) {
-          logger->log_error(name(), "Unexpected exception: %s", e.what());
-        }
-      }
+			{
+				MutexLocker locked{&cloud_mutex_};
 
-      {
-        MutexLocker locked{&cloud_mutex_};
-
-        scene_ = trimmed_scene_;
-        syncpoint_clouds_ready->emit(name());
-      }
-    } // ! cfg_record_model_
-  }   // update_input_cloud()
+				scene_ = trimmed_scene_;
+				syncpoint_clouds_ready->emit(name());
+			}
+		} // ! cfg_record_model_
+	}   // update_input_cloud()
 }
 
-void ConveyorPoseThread::set_initial_tf_from_laserline(
-    fawkes::LaserLineInterface *line, ConveyorPoseInterface::MPS_TYPE mps_type,
-    ConveyorPoseInterface::MPS_TARGET mps_target) {
-  tf::Stamped<tf::Pose> initial_guess;
+void
+ConveyorPoseThread::set_initial_tf_from_laserline(fawkes::LaserLineInterface *      line,
+                                                  ConveyorPoseInterface::MPS_TYPE   mps_type,
+                                                  ConveyorPoseInterface::MPS_TARGET mps_target)
+{
+	tf::Stamped<tf::Pose> initial_guess;
 
-  // Vector from end point 1 to end point 2
-  if (!tf_listener->transform_origin(line->end_point_frame_2(),
-                                     line->end_point_frame_1(), initial_guess,
-                                     Time(0, 0)))
-    throw fawkes::Exception("Failed to transform from %s to %s",
-                            line->end_point_frame_2(),
-                            line->end_point_frame_1());
+	// Vector from end point 1 to end point 2
+	if (!tf_listener->transform_origin(
+	      line->end_point_frame_2(), line->end_point_frame_1(), initial_guess, Time(0, 0)))
+		throw fawkes::Exception("Failed to transform from %s to %s",
+		                        line->end_point_frame_2(),
+		                        line->end_point_frame_1());
 
-  // Halve that to get line center
-  initial_guess.setOrigin(initial_guess.getOrigin() / 2);
+	// Halve that to get line center
+	initial_guess.setOrigin(initial_guess.getOrigin() / 2);
 
-  // Add distance from center to mps_target
-  initial_guess.setOrigin(
-      initial_guess.getOrigin() +
-      tf::Vector3{double(cfg_target_hint_[mps_target][X_DIR]),
-                  double(cfg_target_hint_[mps_target][Y_DIR]),
-                  double(cfg_target_hint_[mps_target][Z_DIR])});
+	// Add distance from center to mps_target
+	initial_guess.setOrigin(initial_guess.getOrigin()
+	                        + tf::Vector3{double(cfg_target_hint_[mps_target][X_DIR]),
+	                                      double(cfg_target_hint_[mps_target][Y_DIR]),
+	                                      double(cfg_target_hint_[mps_target][Z_DIR])});
 
-  if (mps_target == ConveyorPoseInterface::MPS_TARGET::INPUT_CONVEYOR) {
-    // Add distance offset for station type
-    initial_guess.setOrigin(
-        initial_guess.getOrigin() +
-        tf::Vector3{double(cfg_type_offset_[mps_type][X_DIR]),
-                    double(cfg_type_offset_[mps_type][Y_DIR]),
-                    double(cfg_type_offset_[mps_type][Z_DIR])});
-  } else if (mps_target == ConveyorPoseInterface::MPS_TARGET::OUTPUT_CONVEYOR) {
-    // Invert Y axis of the offset
-    initial_guess.setOrigin(
-        initial_guess.getOrigin() +
-        tf::Vector3{double(cfg_type_offset_[mps_type][X_DIR]),
-                    double(-cfg_type_offset_[mps_type][Y_DIR]),
-                    double(cfg_type_offset_[mps_type][Z_DIR])});
-  }
+	if (mps_target == ConveyorPoseInterface::MPS_TARGET::INPUT_CONVEYOR) {
+		// Add distance offset for station type
+		initial_guess.setOrigin(initial_guess.getOrigin()
+		                        + tf::Vector3{double(cfg_type_offset_[mps_type][X_DIR]),
+		                                      double(cfg_type_offset_[mps_type][Y_DIR]),
+		                                      double(cfg_type_offset_[mps_type][Z_DIR])});
+	} else if (mps_target == ConveyorPoseInterface::MPS_TARGET::OUTPUT_CONVEYOR) {
+		// Invert Y axis of the offset
+		initial_guess.setOrigin(initial_guess.getOrigin()
+		                        + tf::Vector3{double(cfg_type_offset_[mps_type][X_DIR]),
+		                                      double(-cfg_type_offset_[mps_type][Y_DIR]),
+		                                      double(cfg_type_offset_[mps_type][Z_DIR])});
+	}
 
-  initial_guess.setRotation(tf::Quaternion(tf::Vector3(0, 1, 0), -M_PI / 2) *
-                            tf::Quaternion(tf::Vector3(0, 0, 1), M_PI / 2));
+	initial_guess.setRotation(tf::Quaternion(tf::Vector3(0, 1, 0), -M_PI / 2)
+	                          * tf::Quaternion(tf::Vector3(0, 0, 1), M_PI / 2));
 
-  // Transform with Time(0,0) to just get the latest transform
-  tf_listener->transform_pose(
-      "odom",
-      tf::Stamped<tf::Pose>(initial_guess, Time(0, 0), initial_guess.frame_id),
-      initial_guess_laser_odom_);
+	// Transform with Time(0,0) to just get the latest transform
+	tf_listener->transform_pose("odom",
+	                            tf::Stamped<tf::Pose>(initial_guess,
+	                                                  Time(0, 0),
+	                                                  initial_guess.frame_id),
+	                            initial_guess_laser_odom_);
 }
 
-void ConveyorPoseThread::record_model() {
-  // Transform model
-  tf::Stamped<tf::Pose> pose_cam;
-  try {
-    tf_listener->transform_origin(cloud_in_->header.frame_id,
-                                  cfg_model_origin_frame_, pose_cam);
-    Eigen::Matrix4f tf_to_cam = pose_to_eigen(pose_cam);
-    pcl::transformPointCloud(*trimmed_scene_, *model_, tf_to_cam);
+void
+ConveyorPoseThread::record_model()
+{
+	// Transform model
+	tf::Stamped<tf::Pose> pose_cam;
+	try {
+		tf_listener->transform_origin(cloud_in_->header.frame_id, cfg_model_origin_frame_, pose_cam);
+		Eigen::Matrix4f tf_to_cam = pose_to_eigen(pose_cam);
+		pcl::transformPointCloud(*trimmed_scene_, *model_, tf_to_cam);
 
-    // Overwrite and atomically rename model so it can be copied at any time
-    int rv = pcl::io::savePCDFileASCII(cfg_record_path_, *model_);
-    if (rv)
-      logger->log_error(name(), "Error %d saving point cloud to %s", rv,
-                        cfg_record_path_.c_str());
-    else
-      ::rename((cfg_record_path_ + ".pcd").c_str(), cfg_record_path_.c_str());
-  } catch (pcl::IOException &e) {
-    logger->log_error(name(), "Exception saving point cloud to %s: %s",
-                      cfg_record_path_.c_str(), e.what());
-  } catch (tf::TransformException &e) {
-    logger->log_error(name(), "Exception recording point cloud: %s", e.what());
-  }
+		// Overwrite and atomically rename model so it can be copied at any time
+		int rv = pcl::io::savePCDFileASCII(cfg_record_path_, *model_);
+		if (rv)
+			logger->log_error(name(), "Error %d saving point cloud to %s", rv, cfg_record_path_.c_str());
+		else
+			::rename((cfg_record_path_ + ".pcd").c_str(), cfg_record_path_.c_str());
+	} catch (pcl::IOException &e) {
+		logger->log_error(name(),
+		                  "Exception saving point cloud to %s: %s",
+		                  cfg_record_path_.c_str(),
+		                  e.what());
+	} catch (tf::TransformException &e) {
+		logger->log_error(name(), "Exception recording point cloud: %s", e.what());
+	}
 }
 
-void ConveyorPoseThread::update_station_information(
-    ConveyorPoseInterface::RunICPMessage &msg) {
-  ConveyorPoseInterface::MPS_TYPE mps_type = msg.mps_type_to_set();
-  ConveyorPoseInterface::MPS_TARGET mps_target = msg.mps_target_to_set();
+void
+ConveyorPoseThread::update_station_information(ConveyorPoseInterface::RunICPMessage &msg)
+{
+	ConveyorPoseInterface::MPS_TYPE   mps_type   = msg.mps_type_to_set();
+	ConveyorPoseInterface::MPS_TARGET mps_target = msg.mps_target_to_set();
 
-  auto map_it = type_target_to_model_.find({mps_type, mps_target});
-  if (map_it == type_target_to_model_.end())
-    logger->log_error(name(), "Invalid station type or target: %i,%i", mps_type,
-                      mps_target);
-  else {
-    logger->log_info(name(), "Setting Station to %s, %s",
-                     bb_pose_->enum_tostring("MPS_TYPE", mps_type),
-                     bb_pose_->enum_tostring("MPS_TARGET", mps_target));
+	auto map_it = type_target_to_model_.find({mps_type, mps_target});
+	if (map_it == type_target_to_model_.end())
+		logger->log_error(name(), "Invalid station type or target: %i,%i", mps_type, mps_target);
+	else {
+		logger->log_info(name(),
+		                 "Setting Station to %s, %s",
+		                 bb_pose_->enum_tostring("MPS_TYPE", mps_type),
+		                 bb_pose_->enum_tostring("MPS_TARGET", mps_target));
 
-    MutexLocker locked2(&bb_mutex_);
+		MutexLocker locked2(&bb_mutex_);
 
-    model_ = map_it->second;
-    current_mps_type_ = mps_type;
-    current_mps_target_ = mps_target;
+		model_              = map_it->second;
+		current_mps_type_   = mps_type;
+		current_mps_target_ = mps_target;
 
-    bb_pose_->set_current_mps_type(mps_type);
-    bb_pose_->set_current_mps_target(mps_target);
-    result_fitness_ = std::numeric_limits<double>::min();
-    bb_pose_->set_euclidean_fitness(result_fitness_);
-    bb_pose_->set_msgid(msg.id());
-    bb_pose_->set_busy(true);
-    bb_pose_->write();
-  }
+		bb_pose_->set_current_mps_type(mps_type);
+		bb_pose_->set_current_mps_target(mps_target);
+		result_fitness_ = std::numeric_limits<double>::min();
+		bb_pose_->set_euclidean_fitness(result_fitness_);
+		bb_pose_->set_msgid(msg.id());
+		bb_pose_->set_busy(true);
+		bb_pose_->write();
+	}
 }
 
-bool ConveyorPoseThread::update_input_cloud() {
-  if (pcl_manager->exists_pointcloud(cloud_in_name_.c_str())) {
-    if (!cloud_in_registered_) { // do I already have this pc
-      cloud_in_ = pcl_manager->get_pointcloud<Point>(cloud_in_name_.c_str());
-      if (cloud_in_->points.size() > 0) {
-        cloud_in_registered_ = true;
-      }
-    }
+bool
+ConveyorPoseThread::update_input_cloud()
+{
+	if (pcl_manager->exists_pointcloud(cloud_in_name_.c_str())) {
+		if (!cloud_in_registered_) { // do I already have this pc
+			cloud_in_ = pcl_manager->get_pointcloud<Point>(cloud_in_name_.c_str());
+			if (cloud_in_->points.size() > 0) {
+				cloud_in_registered_ = true;
+			}
+		}
 
-    unsigned long time_old = header_.stamp;
-    header_ = cloud_in_->header;
+		unsigned long time_old = header_.stamp;
+		header_                = cloud_in_->header;
 
-    return time_old !=
-           header_.stamp; // true, if there is a new cloud, false otherwise
+		return time_old != header_.stamp; // true, if there is a new cloud, false otherwise
 
-  } else {
-    logger->log_debug(name(), "can't get pointcloud %s",
-                      cloud_in_name_.c_str());
-    cloud_in_registered_ = false;
-    return false;
-  }
+	} else {
+		logger->log_debug(name(), "can't get pointcloud %s", cloud_in_name_.c_str());
+		cloud_in_registered_ = false;
+		return false;
+	}
 }
 
-void ConveyorPoseThread::bb_update_switch() {
-  // enable switch
-  bb_enable_switch_->read();
+void
+ConveyorPoseThread::bb_update_switch()
+{
+	// enable switch
+	bb_enable_switch_->read();
 
-  bool rv = bb_enable_switch_->is_enabled();
-  while (!bb_enable_switch_->msgq_empty()) {
-    if (bb_enable_switch_
-            ->msgq_first_is<SwitchInterface::DisableSwitchMessage>()) {
-      logger->log_info(name(), "Received DisableSwitchMessage");
-      rv = false;
-      {
-        MutexLocker locked(&bb_mutex_);
-        result_fitness_ = std::numeric_limits<double>::min();
-        bb_pose_->set_euclidean_fitness(result_fitness_);
-        bb_pose_->write();
-      }
-    } else if (bb_enable_switch_
-                   ->msgq_first_is<SwitchInterface::EnableSwitchMessage>()) {
-      logger->log_info(name(), "Received EnableSwitchMessage");
-      rv = true;
-    }
+	bool rv = bb_enable_switch_->is_enabled();
+	while (!bb_enable_switch_->msgq_empty()) {
+		if (bb_enable_switch_->msgq_first_is<SwitchInterface::DisableSwitchMessage>()) {
+			logger->log_info(name(), "Received DisableSwitchMessage");
+			rv = false;
+			{
+				MutexLocker locked(&bb_mutex_);
+				result_fitness_ = std::numeric_limits<double>::min();
+				bb_pose_->set_euclidean_fitness(result_fitness_);
+				bb_pose_->write();
+			}
+		} else if (bb_enable_switch_->msgq_first_is<SwitchInterface::EnableSwitchMessage>()) {
+			logger->log_info(name(), "Received EnableSwitchMessage");
+			rv = true;
+		}
 
-    bb_enable_switch_->msgq_pop();
-  }
-  if (rv != bb_enable_switch_->is_enabled()) {
-    if (!cfg_debug_mode_) {
-      logger->log_info(name(), "*** enabled: %s", rv ? "yes" : "no");
-      bb_enable_switch_->set_enabled(rv);
-    } else {
-      logger->log_warn(
-          name(),
-          "*** enabled: %s, ignored because of DEBUG MODE, if will be ENABLED",
-          rv ? "yes" : "no");
-      bb_enable_switch_->set_enabled(true);
-    }
-    bb_enable_switch_->write();
-  }
+		bb_enable_switch_->msgq_pop();
+	}
+	if (rv != bb_enable_switch_->is_enabled()) {
+		if (!cfg_debug_mode_) {
+			logger->log_info(name(), "*** enabled: %s", rv ? "yes" : "no");
+			bb_enable_switch_->set_enabled(rv);
+		} else {
+			logger->log_warn(name(),
+			                 "*** enabled: %s, ignored because of DEBUG MODE, if will be ENABLED",
+			                 rv ? "yes" : "no");
+			bb_enable_switch_->set_enabled(true);
+		}
+		bb_enable_switch_->write();
+	}
 
-  // laser lines
-  for (fawkes::LaserLineInterface *ll : laserlines_) {
-    ll->read();
-  }
+	// laser lines
+	for (fawkes::LaserLineInterface *ll : laserlines_) {
+		ll->read();
+	}
 }
 
-bool ConveyorPoseThread::laserline_get_best_fit(
-    fawkes::LaserLineInterface *&best_fit) {
-  best_fit = nullptr;
+bool
+ConveyorPoseThread::laserline_get_best_fit(fawkes::LaserLineInterface *&best_fit)
+{
+	best_fit = nullptr;
 
-  // get best line
-  for (fawkes::LaserLineInterface *ll : laserlines_) {
-    if (!ll->has_writer())
-      continue;
-    if (ll->visibility_history() <= 2)
-      continue;
+	// get best line
+	for (fawkes::LaserLineInterface *ll : laserlines_) {
+		if (!ll->has_writer())
+			continue;
+		if (ll->visibility_history() <= 2)
+			continue;
 
-    try {
-      Eigen::Vector3f center = laserline_get_center_transformed(ll);
-      if (std::sqrt(center(0) * center(0) + center(2) * center(2)) > 0.8f)
-        continue;
+		try {
+			Eigen::Vector3f center = laserline_get_center_transformed(ll);
+			if (std::sqrt(center(0) * center(0) + center(2) * center(2)) > 0.8f)
+				continue;
 
-      // take with lowest angle
-      if (!best_fit || fabs(best_fit->bearing()) > fabs(ll->bearing()))
-        best_fit = ll;
-    } catch (fawkes::tf::TransformException &e) {
-      logger->log_error(name(), e);
-    }
-  }
+			// take with lowest angle
+			if (!best_fit || fabs(best_fit->bearing()) > fabs(ll->bearing()))
+				best_fit = ll;
+		} catch (fawkes::tf::TransformException &e) {
+			logger->log_error(name(), e);
+		}
+	}
 
-  if (!best_fit)
-    return false;
+	if (!best_fit)
+		return false;
 
-  if (!best_fit->has_writer()) {
-    logger->log_info(name(), "no writer for laser lines");
-    best_fit = nullptr;
-    return false;
-  }
-  if (best_fit->visibility_history() <= 2) {
-    best_fit = nullptr;
-    return false;
-  }
-  if (fabs(best_fit->bearing()) > cfg_ll_bearing_thresh_) {
-    best_fit = nullptr;
-    return false; // ~20 deg
-  }
+	if (!best_fit->has_writer()) {
+		logger->log_info(name(), "no writer for laser lines");
+		best_fit = nullptr;
+		return false;
+	}
+	if (best_fit->visibility_history() <= 2) {
+		best_fit = nullptr;
+		return false;
+	}
+	if (fabs(best_fit->bearing()) > cfg_ll_bearing_thresh_) {
+		best_fit = nullptr;
+		return false; // ~20 deg
+	}
 
-  try {
-    Eigen::Vector3f center = laserline_get_center_transformed(best_fit);
-    if (std::sqrt(center(0) * center(0) + center(2) * center(2)) > 0.8f) {
-      best_fit = nullptr;
-      return false;
-    }
-  } catch (tf::TransformException &e) {
-    logger->log_error(name(), e);
-    return false;
-  }
+	try {
+		Eigen::Vector3f center = laserline_get_center_transformed(best_fit);
+		if (std::sqrt(center(0) * center(0) + center(2) * center(2)) > 0.8f) {
+			best_fit = nullptr;
+			return false;
+		}
+	} catch (tf::TransformException &e) {
+		logger->log_error(name(), e);
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
-Eigen::Vector3f ConveyorPoseThread::laserline_get_center_transformed(
-    fawkes::LaserLineInterface *ll) {
-  fawkes::tf::Stamped<fawkes::tf::Point> tf_in, tf_out;
-  tf_in.stamp = ll->timestamp();
-  tf_in.frame_id = ll->frame_id();
-  tf_in.setX(ll->end_point_2(0) +
-             (ll->end_point_1(0) - ll->end_point_2(0)) / 2.);
-  tf_in.setY(ll->end_point_2(1) +
-             (ll->end_point_1(1) - ll->end_point_2(1)) / 2.);
-  tf_in.setZ(ll->end_point_2(2) +
-             (ll->end_point_1(2) - ll->end_point_2(2)) / 2.);
+Eigen::Vector3f
+ConveyorPoseThread::laserline_get_center_transformed(fawkes::LaserLineInterface *ll)
+{
+	fawkes::tf::Stamped<fawkes::tf::Point> tf_in, tf_out;
+	tf_in.stamp    = ll->timestamp();
+	tf_in.frame_id = ll->frame_id();
+	tf_in.setX(ll->end_point_2(0) + (ll->end_point_1(0) - ll->end_point_2(0)) / 2.);
+	tf_in.setY(ll->end_point_2(1) + (ll->end_point_1(1) - ll->end_point_2(1)) / 2.);
+	tf_in.setZ(ll->end_point_2(2) + (ll->end_point_1(2) - ll->end_point_2(2)) / 2.);
 
-  try {
-    tf_listener->transform_point(header_.frame_id, tf_in, tf_out);
-  } catch (tf::ExtrapolationException &) {
-    tf_in.stamp = Time(0, 0);
-    tf_listener->transform_point(header_.frame_id, tf_in, tf_out);
-  }
+	try {
+		tf_listener->transform_point(header_.frame_id, tf_in, tf_out);
+	} catch (tf::ExtrapolationException &) {
+		tf_in.stamp = Time(0, 0);
+		tf_listener->transform_point(header_.frame_id, tf_in, tf_out);
+	}
 
-  Eigen::Vector3f out(tf_out.getX(), tf_out.getY(), tf_out.getZ());
+	Eigen::Vector3f out(tf_out.getX(), tf_out.getY(), tf_out.getZ());
 
-  return out;
+	return out;
 }
 
 ConveyorPoseThread::CloudPtr
-ConveyorPoseThread::cloud_voxel_grid(ConveyorPoseThread::CloudPtr in) {
-  float ls = cfg_voxel_grid_leaf_size_;
-  pcl::ApproximateVoxelGrid<pcl::PointXYZ> vg;
-  CloudPtr out(new Cloud);
-  vg.setInputCloud(in);
-  // logger->log_debug(name(), "voxel leaf size is %f", ls);
-  vg.setLeafSize(ls, ls, ls);
-  vg.filter(*out);
-  out->header = in->header;
-  return out;
+ConveyorPoseThread::cloud_voxel_grid(ConveyorPoseThread::CloudPtr in)
+{
+	float                                    ls = cfg_voxel_grid_leaf_size_;
+	pcl::ApproximateVoxelGrid<pcl::PointXYZ> vg;
+	CloudPtr                                 out(new Cloud);
+	vg.setInputCloud(in);
+	// logger->log_debug(name(), "voxel leaf size is %f", ls);
+	vg.setLeafSize(ls, ls, ls);
+	vg.filter(*out);
+	out->header = in->header;
+	return out;
 }
 
-void ConveyorPoseThread::cloud_publish(ConveyorPoseThread::CloudPtr cloud_in,
-                                       fawkes::RefPtr<Cloud> cloud_out) {
-  **cloud_out = *cloud_in;
-  cloud_out->header = header_;
+void
+ConveyorPoseThread::cloud_publish(ConveyorPoseThread::CloudPtr cloud_in,
+                                  fawkes::RefPtr<Cloud>        cloud_out)
+{
+	**cloud_out       = *cloud_in;
+	cloud_out->header = header_;
 }
 
-void ConveyorPoseThread::pose_write() {
-  if (!result_pose_) {
-    logger->log_error(name(),
-                      "BUG: calling pose_write() when result_pose_ is unset!");
-    return;
-  }
-  bb_pose_->set_translation(0, result_pose_->getOrigin().getX());
-  bb_pose_->set_translation(1, result_pose_->getOrigin().getY());
-  bb_pose_->set_translation(2, result_pose_->getOrigin().getZ());
-  bb_pose_->set_rotation(0, result_pose_->getRotation().getX());
-  bb_pose_->set_rotation(1, result_pose_->getRotation().getY());
-  bb_pose_->set_rotation(2, result_pose_->getRotation().getZ());
-  bb_pose_->set_rotation(3, result_pose_->getRotation().getW());
+void
+ConveyorPoseThread::pose_write()
+{
+	if (!result_pose_) {
+		logger->log_error(name(), "BUG: calling pose_write() when result_pose_ is unset!");
+		return;
+	}
+	bb_pose_->set_translation(0, result_pose_->getOrigin().getX());
+	bb_pose_->set_translation(1, result_pose_->getOrigin().getY());
+	bb_pose_->set_translation(2, result_pose_->getOrigin().getZ());
+	bb_pose_->set_rotation(0, result_pose_->getRotation().getX());
+	bb_pose_->set_rotation(1, result_pose_->getRotation().getY());
+	bb_pose_->set_rotation(2, result_pose_->getRotation().getZ());
+	bb_pose_->set_rotation(3, result_pose_->getRotation().getW());
 
-  bb_pose_->set_frame(result_pose_->frame_id.c_str());
-  bb_pose_->set_euclidean_fitness(result_fitness_);
-  long timestamp[2];
-  result_pose_->stamp.get_timestamp(timestamp[0], timestamp[1]);
-  bb_pose_->set_input_timestamp(timestamp);
-  bb_pose_->write();
+	bb_pose_->set_frame(result_pose_->frame_id.c_str());
+	bb_pose_->set_euclidean_fitness(result_fitness_);
+	long timestamp[2];
+	result_pose_->stamp.get_timestamp(timestamp[0], timestamp[1]);
+	bb_pose_->set_input_timestamp(timestamp);
+	bb_pose_->write();
 }
 
-void ConveyorPoseThread::pose_publish_tf(const tf::Stamped<tf::Pose> &pose) {
-  // transform data into gripper frame (this is better for later use)
-  tf::Stamped<tf::Pose> tf_pose_gripper;
-  tf_listener->transform_pose("gripper", pose, tf_pose_gripper);
+void
+ConveyorPoseThread::pose_publish_tf(const tf::Stamped<tf::Pose> &pose)
+{
+	// transform data into gripper frame (this is better for later use)
+	tf::Stamped<tf::Pose> tf_pose_gripper;
+	tf_listener->transform_pose("gripper", pose, tf_pose_gripper);
 
-  // publish the transform from the gripper to the conveyor
-  tf::Transform transform(tf_pose_gripper.getRotation(),
-                          tf_pose_gripper.getOrigin());
-  tf::StampedTransform stamped_transform(transform, tf_pose_gripper.stamp,
-                                         tf_pose_gripper.frame_id,
-                                         conveyor_frame_id_);
-  tf_publisher->send_transform(stamped_transform);
+	// publish the transform from the gripper to the conveyor
+	tf::Transform        transform(tf_pose_gripper.getRotation(), tf_pose_gripper.getOrigin());
+	tf::StampedTransform stamped_transform(transform,
+	                                       tf_pose_gripper.stamp,
+	                                       tf_pose_gripper.frame_id,
+	                                       conveyor_frame_id_);
+	tf_publisher->send_transform(stamped_transform);
 }
 
-void ConveyorPoseThread::start_waiting() { wait_start_ = Time(); }
-
-bool ConveyorPoseThread::need_to_wait() {
-  return Time() < wait_start_ + wait_time_;
+void
+ConveyorPoseThread::start_waiting()
+{
+	wait_start_ = Time();
 }
 
-void ConveyorPoseThread::set_cg_thread(RecognitionThread *cg_thread) {
-  recognition_thread_ = cg_thread;
+bool
+ConveyorPoseThread::need_to_wait()
+{
+	return Time() < wait_start_ + wait_time_;
 }
 
-void ConveyorPoseThread::config_value_erased(const char *path) {}
-
-void ConveyorPoseThread::config_tag_changed(const char *new_tag) {}
-
-void ConveyorPoseThread::config_comment_changed(
-    const Configuration::ValueIterator *v) {}
-
-void ConveyorPoseThread::config_value_changed(
-    const Configuration::ValueIterator *v) {
-  if (v->valid()) {
-    std::string path = v->path();
-    std::string sufx = path.substr(strlen(CFG_PREFIX));
-    std::string sub_prefix = sufx.substr(0, sufx.substr(1).find("/") + 1);
-    std::string full_pfx = CFG_PREFIX + sub_prefix;
-    std::string opt = path.substr(full_pfx.length());
-
-    if (sub_prefix == "/without_ll") {
-      if (opt == "/left_cut")
-        change_val(opt, cfg_left_cut_no_ll_, v->get_float());
-      else if (opt == "/right_cut")
-        change_val(opt, cfg_right_cut_no_ll_, v->get_float());
-      else if (opt == "/top_cut")
-        change_val(opt, cfg_top_cut_no_ll_, v->get_float());
-      else if (opt == "/bottom_cut")
-        change_val(opt, cfg_bottom_cut_no_ll_, v->get_float());
-      else if (opt == "/front_cut")
-        change_val(opt, cfg_front_cut_no_ll_, v->get_float());
-      else if (opt == "/back_cut")
-        change_val(opt, cfg_back_cut_no_ll_, v->get_float());
-    } else if (sub_prefix == "/with_ll") {
-      if (opt == "/left_cut")
-        change_val(opt, cfg_left_cut_, v->get_float());
-      else if (opt == "/right_cut")
-        change_val(opt, cfg_right_cut_, v->get_float());
-      else if (opt == "/top_cut")
-        change_val(opt, cfg_top_cut_, v->get_float());
-      else if (opt == "/bottom_cut")
-        change_val(opt, cfg_bottom_cut_, v->get_float());
-      else if (opt == "/front_cut")
-        change_val(opt, cfg_front_cut_, v->get_float());
-      else if (opt == "/back_cut")
-        change_val(opt, cfg_back_cut_, v->get_float());
-    } else if (sub_prefix == "/shelf") {
-      if (opt == "/without_ll/left_cut")
-        change_val(opt, cfg_shelf_left_cut_no_ll_, v->get_float());
-      else if (opt == "/without_ll/right_cut")
-        change_val(opt, cfg_shelf_right_cut_no_ll_, v->get_float());
-      else if (opt == "/without_ll/top_cut")
-        change_val(opt, cfg_shelf_top_cut_no_ll_, v->get_float());
-      else if (opt == "/without_ll/bottom_cut")
-        change_val(opt, cfg_shelf_bottom_cut_no_ll_, v->get_float());
-      else if (opt == "/without_ll/front_cut")
-        change_val(opt, cfg_shelf_front_cut_no_ll_, v->get_float());
-      else if (opt == "/without_ll/back_cut")
-        change_val(opt, cfg_shelf_back_cut_no_ll_, v->get_float());
-      else if (opt == "/with_ll/left_cut")
-        change_val(opt, cfg_shelf_left_cut_, v->get_float());
-      else if (opt == "/with_ll/right_cut")
-        change_val(opt, cfg_shelf_right_cut_, v->get_float());
-      else if (opt == "/with_ll/top_cut")
-        change_val(opt, cfg_shelf_top_cut_, v->get_float());
-      else if (opt == "/with_ll/bottom_cut")
-        change_val(opt, cfg_shelf_bottom_cut_, v->get_float());
-      else if (opt == "/with_ll/front_cut")
-        change_val(opt, cfg_shelf_front_cut_, v->get_float());
-      else if (opt == "/with_ll/back_cut")
-        change_val(opt, cfg_shelf_back_cut_, v->get_float());
-      else if (opt == "/left_off")
-        change_val(opt, cfg_shelf_left_off_, v->get_float());
-      else if (opt == "/middle_off")
-        change_val(opt, cfg_shelf_middle_off_, v->get_float());
-      else if (opt == "/right_off")
-        change_val(opt, cfg_shelf_right_off_, v->get_float());
-    } else if (sub_prefix == "/icp") {
-      if (opt == "/max_correspondence_dist")
-        change_val(opt, recognition_thread_->cfg_icp_max_corr_dist_,
-                   v->get_float());
-      else if (opt == "/transformation_epsilon")
-        change_val(opt, recognition_thread_->cfg_icp_tf_epsilon_,
-                   double(v->get_float()));
-      else if (opt == "/refinement_factor")
-        change_val(opt, recognition_thread_->cfg_icp_refinement_factor_,
-                   double(v->get_float()));
-      else if (opt == "/max_iterations")
-        change_val(opt, recognition_thread_->cfg_icp_max_iterations_,
-                   v->get_int());
-      else if (opt == "/hv/penalty_threshold")
-        change_val(opt, recognition_thread_->cfg_icp_hv_penalty_thresh_,
-                   v->get_float());
-      else if (opt == "/hv/support_threshold")
-        change_val(opt, recognition_thread_->cfg_icp_hv_support_thresh_,
-                   v->get_float());
-      else if (opt == "/hv/inlier_threshold")
-        change_val(opt, recognition_thread_->cfg_icp_hv_inlier_thresh_,
-                   v->get_float());
-      else if (opt == "/hv/shelf_penalty_threshold")
-        change_val(opt, recognition_thread_->cfg_icp_shelf_hv_penalty_thresh_,
-                   v->get_float());
-      else if (opt == "/hv/shelf_support_threshold")
-        change_val(opt, recognition_thread_->cfg_icp_shelf_hv_support_thresh_,
-                   v->get_float());
-      else if (opt == "/hv/shelf_inlier_threshold")
-        change_val(opt, recognition_thread_->cfg_icp_shelf_hv_inlier_thresh_,
-                   v->get_float());
-      else if (opt == "/min_loops")
-        change_val(opt, recognition_thread_->cfg_icp_min_loops_, v->get_uint());
-      else if (opt == "/max_loops")
-        change_val(opt, recognition_thread_->cfg_icp_max_loops_, v->get_uint());
-      else if (opt == "/auto_restart")
-        change_val(opt, recognition_thread_->cfg_icp_auto_restart_,
-                   v->get_bool());
-      else if (opt == "/hint/input_conveyor/x") {
-        change_val(
-            opt, cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][X_DIR],
-            v->get_float());
-        change_val(
-            opt,
-            cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][X_DIR],
-            v->get_float());
-      } else if (opt == "/hint/input_conveyor/y") {
-        change_val(
-            opt, cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][Y_DIR],
-            v->get_float());
-        change_val(
-            opt,
-            cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][Y_DIR],
-            -(v->get_float()));
-      } else if (opt == "/hint/input_conveyor/z") {
-        change_val(
-            opt, cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][Z_DIR],
-            v->get_float());
-        change_val(
-            opt,
-            cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][Z_DIR],
-            v->get_float());
-      } else if (opt == "/hint/left_shelf/x")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][X_DIR],
-                   v->get_float());
-      else if (opt == "/hint/left_shelf/y")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][Y_DIR],
-                   v->get_float());
-      else if (opt == "/hint/left_shelf/z")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][Z_DIR],
-                   v->get_float());
-      else if (opt == "/hint/middle_shelf/x")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][X_DIR],
-                   v->get_float());
-      else if (opt == "/hint/middle_shelf/y")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][Y_DIR],
-                   v->get_float());
-      else if (opt == "/hint/middle_shelf/z")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][Z_DIR],
-                   v->get_float());
-      else if (opt == "/hint/right_shelf/x")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][X_DIR],
-                   v->get_float());
-      else if (opt == "/hint/right_shelf/y")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][Y_DIR],
-                   v->get_float());
-      else if (opt == "/hint/right_shelf/z")
-        change_val(opt,
-                   cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][Z_DIR],
-                   v->get_float());
-      else if (opt == "/hint/slide/x")
-        change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SLIDE][X_DIR],
-                   v->get_float());
-      else if (opt == "/hint/slide/y")
-        change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SLIDE][Y_DIR],
-                   v->get_float());
-      else if (opt == "/hint/slide/z")
-        change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SLIDE][Z_DIR],
-                   v->get_float());
-      else if (opt == "/hint/default/x")
-        change_val(
-            opt, cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][X_DIR],
-            v->get_float());
-      else if (opt == "/hint/default/y")
-        change_val(
-            opt, cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][Y_DIR],
-            v->get_float());
-      else if (opt == "/hint/default/z")
-        change_val(
-            opt, cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][Z_DIR],
-            v->get_float());
-
-      else if (opt == "/conveyor_offset/base_station/x")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][X_DIR],
-                   v->get_float());
-      else if (opt == "/conveyor_offset/base_station/y")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][Y_DIR],
-                   v->get_float());
-      else if (opt == "/conveyor_offset/base_station/z")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][Z_DIR],
-                   v->get_float());
-
-      else if (opt == "/conveyor_offset/cap_station/x")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][X_DIR],
-                   v->get_float());
-      else if (opt == "/conveyor_offset/cap_station/y")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][Y_DIR],
-                   v->get_float());
-      else if (opt == "/conveyor_offset/cap_station/z")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][Z_DIR],
-                   v->get_float());
-
-      else if (opt == "/conveyor_offset/ring_station/x")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::RING_STATION][X_DIR],
-                   v->get_float());
-      else if (opt == "/conveyor_offset/ring_station/y")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::RING_STATION][Y_DIR],
-                   v->get_float());
-      else if (opt == "/conveyor_offset/ring_station/z")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::RING_STATION][Z_DIR],
-                   v->get_float());
-
-      else if (opt == "/conveyor_offset/delivery_station/x")
-        change_val(
-            opt,
-            cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][X_DIR],
-            v->get_float());
-      else if (opt == "/conveyor_offset/delivery_station/y")
-        change_val(
-            opt,
-            cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][Y_DIR],
-            v->get_float());
-      else if (opt == "/conveyor_offset/delivery_station/z")
-        change_val(
-            opt,
-            cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][Z_DIR],
-            v->get_float());
-
-      else if (opt == "/conveyor_offset/storage_station/x")
-        change_val(
-            opt,
-            cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][X_DIR],
-            v->get_float());
-      else if (opt == "/conveyor_offset/storage_station/y")
-        change_val(
-            opt,
-            cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][Y_DIR],
-            v->get_float());
-      else if (opt == "/conveyor_offset/storage_station/z")
-        change_val(
-            opt,
-            cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][Z_DIR],
-            v->get_float());
-
-      else if (opt == "/conveyor_offset/default/x")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][X_DIR],
-                   v->get_float());
-      else if (opt == "/conveyor_offset/default/y")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][Y_DIR],
-                   v->get_float());
-      else if (opt == "/conveyor_offset/default/z")
-        change_val(opt,
-                   cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][Z_DIR],
-                   v->get_float());
-    } else if (sub_prefix == "/ll") {
-      if (opt == "/bearing_threshold")
-        change_val(opt, cfg_ll_bearing_thresh_, v->get_float());
-    }
-    if (recognition_thread_->enabled())
-      recognition_thread_->restart();
-  }
+void
+ConveyorPoseThread::set_cg_thread(RecognitionThread *cg_thread)
+{
+	recognition_thread_ = cg_thread;
 }
 
-void ConveyorPoseThread::bb_set_busy(bool busy) {
-  bb_pose_->set_busy(busy);
-  bb_pose_->write();
+void
+ConveyorPoseThread::config_value_erased(const char *path)
+{
 }
 
-float ConveyorPoseThread::cloud_resolution() const {
-  return cfg_voxel_grid_leaf_size_;
+void
+ConveyorPoseThread::config_tag_changed(const char *new_tag)
+{
 }
 
-Eigen::Matrix4f pose_to_eigen(const fawkes::tf::Pose &pose) {
-  const tf::Matrix3x3 &rot = pose.getBasis();
-  const tf::Vector3 &trans = pose.getOrigin();
-  Eigen::Matrix4f rv(Eigen::Matrix4f::Identity());
-  rv.block<3, 3>(0, 0) << float(rot[0][0]), float(rot[0][1]), float(rot[0][2]),
-      float(rot[1][0]), float(rot[1][1]), float(rot[1][2]), float(rot[2][0]),
-      float(rot[2][1]), float(rot[2][2]);
-  rv.block<3, 1>(0, 3) << float(trans[X_DIR]), float(trans[Y_DIR]),
-      float(trans[Z_DIR]);
-  return rv;
+void
+ConveyorPoseThread::config_comment_changed(const Configuration::ValueIterator *v)
+{
 }
 
-fawkes::tf::Pose eigen_to_pose(const Eigen::Matrix4f &m) {
-  fawkes::tf::Pose rv;
-  rv.setOrigin({double(m(0, 3)), double(m(1, 3)), double(m(2, 3))});
-  rv.setBasis({double(m(0, 0)), double(m(0, 1)), double(m(0, 2)),
-               double(m(1, 0)), double(m(1, 1)), double(m(1, 2)),
-               double(m(2, 0)), double(m(2, 1)), double(m(2, 2))});
-  return rv;
+void
+ConveyorPoseThread::config_value_changed(const Configuration::ValueIterator *v)
+{
+	if (v->valid()) {
+		std::string path       = v->path();
+		std::string sufx       = path.substr(strlen(CFG_PREFIX));
+		std::string sub_prefix = sufx.substr(0, sufx.substr(1).find("/") + 1);
+		std::string full_pfx   = CFG_PREFIX + sub_prefix;
+		std::string opt        = path.substr(full_pfx.length());
+
+		if (sub_prefix == "/without_ll") {
+			if (opt == "/left_cut")
+				change_val(opt, cfg_left_cut_no_ll_, v->get_float());
+			else if (opt == "/right_cut")
+				change_val(opt, cfg_right_cut_no_ll_, v->get_float());
+			else if (opt == "/top_cut")
+				change_val(opt, cfg_top_cut_no_ll_, v->get_float());
+			else if (opt == "/bottom_cut")
+				change_val(opt, cfg_bottom_cut_no_ll_, v->get_float());
+			else if (opt == "/front_cut")
+				change_val(opt, cfg_front_cut_no_ll_, v->get_float());
+			else if (opt == "/back_cut")
+				change_val(opt, cfg_back_cut_no_ll_, v->get_float());
+		} else if (sub_prefix == "/with_ll") {
+			if (opt == "/left_cut")
+				change_val(opt, cfg_left_cut_, v->get_float());
+			else if (opt == "/right_cut")
+				change_val(opt, cfg_right_cut_, v->get_float());
+			else if (opt == "/top_cut")
+				change_val(opt, cfg_top_cut_, v->get_float());
+			else if (opt == "/bottom_cut")
+				change_val(opt, cfg_bottom_cut_, v->get_float());
+			else if (opt == "/front_cut")
+				change_val(opt, cfg_front_cut_, v->get_float());
+			else if (opt == "/back_cut")
+				change_val(opt, cfg_back_cut_, v->get_float());
+		} else if (sub_prefix == "/shelf") {
+			if (opt == "/without_ll/left_cut")
+				change_val(opt, cfg_shelf_left_cut_no_ll_, v->get_float());
+			else if (opt == "/without_ll/right_cut")
+				change_val(opt, cfg_shelf_right_cut_no_ll_, v->get_float());
+			else if (opt == "/without_ll/top_cut")
+				change_val(opt, cfg_shelf_top_cut_no_ll_, v->get_float());
+			else if (opt == "/without_ll/bottom_cut")
+				change_val(opt, cfg_shelf_bottom_cut_no_ll_, v->get_float());
+			else if (opt == "/without_ll/front_cut")
+				change_val(opt, cfg_shelf_front_cut_no_ll_, v->get_float());
+			else if (opt == "/without_ll/back_cut")
+				change_val(opt, cfg_shelf_back_cut_no_ll_, v->get_float());
+			else if (opt == "/with_ll/left_cut")
+				change_val(opt, cfg_shelf_left_cut_, v->get_float());
+			else if (opt == "/with_ll/right_cut")
+				change_val(opt, cfg_shelf_right_cut_, v->get_float());
+			else if (opt == "/with_ll/top_cut")
+				change_val(opt, cfg_shelf_top_cut_, v->get_float());
+			else if (opt == "/with_ll/bottom_cut")
+				change_val(opt, cfg_shelf_bottom_cut_, v->get_float());
+			else if (opt == "/with_ll/front_cut")
+				change_val(opt, cfg_shelf_front_cut_, v->get_float());
+			else if (opt == "/with_ll/back_cut")
+				change_val(opt, cfg_shelf_back_cut_, v->get_float());
+			else if (opt == "/left_off")
+				change_val(opt, cfg_shelf_left_off_, v->get_float());
+			else if (opt == "/middle_off")
+				change_val(opt, cfg_shelf_middle_off_, v->get_float());
+			else if (opt == "/right_off")
+				change_val(opt, cfg_shelf_right_off_, v->get_float());
+		} else if (sub_prefix == "/icp") {
+			if (opt == "/max_correspondence_dist")
+				change_val(opt, recognition_thread_->cfg_icp_max_corr_dist_, v->get_float());
+			else if (opt == "/transformation_epsilon")
+				change_val(opt, recognition_thread_->cfg_icp_tf_epsilon_, double(v->get_float()));
+			else if (opt == "/refinement_factor")
+				change_val(opt, recognition_thread_->cfg_icp_refinement_factor_, double(v->get_float()));
+			else if (opt == "/max_iterations")
+				change_val(opt, recognition_thread_->cfg_icp_max_iterations_, v->get_int());
+			else if (opt == "/hv/penalty_threshold")
+				change_val(opt, recognition_thread_->cfg_icp_hv_penalty_thresh_, v->get_float());
+			else if (opt == "/hv/support_threshold")
+				change_val(opt, recognition_thread_->cfg_icp_hv_support_thresh_, v->get_float());
+			else if (opt == "/hv/inlier_threshold")
+				change_val(opt, recognition_thread_->cfg_icp_hv_inlier_thresh_, v->get_float());
+			else if (opt == "/hv/shelf_penalty_threshold")
+				change_val(opt, recognition_thread_->cfg_icp_shelf_hv_penalty_thresh_, v->get_float());
+			else if (opt == "/hv/shelf_support_threshold")
+				change_val(opt, recognition_thread_->cfg_icp_shelf_hv_support_thresh_, v->get_float());
+			else if (opt == "/hv/shelf_inlier_threshold")
+				change_val(opt, recognition_thread_->cfg_icp_shelf_hv_inlier_thresh_, v->get_float());
+			else if (opt == "/min_loops")
+				change_val(opt, recognition_thread_->cfg_icp_min_loops_, v->get_uint());
+			else if (opt == "/max_loops")
+				change_val(opt, recognition_thread_->cfg_icp_max_loops_, v->get_uint());
+			else if (opt == "/auto_restart")
+				change_val(opt, recognition_thread_->cfg_icp_auto_restart_, v->get_bool());
+			else if (opt == "/hint/input_conveyor/x") {
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][X_DIR],
+				           v->get_float());
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][X_DIR],
+				           v->get_float());
+			} else if (opt == "/hint/input_conveyor/y") {
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][Y_DIR],
+				           v->get_float());
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][Y_DIR],
+				           -(v->get_float()));
+			} else if (opt == "/hint/input_conveyor/z") {
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::INPUT_CONVEYOR][Z_DIR],
+				           v->get_float());
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::OUTPUT_CONVEYOR][Z_DIR],
+				           v->get_float());
+			} else if (opt == "/hint/left_shelf/x")
+				change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][X_DIR], v->get_float());
+			else if (opt == "/hint/left_shelf/y")
+				change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][Y_DIR], v->get_float());
+			else if (opt == "/hint/left_shelf/z")
+				change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SHELF_LEFT][Z_DIR], v->get_float());
+			else if (opt == "/hint/middle_shelf/x")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][X_DIR],
+				           v->get_float());
+			else if (opt == "/hint/middle_shelf/y")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][Y_DIR],
+				           v->get_float());
+			else if (opt == "/hint/middle_shelf/z")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::SHELF_MIDDLE][Z_DIR],
+				           v->get_float());
+			else if (opt == "/hint/right_shelf/x")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][X_DIR],
+				           v->get_float());
+			else if (opt == "/hint/right_shelf/y")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][Y_DIR],
+				           v->get_float());
+			else if (opt == "/hint/right_shelf/z")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::SHELF_RIGHT][Z_DIR],
+				           v->get_float());
+			else if (opt == "/hint/slide/x")
+				change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SLIDE][X_DIR], v->get_float());
+			else if (opt == "/hint/slide/y")
+				change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SLIDE][Y_DIR], v->get_float());
+			else if (opt == "/hint/slide/z")
+				change_val(opt, cfg_target_hint_[ConveyorPoseInterface::SLIDE][Z_DIR], v->get_float());
+			else if (opt == "/hint/default/x")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][X_DIR],
+				           v->get_float());
+			else if (opt == "/hint/default/y")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][Y_DIR],
+				           v->get_float());
+			else if (opt == "/hint/default/z")
+				change_val(opt,
+				           cfg_target_hint_[ConveyorPoseInterface::DEFAULT_TARGET][Z_DIR],
+				           v->get_float());
+
+			else if (opt == "/conveyor_offset/base_station/x")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][X_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/base_station/y")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][Y_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/base_station/z")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::BASE_STATION][Z_DIR],
+				           v->get_float());
+
+			else if (opt == "/conveyor_offset/cap_station/x")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][X_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/cap_station/y")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][Y_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/cap_station/z")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::CAP_STATION][Z_DIR],
+				           v->get_float());
+
+			else if (opt == "/conveyor_offset/ring_station/x")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::RING_STATION][X_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/ring_station/y")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::RING_STATION][Y_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/ring_station/z")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::RING_STATION][Z_DIR],
+				           v->get_float());
+
+			else if (opt == "/conveyor_offset/delivery_station/x")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][X_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/delivery_station/y")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][Y_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/delivery_station/z")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::DELIVERY_STATION][Z_DIR],
+				           v->get_float());
+
+			else if (opt == "/conveyor_offset/storage_station/x")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][X_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/storage_station/y")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][Y_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/storage_station/z")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::STORAGE_STATION][Z_DIR],
+				           v->get_float());
+
+			else if (opt == "/conveyor_offset/default/x")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][X_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/default/y")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][Y_DIR],
+				           v->get_float());
+			else if (opt == "/conveyor_offset/default/z")
+				change_val(opt,
+				           cfg_type_offset_[ConveyorPoseInterface::DEFAULT_TYPE][Z_DIR],
+				           v->get_float());
+		} else if (sub_prefix == "/ll") {
+			if (opt == "/bearing_threshold")
+				change_val(opt, cfg_ll_bearing_thresh_, v->get_float());
+		}
+		if (recognition_thread_->enabled())
+			recognition_thread_->restart();
+	}
+}
+
+void
+ConveyorPoseThread::bb_set_busy(bool busy)
+{
+	bb_pose_->set_busy(busy);
+	bb_pose_->write();
+}
+
+float
+ConveyorPoseThread::cloud_resolution() const
+{
+	return cfg_voxel_grid_leaf_size_;
+}
+
+Eigen::Matrix4f
+pose_to_eigen(const fawkes::tf::Pose &pose)
+{
+	const tf::Matrix3x3 &rot   = pose.getBasis();
+	const tf::Vector3 &  trans = pose.getOrigin();
+	Eigen::Matrix4f      rv(Eigen::Matrix4f::Identity());
+	rv.block<3, 3>(0, 0) << float(rot[0][0]), float(rot[0][1]), float(rot[0][2]), float(rot[1][0]),
+	  float(rot[1][1]), float(rot[1][2]), float(rot[2][0]), float(rot[2][1]), float(rot[2][2]);
+	rv.block<3, 1>(0, 3) << float(trans[X_DIR]), float(trans[Y_DIR]), float(trans[Z_DIR]);
+	return rv;
+}
+
+fawkes::tf::Pose
+eigen_to_pose(const Eigen::Matrix4f &m)
+{
+	fawkes::tf::Pose rv;
+	rv.setOrigin({double(m(0, 3)), double(m(1, 3)), double(m(2, 3))});
+	rv.setBasis({double(m(0, 0)),
+	             double(m(0, 1)),
+	             double(m(0, 2)),
+	             double(m(1, 0)),
+	             double(m(1, 1)),
+	             double(m(1, 2)),
+	             double(m(2, 0)),
+	             double(m(2, 1)),
+	             double(m(2, 2))});
+	return rv;
 }
 
 /*
@@ -1271,108 +1218,107 @@ fawkes::tf::Pose eigen_to_pose(const Eigen::Matrix4f &m) {
  * */
 ConveyorPoseThread::CloudPtr
 ConveyorPoseThread::cloud_trim(ConveyorPoseThread::CloudPtr in,
-                               fawkes::LaserLineInterface *ll, bool use_ll) {
-  float x_min = -FLT_MAX, x_max = FLT_MAX, y_min = -FLT_MAX, y_max = FLT_MAX,
-        z_min = -FLT_MAX, z_max = FLT_MAX;
+                               fawkes::LaserLineInterface * ll,
+                               bool                         use_ll)
+{
+	float x_min = -FLT_MAX, x_max = FLT_MAX, y_min = -FLT_MAX, y_max = FLT_MAX, z_min = -FLT_MAX,
+	      z_max = FLT_MAX;
 
-  if (use_ll) {
-    // get position of initial guess in conveyor cam frame
-    // rotation is ignored, since rotation values are small
-    tf::Stamped<tf::Pose> origin_pose;
-    if (cfg_record_model_) {
-      tf_listener->transform_origin(cfg_model_origin_frame_,
-                                    in->header.frame_id, origin_pose);
-    } else {
-      tf_listener->transform_pose(
-          in->header.frame_id,
-          tf::Stamped<tf::Pose>(initial_guess_laser_odom_, Time(0, 0),
-                                initial_guess_laser_odom_.frame_id),
-          origin_pose);
-    }
-    float x_ini = origin_pose.getOrigin()[X_DIR],
-          y_ini = origin_pose.getOrigin()[Y_DIR],
-          z_ini = origin_pose.getOrigin()[Z_DIR];
+	if (use_ll) {
+		// get position of initial guess in conveyor cam frame
+		// rotation is ignored, since rotation values are small
+		tf::Stamped<tf::Pose> origin_pose;
+		if (cfg_record_model_) {
+			tf_listener->transform_origin(cfg_model_origin_frame_, in->header.frame_id, origin_pose);
+		} else {
+			tf_listener->transform_pose(in->header.frame_id,
+			                            tf::Stamped<tf::Pose>(initial_guess_laser_odom_,
+			                                                  Time(0, 0),
+			                                                  initial_guess_laser_odom_.frame_id),
+			                            origin_pose);
+		}
+		float x_ini = origin_pose.getOrigin()[X_DIR], y_ini = origin_pose.getOrigin()[Y_DIR],
+		      z_ini = origin_pose.getOrigin()[Z_DIR];
 
-    if (is_target_shelf()) { // using shelf cut values
-      float x_min_temp = x_ini + (float)cfg_shelf_left_cut_,
-            x_max_temp = x_ini + (float)cfg_shelf_right_cut_;
-      switch (current_mps_target_) {
-      case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_LEFT:
-        x_min_temp += (float)cfg_shelf_left_off_;
-        x_max_temp += (float)cfg_shelf_left_off_;
-        break;
-      case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_MIDDLE:
-        x_min_temp += (float)cfg_shelf_middle_off_;
-        x_max_temp += (float)cfg_shelf_middle_off_;
-        break;
-      case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_RIGHT:
-        x_min_temp += (float)cfg_shelf_right_off_;
-        x_max_temp += (float)cfg_shelf_right_off_;
-        break;
-      default: // This should not happen
-        break;
-      }
-      x_min = std::max(x_min_temp, x_min);
-      x_max = std::min(x_max_temp, x_max);
+		if (is_target_shelf()) { // using shelf cut values
+			float x_min_temp = x_ini + (float)cfg_shelf_left_cut_,
+			      x_max_temp = x_ini + (float)cfg_shelf_right_cut_;
+			switch (current_mps_target_) {
+			case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_LEFT:
+				x_min_temp += (float)cfg_shelf_left_off_;
+				x_max_temp += (float)cfg_shelf_left_off_;
+				break;
+			case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_MIDDLE:
+				x_min_temp += (float)cfg_shelf_middle_off_;
+				x_max_temp += (float)cfg_shelf_middle_off_;
+				break;
+			case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_RIGHT:
+				x_min_temp += (float)cfg_shelf_right_off_;
+				x_max_temp += (float)cfg_shelf_right_off_;
+				break;
+			default: // This should not happen
+				break;
+			}
+			x_min = std::max(x_min_temp, x_min);
+			x_max = std::min(x_max_temp, x_max);
 
-      y_min = std::max(y_ini + (float)cfg_shelf_top_cut_, y_min);
-      y_max = std::min(y_ini + (float)cfg_shelf_bottom_cut_, y_max);
+			y_min = std::max(y_ini + (float)cfg_shelf_top_cut_, y_min);
+			y_max = std::min(y_ini + (float)cfg_shelf_bottom_cut_, y_max);
 
-      z_min = std::max(z_ini + (float)cfg_shelf_front_cut_, z_min);
-      z_max = std::min(z_ini + (float)cfg_shelf_back_cut_, z_max);
-    } else { // using general cut values
-      x_min = std::max(x_ini + (float)cfg_left_cut_, x_min);
-      x_max = std::min(x_ini + (float)cfg_right_cut_, x_max);
+			z_min = std::max(z_ini + (float)cfg_shelf_front_cut_, z_min);
+			z_max = std::min(z_ini + (float)cfg_shelf_back_cut_, z_max);
+		} else { // using general cut values
+			x_min = std::max(x_ini + (float)cfg_left_cut_, x_min);
+			x_max = std::min(x_ini + (float)cfg_right_cut_, x_max);
 
-      y_min = std::max(y_ini + (float)cfg_top_cut_, y_min);
-      y_max = std::min(y_ini + (float)cfg_bottom_cut_, y_max);
+			y_min = std::max(y_ini + (float)cfg_top_cut_, y_min);
+			y_max = std::min(y_ini + (float)cfg_bottom_cut_, y_max);
 
-      z_min = std::max(z_ini + (float)cfg_front_cut_, z_min);
-      z_max = std::min(z_ini + (float)cfg_back_cut_, z_max);
-    }
+			z_min = std::max(z_ini + (float)cfg_front_cut_, z_min);
+			z_max = std::min(z_ini + (float)cfg_back_cut_, z_max);
+		}
 
-  } else { // there is no laser line matching tolerances, thus no initial tf
-           // guess
-    if (is_target_shelf()) { // using shelf cut values
-      x_min = std::max((float)cfg_shelf_left_cut_no_ll_, x_min);
-      x_max = std::min((float)cfg_shelf_right_cut_no_ll_, x_max);
+	} else {                   // there is no laser line matching tolerances, thus no initial tf
+		                         // guess
+		if (is_target_shelf()) { // using shelf cut values
+			x_min = std::max((float)cfg_shelf_left_cut_no_ll_, x_min);
+			x_max = std::min((float)cfg_shelf_right_cut_no_ll_, x_max);
 
-      y_min = std::max((float)cfg_shelf_top_cut_no_ll_, y_min);
-      y_max = std::min((float)cfg_shelf_bottom_cut_no_ll_, y_max);
+			y_min = std::max((float)cfg_shelf_top_cut_no_ll_, y_min);
+			y_max = std::min((float)cfg_shelf_bottom_cut_no_ll_, y_max);
 
-      z_min = std::max((float)cfg_shelf_front_cut_no_ll_, z_min);
-      z_max = std::min((float)cfg_shelf_back_cut_no_ll_, z_max);
-    } else { // using general cut values
-      x_min = std::max((float)cfg_left_cut_no_ll_, x_min);
-      x_max = std::min((float)cfg_right_cut_no_ll_, x_max);
+			z_min = std::max((float)cfg_shelf_front_cut_no_ll_, z_min);
+			z_max = std::min((float)cfg_shelf_back_cut_no_ll_, z_max);
+		} else { // using general cut values
+			x_min = std::max((float)cfg_left_cut_no_ll_, x_min);
+			x_max = std::min((float)cfg_right_cut_no_ll_, x_max);
 
-      y_min = std::max((float)cfg_top_cut_no_ll_, y_min);
-      y_max = std::min((float)cfg_bottom_cut_no_ll_, y_max);
+			y_min = std::max((float)cfg_top_cut_no_ll_, y_min);
+			y_max = std::min((float)cfg_bottom_cut_no_ll_, y_max);
 
-      z_min = std::max((float)cfg_front_cut_no_ll_, z_min);
-      z_max = std::min((float)cfg_back_cut_no_ll_, z_max);
-    }
-  }
+			z_min = std::max((float)cfg_front_cut_no_ll_, z_min);
+			z_max = std::min((float)cfg_back_cut_no_ll_, z_max);
+		}
+	}
 
-  CloudPtr out(new Cloud);
-  for (Point p : *in) {
-    if (p.x < x_max && p.x > x_min && p.y < y_max && p.y > y_min &&
-        p.z < z_max && p.z > z_min) {
-      out->push_back(p);
-    }
-  }
+	CloudPtr out(new Cloud);
+	for (Point p : *in) {
+		if (p.x < x_max && p.x > x_min && p.y < y_max && p.y > y_min && p.z < z_max && p.z > z_min) {
+			out->push_back(p);
+		}
+	}
 
-  out->header = in->header;
-  return out;
+	out->header = in->header;
+	return out;
 }
 
-bool ConveyorPoseThread::is_target_shelf() {
-  switch (current_mps_target_) {
-  case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_LEFT:
-  case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_MIDDLE:
-  case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_RIGHT:
-    return true;
-  default:
-    return false;
-  }
+bool
+ConveyorPoseThread::is_target_shelf()
+{
+	switch (current_mps_target_) {
+	case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_LEFT:
+	case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_MIDDLE:
+	case fawkes::ConveyorPoseInterface::MPS_TARGET::SHELF_RIGHT: return true;
+	default: return false;
+	}
 }

--- a/src/plugins/conveyor_pose/conveyor_pose_thread.h
+++ b/src/plugins/conveyor_pose/conveyor_pose_thread.h
@@ -25,10 +25,6 @@
 #ifndef _CONVEYOR_POSE_THREAD_
 #define _CONVEYOR_POSE_THREAD_
 
-#include <core/threading/mutex.h>
-#include <core/threading/mutex_locker.h>
-#include <core/threading/thread.h>
-
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/configurable.h>
@@ -36,11 +32,11 @@
 #include <aspect/pointcloud.h>
 #include <aspect/syncpoint_manager.h>
 #include <aspect/tf.h>
-
-#include <interfaces/ConveyorPoseInterface.h>
-
 #include <config/change_handler.h>
-
+#include <core/threading/mutex.h>
+#include <core/threading/mutex_locker.h>
+#include <core/threading/thread.h>
+#include <interfaces/ConveyorPoseInterface.h>
 #include <plugins/ros/aspect/ros.h>
 
 //#include <pcl/filters/uniform_sampling.h>
@@ -75,210 +71,210 @@ class ConveyorPoseThread : public fawkes::Thread,
                            public fawkes::PointCloudAspect,
                            public fawkes::ROSAspect,
                            public fawkes::TransformAspect,
-                           public fawkes::SyncPointManagerAspect {
+                           public fawkes::SyncPointManagerAspect
+{
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  ConveyorPoseThread();
+	ConveyorPoseThread();
 
-  virtual void init() override;
-  virtual void loop() override;
-  virtual void finalize() override;
+	virtual void init() override;
+	virtual void loop() override;
+	virtual void finalize() override;
 
-  /** Used by the plugin constructor to enable data exchange between the two
+	/** Used by the plugin constructor to enable data exchange between the two
    * threads
    * @param recog_thread pointer to the thread that does the actual pose
    * recognition
    */
-  void set_cg_thread(RecognitionThread *recog_thread);
+	void set_cg_thread(RecognitionThread *recog_thread);
 
 private:
-  friend RecognitionThread;
+	friend RecognitionThread;
 
-  typedef pcl::PointXYZ Point;
-  typedef pcl::PointCloud<Point> Cloud;
-  typedef Cloud::Ptr CloudPtr;
-  typedef Cloud::ConstPtr CloudConstPtr;
+	typedef pcl::PointXYZ          Point;
+	typedef pcl::PointCloud<Point> Cloud;
+	typedef Cloud::Ptr             CloudPtr;
+	typedef Cloud::ConstPtr        CloudConstPtr;
 
-  std::atomic<double> result_fitness_;
-  const std::string syncpoint_clouds_ready_name_;
-  fawkes::RefPtr<fawkes::SyncPoint> syncpoint_clouds_ready;
+	std::atomic<double>               result_fitness_;
+	const std::string                 syncpoint_clouds_ready_name_;
+	fawkes::RefPtr<fawkes::SyncPoint> syncpoint_clouds_ready;
 
-  // cfg values
-  std::string cfg_if_prefix_;
-  std::string cloud_in_name_;
-  const std::string cloud_out_raw_name_;
-  const std::string cloud_out_trimmed_name_;
-  std::string cfg_bb_realsense_switch_name_;
-  std::string conveyor_frame_id_;
-  std::vector<std::string> laserlines_names_;
+	// cfg values
+	std::string              cfg_if_prefix_;
+	std::string              cloud_in_name_;
+	const std::string        cloud_out_raw_name_;
+	const std::string        cloud_out_trimmed_name_;
+	std::string              cfg_bb_realsense_switch_name_;
+	std::string              conveyor_frame_id_;
+	std::vector<std::string> laserlines_names_;
 
-  CloudPtr trimmed_scene_;
+	CloudPtr trimmed_scene_;
 
-  fawkes::ConveyorPoseInterface::MPS_TYPE current_mps_type_;
-  fawkes::ConveyorPoseInterface::MPS_TARGET current_mps_target_;
+	fawkes::ConveyorPoseInterface::MPS_TYPE   current_mps_type_;
+	fawkes::ConveyorPoseInterface::MPS_TARGET current_mps_target_;
 
-  int cfg_force_shelf_;
+	int cfg_force_shelf_;
 
-  void
-  update_station_information(fawkes::ConveyorPoseInterface::RunICPMessage &msg);
-  std::string get_model_path(fawkes::ConveyorPoseInterface *iface,
-                             fawkes::ConveyorPoseInterface::MPS_TYPE,
-                             fawkes::ConveyorPoseInterface::MPS_TARGET);
+	void        update_station_information(fawkes::ConveyorPoseInterface::RunICPMessage &msg);
+	std::string get_model_path(fawkes::ConveyorPoseInterface *iface,
+	                           fawkes::ConveyorPoseInterface::MPS_TYPE,
+	                           fawkes::ConveyorPoseInterface::MPS_TARGET);
 
-  // Mapping from {Type,Target} to its corresponding model path
-  std::map<std::pair<fawkes::ConveyorPoseInterface::MPS_TYPE,
-                     fawkes::ConveyorPoseInterface::MPS_TARGET>,
-           std::string>
-      type_target_to_path_;
+	// Mapping from {Type,Target} to its corresponding model path
+	std::map<
+	  std::pair<fawkes::ConveyorPoseInterface::MPS_TYPE, fawkes::ConveyorPoseInterface::MPS_TARGET>,
+	  std::string>
+	  type_target_to_path_;
 
-  // Mapping from station name to preprocessed pointcloud model
-  std::map<std::pair<fawkes::ConveyorPoseInterface::MPS_TYPE,
-                     fawkes::ConveyorPoseInterface::MPS_TARGET>,
-           CloudPtr>
-      type_target_to_model_;
+	// Mapping from station name to preprocessed pointcloud model
+	std::map<
+	  std::pair<fawkes::ConveyorPoseInterface::MPS_TYPE, fawkes::ConveyorPoseInterface::MPS_TARGET>,
+	  CloudPtr>
+	  type_target_to_model_;
 
-  RecognitionThread *recognition_thread_;
+	RecognitionThread *recognition_thread_;
 
-  bool cfg_record_model_;
-  std::string cfg_model_origin_frame_;
-  std::string cfg_record_path_;
+	bool        cfg_record_model_;
+	std::string cfg_model_origin_frame_;
+	std::string cfg_record_path_;
 
-  std::atomic<float> cfg_left_cut_;
-  std::atomic<float> cfg_right_cut_;
-  std::atomic<float> cfg_top_cut_;
-  std::atomic<float> cfg_bottom_cut_;
-  std::atomic<float> cfg_front_cut_;
-  std::atomic<float> cfg_back_cut_;
+	std::atomic<float> cfg_left_cut_;
+	std::atomic<float> cfg_right_cut_;
+	std::atomic<float> cfg_top_cut_;
+	std::atomic<float> cfg_bottom_cut_;
+	std::atomic<float> cfg_front_cut_;
+	std::atomic<float> cfg_back_cut_;
 
-  std::atomic<float> cfg_left_cut_no_ll_;
-  std::atomic<float> cfg_right_cut_no_ll_;
-  std::atomic<float> cfg_top_cut_no_ll_;
-  std::atomic<float> cfg_bottom_cut_no_ll_;
-  std::atomic<float> cfg_front_cut_no_ll_;
-  std::atomic<float> cfg_back_cut_no_ll_;
+	std::atomic<float> cfg_left_cut_no_ll_;
+	std::atomic<float> cfg_right_cut_no_ll_;
+	std::atomic<float> cfg_top_cut_no_ll_;
+	std::atomic<float> cfg_bottom_cut_no_ll_;
+	std::atomic<float> cfg_front_cut_no_ll_;
+	std::atomic<float> cfg_back_cut_no_ll_;
 
-  std::atomic<float> cfg_shelf_left_cut_;
-  std::atomic<float> cfg_shelf_right_cut_;
-  std::atomic<float> cfg_shelf_top_cut_;
-  std::atomic<float> cfg_shelf_bottom_cut_;
-  std::atomic<float> cfg_shelf_front_cut_;
-  std::atomic<float> cfg_shelf_back_cut_;
+	std::atomic<float> cfg_shelf_left_cut_;
+	std::atomic<float> cfg_shelf_right_cut_;
+	std::atomic<float> cfg_shelf_top_cut_;
+	std::atomic<float> cfg_shelf_bottom_cut_;
+	std::atomic<float> cfg_shelf_front_cut_;
+	std::atomic<float> cfg_shelf_back_cut_;
 
-  std::atomic<float> cfg_shelf_left_cut_no_ll_;
-  std::atomic<float> cfg_shelf_right_cut_no_ll_;
-  std::atomic<float> cfg_shelf_top_cut_no_ll_;
-  std::atomic<float> cfg_shelf_bottom_cut_no_ll_;
-  std::atomic<float> cfg_shelf_front_cut_no_ll_;
-  std::atomic<float> cfg_shelf_back_cut_no_ll_;
+	std::atomic<float> cfg_shelf_left_cut_no_ll_;
+	std::atomic<float> cfg_shelf_right_cut_no_ll_;
+	std::atomic<float> cfg_shelf_top_cut_no_ll_;
+	std::atomic<float> cfg_shelf_bottom_cut_no_ll_;
+	std::atomic<float> cfg_shelf_front_cut_no_ll_;
+	std::atomic<float> cfg_shelf_back_cut_no_ll_;
 
-  std::atomic<float> cfg_shelf_left_off_;
-  std::atomic<float> cfg_shelf_middle_off_;
-  std::atomic<float> cfg_shelf_right_off_;
+	std::atomic<float> cfg_shelf_left_off_;
+	std::atomic<float> cfg_shelf_middle_off_;
+	std::atomic<float> cfg_shelf_right_off_;
 
-  std::atomic<float> cfg_voxel_grid_leaf_size_;
+	std::atomic<float> cfg_voxel_grid_leaf_size_;
 
-  std::map<fawkes::ConveyorPoseInterface::MPS_TARGET,
-           std::array<std::atomic<float>, 3>>
-      cfg_target_hint_;
-  std::map<fawkes::ConveyorPoseInterface::MPS_TYPE,
-           std::array<std::atomic<float>, 3>>
-      cfg_type_offset_;
+	std::map<fawkes::ConveyorPoseInterface::MPS_TARGET, std::array<std::atomic<float>, 3>>
+	  cfg_target_hint_;
+	std::map<fawkes::ConveyorPoseInterface::MPS_TYPE, std::array<std::atomic<float>, 3>>
+	  cfg_type_offset_;
 
-  std::atomic<float> cfg_ll_bearing_thresh_;
+	std::atomic<float> cfg_ll_bearing_thresh_;
 
-  // state vars
-  bool cfg_enable_switch_;
-  bool cloud_in_registered_;
-  pcl::PCLHeader header_;
+	// state vars
+	bool           cfg_enable_switch_;
+	bool           cloud_in_registered_;
+	pcl::PCLHeader header_;
 
-  // point clouds from pcl_manager
-  fawkes::RefPtr<const Cloud> cloud_in_;
+	// point clouds from pcl_manager
+	fawkes::RefPtr<const Cloud> cloud_in_;
 
-  // interfaces write
-  fawkes::SwitchInterface *bb_enable_switch_;
-  fawkes::ConveyorPoseInterface *bb_pose_;
+	// interfaces write
+	fawkes::SwitchInterface *      bb_enable_switch_;
+	fawkes::ConveyorPoseInterface *bb_pose_;
 
-  // interfaces read
-  std::vector<fawkes::LaserLineInterface *> laserlines_;
-  fawkes::SwitchInterface *realsense_switch_;
-  fawkes::Time wait_start_;
-  fawkes::Time wait_time_;
+	// interfaces read
+	std::vector<fawkes::LaserLineInterface *> laserlines_;
+	fawkes::SwitchInterface *                 realsense_switch_;
+	fawkes::Time                              wait_start_;
+	fawkes::Time                              wait_time_;
 
-  float cloud_resolution() const;
-  void cloud_publish(CloudPtr cloud_in, fawkes::RefPtr<Cloud> cloud_out);
+	float cloud_resolution() const;
+	void  cloud_publish(CloudPtr cloud_in, fawkes::RefPtr<Cloud> cloud_out);
 
-  void bb_set_busy(bool busy);
+	void bb_set_busy(bool busy);
 
-  CloudPtr model_;
-  CloudPtr scene_;
+	CloudPtr model_;
+	CloudPtr scene_;
 
-  fawkes::Mutex cloud_mutex_;
-  fawkes::Mutex bb_mutex_;
+	fawkes::Mutex cloud_mutex_;
+	fawkes::Mutex bb_mutex_;
 
-  std::atomic_bool have_laser_line_;
+	std::atomic_bool have_laser_line_;
 
-  fawkes::RefPtr<Cloud> cloud_out_raw_;
-  fawkes::RefPtr<Cloud> cloud_out_trimmed_;
-  fawkes::RefPtr<Cloud> cloud_out_model_;
+	fawkes::RefPtr<Cloud> cloud_out_raw_;
+	fawkes::RefPtr<Cloud> cloud_out_trimmed_;
+	fawkes::RefPtr<Cloud> cloud_out_model_;
 
-  std::unique_ptr<fawkes::tf::Stamped<fawkes::tf::Pose>> result_pose_;
+	std::unique_ptr<fawkes::tf::Stamped<fawkes::tf::Pose>> result_pose_;
 
-  fawkes::tf::Stamped<fawkes::tf::Pose> initial_guess_laser_odom_;
+	fawkes::tf::Stamped<fawkes::tf::Pose> initial_guess_laser_odom_;
 
-  bool cfg_debug_mode_;
+	bool cfg_debug_mode_;
 
-  bool update_input_cloud();
+	bool update_input_cloud();
 
-  void bb_update_switch();
-  bool laserline_get_best_fit(fawkes::LaserLineInterface *&best_fit);
-  Eigen::Vector3f
-  laserline_get_center_transformed(fawkes::LaserLineInterface *ll);
-  fawkes::tf::Stamped<fawkes::tf::Pose>
-  laserline_get_center(fawkes::LaserLineInterface *ll);
+	void            bb_update_switch();
+	bool            laserline_get_best_fit(fawkes::LaserLineInterface *&best_fit);
+	Eigen::Vector3f laserline_get_center_transformed(fawkes::LaserLineInterface *ll);
+	fawkes::tf::Stamped<fawkes::tf::Pose> laserline_get_center(fawkes::LaserLineInterface *ll);
 
-  void set_initial_tf_from_laserline(
-      fawkes::LaserLineInterface *ll,
-      fawkes::ConveyorPoseInterface::MPS_TYPE mps_type,
-      fawkes::ConveyorPoseInterface::MPS_TARGET mps_target);
+	void set_initial_tf_from_laserline(fawkes::LaserLineInterface *              ll,
+	                                   fawkes::ConveyorPoseInterface::MPS_TYPE   mps_type,
+	                                   fawkes::ConveyorPoseInterface::MPS_TARGET mps_target);
 
-  CloudPtr cloud_trim(CloudPtr in, fawkes::LaserLineInterface *ll, bool use_ll);
+	CloudPtr cloud_trim(CloudPtr in, fawkes::LaserLineInterface *ll, bool use_ll);
 
-  boost::shared_ptr<std::vector<pcl::PointIndices>> cloud_cluster(CloudPtr in);
-  CloudPtr cloud_voxel_grid(CloudPtr in);
+	boost::shared_ptr<std::vector<pcl::PointIndices>> cloud_cluster(CloudPtr in);
+	CloudPtr                                          cloud_voxel_grid(CloudPtr in);
 
-  bool is_target_shelf();
+	bool is_target_shelf();
 
-  void pose_write();
-  void record_model();
+	void pose_write();
+	void record_model();
 
-  void pose_publish_tf(const fawkes::tf::Stamped<fawkes::tf::Pose> &pose);
-  void start_waiting();
-  bool need_to_wait();
+	void pose_publish_tf(const fawkes::tf::Stamped<fawkes::tf::Pose> &pose);
+	void start_waiting();
+	bool need_to_wait();
 
-  virtual void config_value_erased(const char *path) override;
-  virtual void config_tag_changed(const char *new_tag) override;
-  virtual void config_comment_changed(
-      const fawkes::Configuration::ValueIterator *v) override;
-  virtual void
-  config_value_changed(const fawkes::Configuration::ValueIterator *v) override;
+	virtual void config_value_erased(const char *path) override;
+	virtual void config_tag_changed(const char *new_tag) override;
+	virtual void config_comment_changed(const fawkes::Configuration::ValueIterator *v) override;
+	virtual void config_value_changed(const fawkes::Configuration::ValueIterator *v) override;
 
-  template <typename T>
-  inline void change_val(const std::string &setting, std::atomic<T> &var,
-                         const T &val) {
-    if (var != val) {
-      logger->log_info(name(), "Changing %s from %s to %s", setting.c_str(),
-                       std::to_string(var).c_str(),
-                       std::to_string(val).c_str());
-      var = val;
-    }
-  }
+	template <typename T>
+	inline void
+	change_val(const std::string &setting, std::atomic<T> &var, const T &val)
+	{
+		if (var != val) {
+			logger->log_info(name(),
+			                 "Changing %s from %s to %s",
+			                 setting.c_str(),
+			                 std::to_string(var).c_str(),
+			                 std::to_string(val).c_str());
+			var = val;
+		}
+	}
 
 protected:
-  virtual void run() override { Thread::run(); }
+	virtual void
+	run() override
+	{
+		Thread::run();
+	}
 };
 
-Eigen::Matrix4f pose_to_eigen(const fawkes::tf::Pose &pose);
+Eigen::Matrix4f  pose_to_eigen(const fawkes::tf::Pose &pose);
 fawkes::tf::Pose eigen_to_pose(const Eigen::Matrix4f &m);
 
 #endif

--- a/src/plugins/conveyor_pose/recognition_thread.cpp
+++ b/src/plugins/conveyor_pose/recognition_thread.cpp
@@ -20,291 +20,316 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <pcl/filters/filter.h>
-#include <pcl/recognition/impl/hv/hv_papazov.hpp>
-#include <pcl/registration/transforms.h>
-
-#include "conveyor_pose_thread.h"
 #include "recognition_thread.h"
 
+#include "conveyor_pose_thread.h"
+
+#include <pcl/filters/filter.h>
+#include <pcl/registration/transforms.h>
 #include <utils/time/clock.h>
+
+#include <pcl/recognition/impl/hv/hv_papazov.hpp>
 
 using namespace fawkes;
 
-double CustomICP::getScaledFitness() {
-  double sum_dists = 0;
-  for (const pcl::Correspondence &corr : *correspondences_) {
-    if (corr.index_match >= 0) {
-      sum_dists += 1 / (0.001 + double(std::sqrt(corr.distance)));
-    }
-  }
-  return sum_dists;
+double
+CustomICP::getScaledFitness()
+{
+	double sum_dists = 0;
+	for (const pcl::Correspondence &corr : *correspondences_) {
+		if (corr.index_match >= 0) {
+			sum_dists += 1 / (0.001 + double(std::sqrt(corr.distance)));
+		}
+	}
+	return sum_dists;
 }
 
 RecognitionThread::RecognitionThread(ConveyorPoseThread *cp_thread)
-    : Thread("ICPThread", Thread::OPMODE_CONTINUOUS),
-      TransformAspect(fawkes::TransformAspect::BOTH,
-                      "conveyor_pose_initial_guess"),
-      main_thread_(cp_thread), enabled_(false), restart_pending_(true) {
-  // Allow finalization while loop() is blocked
-  set_prepfin_conc_loop(true);
+: Thread("ICPThread", Thread::OPMODE_CONTINUOUS),
+  TransformAspect(fawkes::TransformAspect::BOTH, "conveyor_pose_initial_guess"),
+  main_thread_(cp_thread),
+  enabled_(false),
+  restart_pending_(true)
+{
+	// Allow finalization while loop() is blocked
+	set_prepfin_conc_loop(true);
 }
 
-void RecognitionThread::init() {
-  syncpoint_clouds_ready_ = syncpoint_manager->get_syncpoint(
-      name(), main_thread_->syncpoint_clouds_ready_name_);
+void
+RecognitionThread::init()
+{
+	syncpoint_clouds_ready_ =
+	  syncpoint_manager->get_syncpoint(name(), main_thread_->syncpoint_clouds_ready_name_);
 }
 
-void RecognitionThread::restart_icp() {
-  logger->log_info(name(), "Restarting ICP");
+void
+RecognitionThread::restart_icp()
+{
+	logger->log_info(name(), "Restarting ICP");
 
-  syncpoint_clouds_ready_->wait(name());
+	syncpoint_clouds_ready_->wait(name());
 
-  {
-    fawkes::MutexLocker locked{&main_thread_->bb_mutex_};
-    main_thread_->bb_set_busy(true);
-  }
+	{
+		fawkes::MutexLocker locked{&main_thread_->bb_mutex_};
+		main_thread_->bb_set_busy(true);
+	}
 
-  tf::Stamped<tf::Pose> initial_pose_cam;
+	tf::Stamped<tf::Pose> initial_pose_cam;
 
-  {
-    fawkes::MutexLocker locked{&main_thread_->cloud_mutex_};
-    std::vector<int> tmp;
-    model_ = main_thread_->model_;
-    pcl::removeNaNFromPointCloud(*model_, *model_, tmp);
-    scene_ = main_thread_->scene_;
-    pcl::removeNaNFromPointCloud(*scene_, *scene_, tmp);
+	{
+		fawkes::MutexLocker locked{&main_thread_->cloud_mutex_};
+		std::vector<int>    tmp;
+		model_ = main_thread_->model_;
+		pcl::removeNaNFromPointCloud(*model_, *model_, tmp);
+		scene_ = main_thread_->scene_;
+		pcl::removeNaNFromPointCloud(*scene_, *scene_, tmp);
 
-    model_->header.frame_id = scene_->header.frame_id;
+		model_->header.frame_id = scene_->header.frame_id;
 
-    try {
-      if (!main_thread_->have_laser_line_) {
-        if (initial_guess_icp_odom_.frame_id ==
-            "NO_ID_STAMPED_DEFAULT_CONSTRUCTION") {
-          logger->log_error(name(), "Cannot get initial estimate: No "
-                                    "laser-line and no previous result!");
-          restart_pending_ = true;
-          return;
-        }
-        tf_listener->transform_pose(
-            scene_->header.frame_id,
-            tf::Stamped<tf::Pose>(initial_guess_icp_odom_, Time(0, 0),
-                                  initial_guess_icp_odom_.frame_id),
-            initial_pose_cam);
-      } else {
-        tf_listener->transform_pose(
-            scene_->header.frame_id,
-            tf::Stamped<tf::Pose>(
-                main_thread_->initial_guess_laser_odom_, Time(0, 0),
-                main_thread_->initial_guess_laser_odom_.frame_id),
-            initial_pose_cam);
-      }
-    } catch (tf::TransformException &e) {
-      logger->log_error(
-          name(), "Cannot get initial estimate - laserline was %savailable: %s",
-          !main_thread_->have_laser_line_ ? "not " : "", e.what());
-      restart_pending_ = true;
-      return;
-    }
-  }
+		try {
+			if (!main_thread_->have_laser_line_) {
+				if (initial_guess_icp_odom_.frame_id == "NO_ID_STAMPED_DEFAULT_CONSTRUCTION") {
+					logger->log_error(name(),
+					                  "Cannot get initial estimate: No "
+					                  "laser-line and no previous result!");
+					restart_pending_ = true;
+					return;
+				}
+				tf_listener->transform_pose(scene_->header.frame_id,
+				                            tf::Stamped<tf::Pose>(initial_guess_icp_odom_,
+				                                                  Time(0, 0),
+				                                                  initial_guess_icp_odom_.frame_id),
+				                            initial_pose_cam);
+			} else {
+				tf_listener->transform_pose(
+				  scene_->header.frame_id,
+				  tf::Stamped<tf::Pose>(main_thread_->initial_guess_laser_odom_,
+				                        Time(0, 0),
+				                        main_thread_->initial_guess_laser_odom_.frame_id),
+				  initial_pose_cam);
+			}
+		} catch (tf::TransformException &e) {
+			logger->log_error(name(),
+			                  "Cannot get initial estimate - laserline was %savailable: %s",
+			                  !main_thread_->have_laser_line_ ? "not " : "",
+			                  e.what());
+			restart_pending_ = true;
+			return;
+		}
+	}
 
-  hypot_verif_.setSceneCloud(scene_);
-  hypot_verif_.setResolution(main_thread_->cloud_resolution());
-  if (main_thread_->is_target_shelf()) { // use shelf values
-    hypot_verif_.setInlierThreshold(cfg_icp_shelf_hv_inlier_thresh_);
-    hypot_verif_.setPenaltyThreshold(cfg_icp_shelf_hv_penalty_thresh_);
-    hypot_verif_.setSupportThreshold(cfg_icp_shelf_hv_support_thresh_);
-  } else { // use general values
-    hypot_verif_.setInlierThreshold(cfg_icp_hv_inlier_thresh_);
-    hypot_verif_.setPenaltyThreshold(cfg_icp_hv_penalty_thresh_);
-    hypot_verif_.setSupportThreshold(cfg_icp_hv_support_thresh_);
-  }
+	hypot_verif_.setSceneCloud(scene_);
+	hypot_verif_.setResolution(main_thread_->cloud_resolution());
+	if (main_thread_->is_target_shelf()) { // use shelf values
+		hypot_verif_.setInlierThreshold(cfg_icp_shelf_hv_inlier_thresh_);
+		hypot_verif_.setPenaltyThreshold(cfg_icp_shelf_hv_penalty_thresh_);
+		hypot_verif_.setSupportThreshold(cfg_icp_shelf_hv_support_thresh_);
+	} else { // use general values
+		hypot_verif_.setInlierThreshold(cfg_icp_hv_inlier_thresh_);
+		hypot_verif_.setPenaltyThreshold(cfg_icp_hv_penalty_thresh_);
+		hypot_verif_.setSupportThreshold(cfg_icp_hv_support_thresh_);
+	}
 
-  initial_tf_ = pose_to_eigen(initial_pose_cam);
+	initial_tf_ = pose_to_eigen(initial_pose_cam);
 
-  tf_publisher->send_transform(tf::StampedTransform(
-      initial_pose_cam, initial_pose_cam.stamp, initial_pose_cam.frame_id,
-      "conveyor_pose_initial_guess"));
+	tf_publisher->send_transform(tf::StampedTransform(initial_pose_cam,
+	                                                  initial_pose_cam.stamp,
+	                                                  initial_pose_cam.frame_id,
+	                                                  "conveyor_pose_initial_guess"));
 
-  icp_result_.reset(new Cloud());
-  icp_result_->header = model_->header;
+	icp_result_.reset(new Cloud());
+	icp_result_->header = model_->header;
 
-  icp_ = CustomICP();
+	icp_ = CustomICP();
 
-  // Set tunables
-  icp_.setTransformationEpsilon(std::pow(cfg_icp_tf_epsilon_, 2));
-  icp_.setMaxCorrespondenceDistance(double(cfg_icp_max_corr_dist_));
-  icp_.setInputTarget(scene_);
-  icp_.setMaximumIterations(cfg_icp_max_iterations_);
+	// Set tunables
+	icp_.setTransformationEpsilon(std::pow(cfg_icp_tf_epsilon_, 2));
+	icp_.setMaxCorrespondenceDistance(double(cfg_icp_max_corr_dist_));
+	icp_.setInputTarget(scene_);
+	icp_.setMaximumIterations(cfg_icp_max_iterations_);
 
-  // Run first alignment with initial estimate
-  icp_.setInputSource(model_);
-  icp_.align(*icp_result_, initial_tf_);
-  final_tf_ = icp_.getFinalTransformation();
+	// Run first alignment with initial estimate
+	icp_.setInputSource(model_);
+	icp_.align(*icp_result_, initial_tf_);
+	final_tf_ = icp_.getFinalTransformation();
 
-  iterations_ = 0;
-  last_raw_fitness_ = std::numeric_limits<double>::max();
+	iterations_       = 0;
+	last_raw_fitness_ = std::numeric_limits<double>::max();
 
-  restart_pending_ = false;
+	restart_pending_ = false;
 }
 
-void RecognitionThread::loop() {
-  if (!enabled_) {
-    logger->log_info(name(), "ICP stopped");
+void
+RecognitionThread::loop()
+{
+	if (!enabled_) {
+		logger->log_info(name(), "ICP stopped");
 
-    {
-      MutexLocker locked{&main_thread_->bb_mutex_};
-      main_thread_->bb_set_busy(false);
-    }
+		{
+			MutexLocker locked{&main_thread_->bb_mutex_};
+			main_thread_->bb_set_busy(false);
+		}
 
-    while (!enabled_)
-      syncpoint_clouds_ready_->wait(name());
-  }
+		while (!enabled_)
+			syncpoint_clouds_ready_->wait(name());
+	}
 
-  if (restart_pending_) {
-    restart_icp();
-    return;
-  }
+	if (restart_pending_) {
+		restart_icp();
+		return;
+	}
 
-  if (!enabled_ ||
-      restart_pending_) // cancel if disabled from ConveyorPoseThread
-    return;
+	if (!enabled_ || restart_pending_) // cancel if disabled from ConveyorPoseThread
+		return;
 
-  icp_.setInputSource(icp_result_);
-  icp_.align(*icp_result_);
+	icp_.setInputSource(icp_result_);
+	icp_.align(*icp_result_);
 
-  // accumulate transformation between each Iteration
-  final_tf_ = icp_.getFinalTransformation() * final_tf_;
+	// accumulate transformation between each Iteration
+	final_tf_ = icp_.getFinalTransformation() * final_tf_;
 
-  if (!enabled_ ||
-      restart_pending_) // cancel if disabled from ConveyorPoseThread
-    return;
+	if (!enabled_ || restart_pending_) // cancel if disabled from ConveyorPoseThread
+		return;
 
-  // if the difference between this transformation and the previous one
-  // is smaller than the threshold, refine the process by reducing
-  // the maximal correspondence distance
-  bool epsilon_reached = false;
-  if (double(std::abs(
-          (icp_.getLastIncrementalTransformation() - prev_last_tf_).sum())) <
-      icp_.getTransformationEpsilon()) {
-    icp_.setMaxCorrespondenceDistance(icp_.getMaxCorrespondenceDistance() *
-                                      cfg_icp_refinement_factor_);
-    epsilon_reached = true;
-  }
-  prev_last_tf_ = icp_.getLastIncrementalTransformation();
+	// if the difference between this transformation and the previous one
+	// is smaller than the threshold, refine the process by reducing
+	// the maximal correspondence distance
+	bool epsilon_reached = false;
+	if (double(std::abs((icp_.getLastIncrementalTransformation() - prev_last_tf_).sum()))
+	    < icp_.getTransformationEpsilon()) {
+		icp_.setMaxCorrespondenceDistance(icp_.getMaxCorrespondenceDistance()
+		                                  * cfg_icp_refinement_factor_);
+		epsilon_reached = true;
+	}
+	prev_last_tf_ = icp_.getLastIncrementalTransformation();
 
-  if (main_thread_->cfg_debug_mode_)
-    publish_result();
+	if (main_thread_->cfg_debug_mode_)
+		publish_result();
 
-  if (iterations_++ >= cfg_icp_min_loops_ || epsilon_reached) {
-    // Perform hypothesis verification, i.e. skip results that don't match
-    // closely enough according to certain thresholds. See the config file for
-    // an explanation of the individual parameters.
-    std::vector<Cloud::ConstPtr> icp_result_vector{icp_result_};
+	if (iterations_++ >= cfg_icp_min_loops_ || epsilon_reached) {
+		// Perform hypothesis verification, i.e. skip results that don't match
+		// closely enough according to certain thresholds. See the config file for
+		// an explanation of the individual parameters.
+		std::vector<Cloud::ConstPtr> icp_result_vector{icp_result_};
 
-    // This resets the result vectors (see hypot_mask below) so we only ever
-    // verify the last ICP result
-    hypot_verif_.setSceneCloud(scene_);
-    hypot_verif_.addModels(icp_result_vector, true);
+		// This resets the result vectors (see hypot_mask below) so we only ever
+		// verify the last ICP result
+		hypot_verif_.setSceneCloud(scene_);
+		hypot_verif_.addModels(icp_result_vector, true);
 
-    hypot_verif_.verify();
-    std::vector<bool> hypot_mask;
-    hypot_verif_.getMask(hypot_mask);
+		hypot_verif_.verify();
+		std::vector<bool> hypot_mask;
+		hypot_verif_.getMask(hypot_mask);
 
-    if (hypot_mask[0] && icp_.getFitnessScore() < last_raw_fitness_) {
-      // Hypothesis verification was successful and and the match improved
-      last_raw_fitness_ = icp_.getFitnessScore();
+		if (hypot_mask[0] && icp_.getFitnessScore() < last_raw_fitness_) {
+			// Hypothesis verification was successful and and the match improved
+			last_raw_fitness_ = icp_.getFitnessScore();
 
-      // In debug mode, publish_result has already been called (see above)
-      if (!main_thread_->cfg_debug_mode_)
-        publish_result();
-    }
+			// In debug mode, publish_result has already been called (see above)
+			if (!main_thread_->cfg_debug_mode_)
+				publish_result();
+		}
 
-    if (iterations_ >= cfg_icp_max_loops_) {
-      if (last_raw_fitness_ >= std::numeric_limits<double>::max() - 1) {
-        logger->log_warn(name(), "No acceptable fit after %u iterations",
-                         iterations_);
-        restart_icp();
-      } else {
-        if (cfg_icp_auto_restart_)
-          restart_icp();
-        else
-          enabled_ = false;
-      }
-    }
-  }
+		if (iterations_ >= cfg_icp_max_loops_) {
+			if (last_raw_fitness_ >= std::numeric_limits<double>::max() - 1) {
+				logger->log_warn(name(), "No acceptable fit after %u iterations", iterations_);
+				restart_icp();
+			} else {
+				if (cfg_icp_auto_restart_)
+					restart_icp();
+				else
+					enabled_ = false;
+			}
+		}
+	}
 }
 
-void RecognitionThread::publish_result() {
-  CloudPtr aligned_model(new Cloud());
-  pcl::copyPointCloud(*icp_result_, *aligned_model);
-  aligned_model->header = icp_result_->header;
-  main_thread_->cloud_publish(aligned_model, main_thread_->cloud_out_model_);
+void
+RecognitionThread::publish_result()
+{
+	CloudPtr aligned_model(new Cloud());
+	pcl::copyPointCloud(*icp_result_, *aligned_model);
+	aligned_model->header = icp_result_->header;
+	main_thread_->cloud_publish(aligned_model, main_thread_->cloud_out_model_);
 
-  tf::Stamped<tf::Pose> result_pose{eigen_to_pose(final_tf_),
-                                    Time{long(scene_->header.stamp) / 1000},
-                                    scene_->header.frame_id};
+	tf::Stamped<tf::Pose> result_pose{eigen_to_pose(final_tf_),
+	                                  Time{long(scene_->header.stamp) / 1000},
+	                                  scene_->header.frame_id};
 
-  double new_fitness = (1 / icp_.getFitnessScore()) / 10000;
+	double new_fitness = (1 / icp_.getFitnessScore()) / 10000;
 
-  {
-    MutexLocker locked2(&main_thread_->bb_mutex_);
+	{
+		MutexLocker locked2(&main_thread_->bb_mutex_);
 
-    if (enabled_) {
-      main_thread_->result_fitness_ = new_fitness;
-      main_thread_->result_pose_.reset(new tf::Stamped<tf::Pose>{result_pose});
-      main_thread_->result_pose_->setRotation(
-          main_thread_->result_pose_->getRotation() *
-          tf::Quaternion({1, 0, 0}, M_PI_2) *
-          tf::Quaternion({0, 0, 1}, M_PI_2));
+		if (enabled_) {
+			main_thread_->result_fitness_ = new_fitness;
+			main_thread_->result_pose_.reset(new tf::Stamped<tf::Pose>{result_pose});
+			main_thread_->result_pose_->setRotation(main_thread_->result_pose_->getRotation()
+			                                        * tf::Quaternion({1, 0, 0}, M_PI_2)
+			                                        * tf::Quaternion({0, 0, 1}, M_PI_2));
 
-      try {
-        tf_listener->transform_pose("odom",
-                                    tf::Stamped<tf::Pose>(result_pose,
-                                                          Time(0, 0),
-                                                          result_pose.frame_id),
-                                    initial_guess_icp_odom_);
+			try {
+				tf_listener->transform_pose("odom",
+				                            tf::Stamped<tf::Pose>(result_pose,
+				                                                  Time(0, 0),
+				                                                  result_pose.frame_id),
+				                            initial_guess_icp_odom_);
 
-      } catch (tf::TransformException &e) {
-        logger->log_error(name(), e);
-      }
-    }
-  } // MutexLocker
+			} catch (tf::TransformException &e) {
+				logger->log_error(name(), e);
+			}
+		}
+	} // MutexLocker
 }
 
-fawkes::tf::Quaternion constrainYtoNegZ(fawkes::tf::Quaternion rotation) {
-  fawkes::tf::Transform pose;
-  pose.setRotation(rotation);
-  fawkes::tf::Matrix3x3 basis = pose.getBasis();
-  fawkes::tf::Vector3 yaxis_tf = basis.getColumn(1);
-  fawkes::tf::Vector3 aligned_y(0, 0, -1);
-  fawkes::tf::Scalar angle = yaxis_tf.angle(aligned_y);
-  fawkes::tf::Vector3 rotational_axis = yaxis_tf.cross(aligned_y);
-  rotational_axis.normalize();
-  fawkes::tf::Quaternion resultRotation(rotational_axis, angle);
-  resultRotation *= rotation;
-  return resultRotation;
+fawkes::tf::Quaternion
+constrainYtoNegZ(fawkes::tf::Quaternion rotation)
+{
+	fawkes::tf::Transform pose;
+	pose.setRotation(rotation);
+	fawkes::tf::Matrix3x3 basis    = pose.getBasis();
+	fawkes::tf::Vector3   yaxis_tf = basis.getColumn(1);
+	fawkes::tf::Vector3   aligned_y(0, 0, -1);
+	fawkes::tf::Scalar    angle           = yaxis_tf.angle(aligned_y);
+	fawkes::tf::Vector3   rotational_axis = yaxis_tf.cross(aligned_y);
+	rotational_axis.normalize();
+	fawkes::tf::Quaternion resultRotation(rotational_axis, angle);
+	resultRotation *= rotation;
+	return resultRotation;
 }
 
-void RecognitionThread::constrainTransformToGround(
-    fawkes::tf::Stamped<fawkes::tf::Pose> &fittedPose_conv) {
-  fawkes::tf::Stamped<fawkes::tf::Pose> fittedPose_base;
-  tf_listener->transform_pose("base_link", fittedPose_conv, fittedPose_base);
-  fittedPose_base.setRotation(constrainYtoNegZ(fittedPose_base.getRotation()));
-  tf_listener->transform_pose(fittedPose_conv.frame_id, fittedPose_base,
-                              fittedPose_conv);
+void
+RecognitionThread::constrainTransformToGround(
+  fawkes::tf::Stamped<fawkes::tf::Pose> &fittedPose_conv)
+{
+	fawkes::tf::Stamped<fawkes::tf::Pose> fittedPose_base;
+	tf_listener->transform_pose("base_link", fittedPose_conv, fittedPose_base);
+	fittedPose_base.setRotation(constrainYtoNegZ(fittedPose_base.getRotation()));
+	tf_listener->transform_pose(fittedPose_conv.frame_id, fittedPose_base, fittedPose_conv);
 }
 
-void RecognitionThread::enable() { enabled_ = true; }
-
-void RecognitionThread::disable() {
-  enabled_ = false;
-  initial_guess_icp_odom_ = fawkes::tf::Stamped<fawkes::tf::Pose>();
+void
+RecognitionThread::enable()
+{
+	enabled_ = true;
 }
 
-void RecognitionThread::restart() {
-  restart_pending_ = true;
-  enable();
+void
+RecognitionThread::disable()
+{
+	enabled_                = false;
+	initial_guess_icp_odom_ = fawkes::tf::Stamped<fawkes::tf::Pose>();
 }
 
-bool RecognitionThread::enabled() { return enabled_; }
+void
+RecognitionThread::restart()
+{
+	restart_pending_ = true;
+	enable();
+}
+
+bool
+RecognitionThread::enabled()
+{
+	return enabled_;
+}

--- a/src/plugins/conveyor_pose/recognition_thread.h
+++ b/src/plugins/conveyor_pose/recognition_thread.h
@@ -23,105 +23,104 @@
 #ifndef CORRESPONDENCE_GROUPING_THREAD_H
 #define CORRESPONDENCE_GROUPING_THREAD_H
 
+#include "conveyor_pose_thread.h"
+
 #include <aspect/logging.h>
 #include <aspect/syncpoint_manager.h>
 #include <aspect/tf.h>
 #include <core/threading/thread.h>
 #include <core/threading/wait_condition.h>
-
-#include <atomic>
-
 #include <pcl/recognition/hv/hv_papazov.h>
 #include <pcl/registration/icp_nl.h>
 
-#include "conveyor_pose_thread.h"
+#include <atomic>
 
 /** Derive from the ICP algorithm in case we want to override something */
-class CustomICP
-    : public pcl::IterativeClosestPointNonLinear<pcl::PointXYZ, pcl::PointXYZ> {
+class CustomICP : public pcl::IterativeClosestPointNonLinear<pcl::PointXYZ, pcl::PointXYZ>
+{
 public:
-  using pcl::IterativeClosestPointNonLinear<
-      pcl::PointXYZ, pcl::PointXYZ>::IterativeClosestPointNonLinear;
+	using pcl::IterativeClosestPointNonLinear<pcl::PointXYZ,
+	                                          pcl::PointXYZ>::IterativeClosestPointNonLinear;
 
-  /** @return A custom fitness measure of the computed fit */
-  double getScaledFitness();
+	/** @return A custom fitness measure of the computed fit */
+	double getScaledFitness();
 };
 
 /** Run ICP, perform HypothesisVerification and publish the result */
 class RecognitionThread : public fawkes::Thread,
                           public fawkes::LoggingAspect,
                           public fawkes::TransformAspect,
-                          public fawkes::SyncPointManagerAspect {
+                          public fawkes::SyncPointManagerAspect
+{
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  /** RecognitionThread constructor
+	/** RecognitionThread constructor
    * @param cp_thread pointer back to the main thread
    */
-  RecognitionThread(ConveyorPoseThread *cp_thread);
+	RecognitionThread(ConveyorPoseThread *cp_thread);
 
-  virtual void loop() override;
-  virtual void init() override;
+	virtual void loop() override;
+	virtual void init() override;
 
-  /** Continue running this thread */
-  void enable();
+	/** Continue running this thread */
+	void enable();
 
-  /** Stop running this thread */
-  void disable();
+	/** Stop running this thread */
+	void disable();
 
-  /** Re-initialize this thread, e.g. after a config change */
-  void restart();
+	/** Re-initialize this thread, e.g. after a config change */
+	void restart();
 
-  /** @return whether this thread is currently enabled (running) */
-  bool enabled();
+	/** @return whether this thread is currently enabled (running) */
+	bool enabled();
 
 private:
-  friend ConveyorPoseThread;
+	friend ConveyorPoseThread;
 
-  void restart_icp();
-  void publish_result();
-  void constrainTransformToGround(
-      fawkes::tf::Stamped<fawkes::tf::Pose> &fittedPose_conv);
+	void restart_icp();
+	void publish_result();
+	void constrainTransformToGround(fawkes::tf::Stamped<fawkes::tf::Pose> &fittedPose_conv);
 
-  using Point = ConveyorPoseThread::Point;
-  using Cloud = ConveyorPoseThread::Cloud;
-  using CloudPtr = ConveyorPoseThread::CloudPtr;
+	using Point    = ConveyorPoseThread::Point;
+	using Cloud    = ConveyorPoseThread::Cloud;
+	using CloudPtr = ConveyorPoseThread::CloudPtr;
 
-  ConveyorPoseThread *main_thread_;
+	ConveyorPoseThread *main_thread_;
 
-  fawkes::RefPtr<fawkes::SyncPoint> syncpoint_clouds_ready_;
+	fawkes::RefPtr<fawkes::SyncPoint> syncpoint_clouds_ready_;
 
-  std::atomic_bool enabled_;
-  std::atomic_bool restart_pending_;
+	std::atomic_bool enabled_;
+	std::atomic_bool restart_pending_;
 
-  fawkes::tf::Stamped<fawkes::tf::Pose> initial_guess_icp_odom_;
-  Eigen::Matrix4f initial_tf_;
-  CloudPtr model_;
-  CloudPtr scene_;
+	fawkes::tf::Stamped<fawkes::tf::Pose> initial_guess_icp_odom_;
+	Eigen::Matrix4f                       initial_tf_;
+	CloudPtr                              model_;
+	CloudPtr                              scene_;
 
-  CustomICP icp_;
-  pcl::PapazovHV<Point, Point> hypot_verif_;
-  Eigen::Matrix4f prev_last_tf_;
-  CloudPtr icp_result_;
-  Eigen::Matrix4f final_tf_;
+	CustomICP                    icp_;
+	pcl::PapazovHV<Point, Point> hypot_verif_;
+	Eigen::Matrix4f              prev_last_tf_;
+	CloudPtr                     icp_result_;
+	Eigen::Matrix4f              final_tf_;
 
-  unsigned int iterations_;
-  double last_raw_fitness_;
+	unsigned int iterations_;
+	double       last_raw_fitness_;
 
-  std::atomic<float> cfg_icp_max_corr_dist_;
-  std::atomic<double> cfg_icp_tf_epsilon_;
-  std::atomic<double> cfg_icp_refinement_factor_;
-  std::array<std::atomic<float>, 3> cfg_icp_conveyor_hint_;
-  std::atomic<int> cfg_icp_max_iterations_;
-  std::atomic<float> cfg_icp_hv_penalty_thresh_;
-  std::atomic<float> cfg_icp_hv_support_thresh_;
-  std::atomic<float> cfg_icp_hv_inlier_thresh_;
-  std::atomic<float> cfg_icp_shelf_hv_penalty_thresh_;
-  std::atomic<float> cfg_icp_shelf_hv_support_thresh_;
-  std::atomic<float> cfg_icp_shelf_hv_inlier_thresh_;
-  std::atomic<unsigned int> cfg_icp_min_loops_;
-  std::atomic<unsigned int> cfg_icp_max_loops_;
-  std::atomic_bool cfg_icp_auto_restart_;
+	std::atomic<float>                cfg_icp_max_corr_dist_;
+	std::atomic<double>               cfg_icp_tf_epsilon_;
+	std::atomic<double>               cfg_icp_refinement_factor_;
+	std::array<std::atomic<float>, 3> cfg_icp_conveyor_hint_;
+	std::atomic<int>                  cfg_icp_max_iterations_;
+	std::atomic<float>                cfg_icp_hv_penalty_thresh_;
+	std::atomic<float>                cfg_icp_hv_support_thresh_;
+	std::atomic<float>                cfg_icp_hv_inlier_thresh_;
+	std::atomic<float>                cfg_icp_shelf_hv_penalty_thresh_;
+	std::atomic<float>                cfg_icp_shelf_hv_support_thresh_;
+	std::atomic<float>                cfg_icp_shelf_hv_inlier_thresh_;
+	std::atomic<unsigned int>         cfg_icp_min_loops_;
+	std::atomic<unsigned int>         cfg_icp_max_loops_;
+	std::atomic_bool                  cfg_icp_auto_restart_;
 };
 
 #endif // CORRESPONDENCE_GROUPING_THREAD_H

--- a/src/plugins/gazebo/gazsim-conveyor/gazsim_conveyor_plugin.cpp
+++ b/src/plugins/gazebo/gazsim-conveyor/gazsim_conveyor_plugin.cpp
@@ -29,14 +29,16 @@ using namespace fawkes;
 /** Plugin to simulate conveyor
  * @author Frederik Zwilling
  */
-class GazsimConveyorPlugin : public fawkes::Plugin {
+class GazsimConveyorPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimConveyorPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new GazsimConveyorThread());
-  }
+	GazsimConveyorPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new GazsimConveyorThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Simulation of a Conveyor")

--- a/src/plugins/gazebo/gazsim-conveyor/gazsim_conveyor_thread.cpp
+++ b/src/plugins/gazebo/gazsim-conveyor/gazsim_conveyor_thread.cpp
@@ -22,7 +22,6 @@
 
 #include "gazsim_conveyor_thread.h"
 
-#include <boost/lexical_cast.hpp>
 #include <config/change_handler.h>
 #include <core/threading/mutex_locker.h>
 #include <core/threading/read_write_lock.h>
@@ -31,6 +30,7 @@
 #include <tf/types.h>
 #include <utils/math/angle.h>
 
+#include <boost/lexical_cast.hpp>
 #include <cmath>
 #include <cstdarg>
 #include <unistd.h>
@@ -47,92 +47,96 @@ using namespace gazebo;
 /** Constructor. */
 
 GazsimConveyorThread::GazsimConveyorThread()
-    : Thread("GazsimConveyorThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT_EXEC),
-      fawkes::TransformAspect(fawkes::TransformAspect::BOTH, "conveyor_pose"),
-      new_data_(false) {
-  set_name("GazsimConveyorThread()");
-  loopcount_ = 0;
+: Thread("GazsimConveyorThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT_EXEC),
+  fawkes::TransformAspect(fawkes::TransformAspect::BOTH, "conveyor_pose"),
+  new_data_(false)
+{
+	set_name("GazsimConveyorThread()");
+	loopcount_ = 0;
 }
 
-void GazsimConveyorThread::init() {
-  logger->log_debug(name(),
-                    "Initializing Simulation of the Conveyor Vision Plugin");
-  const std::string if_prefix =
-      config->get_string("plugins/conveyor_pose/if/prefix") + "/";
-  frame_name_ = config->get_string("/realsense/frame_id");
-  conveyor_frame_id_ =
-      config->get_string("plugins/conveyor_pose/conveyor_frame_id");
+void
+GazsimConveyorThread::init()
+{
+	logger->log_debug(name(), "Initializing Simulation of the Conveyor Vision Plugin");
+	const std::string if_prefix = config->get_string("plugins/conveyor_pose/if/prefix") + "/";
+	frame_name_                 = config->get_string("/realsense/frame_id");
+	conveyor_frame_id_          = config->get_string("plugins/conveyor_pose/conveyor_frame_id");
 
-  cfg_if_prefix_ = config->get_string(CFG_PREFIX "/if/prefix");
-  if (cfg_if_prefix_.back() != '/')
-    cfg_if_prefix_.append("/");
+	cfg_if_prefix_ = config->get_string(CFG_PREFIX "/if/prefix");
+	if (cfg_if_prefix_.back() != '/')
+		cfg_if_prefix_.append("/");
 
-  // setup ConveyorPoseInterface if with default values
-  pos_if_ = blackboard->open_for_writing<ConveyorPoseInterface>(
-      (cfg_if_prefix_ + "status").c_str());
-  switch_if_ = blackboard->open_for_writing<SwitchInterface>(
-      config->get_string("/gazsim/conveyor/switch-if-name").c_str());
+	// setup ConveyorPoseInterface if with default values
+	pos_if_ =
+	  blackboard->open_for_writing<ConveyorPoseInterface>((cfg_if_prefix_ + "status").c_str());
+	switch_if_ = blackboard->open_for_writing<SwitchInterface>(
+	  config->get_string("/gazsim/conveyor/switch-if-name").c_str());
 
-  conveyor_vision_sub_ = gazebonode->Subscribe(
-      "~/RobotinoSim/ConveyorVisionResult/",
-      &GazsimConveyorThread::on_conveyor_vision_msg, this);
+	conveyor_vision_sub_ = gazebonode->Subscribe("~/RobotinoSim/ConveyorVisionResult/",
+	                                             &GazsimConveyorThread::on_conveyor_vision_msg,
+	                                             this);
 }
 
-void GazsimConveyorThread::finalize() {
-  blackboard->close(pos_if_);
-  blackboard->close(switch_if_);
+void
+GazsimConveyorThread::finalize()
+{
+	blackboard->close(pos_if_);
+	blackboard->close(switch_if_);
 }
 
-void GazsimConveyorThread::loop() {
+void
+GazsimConveyorThread::loop()
+{
+	pos_if_->set_frame(frame_name_.c_str());
+	if (new_data_ && pos_if_->msgq_first_is<ConveyorPoseInterface::RunICPMessage>()) {
+		new_data_ = false;
 
-  pos_if_->set_frame(frame_name_.c_str());
-  if (new_data_ &&
-      pos_if_->msgq_first_is<ConveyorPoseInterface::RunICPMessage>()) {
-    new_data_ = false;
+		ConveyorPoseInterface::RunICPMessage *msg =
+		  pos_if_->msgq_first<ConveyorPoseInterface::RunICPMessage>();
+		// write to interface
+		// swap the axis' because the cam_conveyor frame has the z-axis facing
+		// foward
+		double trans[] = {-last_msg_.positions().y(),
+		                  -last_msg_.positions().z(),
+		                  last_msg_.positions().x()};
+		if (strcmp(pos_if_->tostring_MPS_TARGET(msg->mps_target_to_set()), "SLIDE") == 0) {
+			trans[0] += shelf_offset_x;
+		}
+		double rot[] = {last_msg_.positions().ori_x(),
+		                last_msg_.positions().ori_y(),
+		                last_msg_.positions().ori_z(),
+		                last_msg_.positions().ori_w()};
 
-    ConveyorPoseInterface::RunICPMessage *msg =
-        pos_if_->msgq_first<ConveyorPoseInterface::RunICPMessage>();
-    // write to interface
-    // swap the axis' because the cam_conveyor frame has the z-axis facing
-    // foward
-    double trans[] = {-last_msg_.positions().y(), -last_msg_.positions().z(),
-                      last_msg_.positions().x()};
-    if (strcmp(pos_if_->tostring_MPS_TARGET(msg->mps_target_to_set()),
-               "SLIDE") == 0) {
-      trans[0] += shelf_offset_x;
-    }
-    double rot[] = {
-        last_msg_.positions().ori_x(), last_msg_.positions().ori_y(),
-        last_msg_.positions().ori_z(), last_msg_.positions().ori_w()};
+		pos_if_->set_translation(trans);
+		pos_if_->set_rotation(rot);
+		pos_if_->set_euclidean_fitness(rand() % 100);
+		pos_if_->set_msgid(msg->id());
+		pos_if_->write();
 
-    pos_if_->set_translation(trans);
-    pos_if_->set_rotation(rot);
-    pos_if_->set_euclidean_fitness(rand() % 100);
-    pos_if_->set_msgid(msg->id());
-    pos_if_->write();
+		// publishe tf
+		fawkes::tf::StampedTransform transform;
 
-    // publishe tf
-    fawkes::tf::StampedTransform transform;
+		transform.frame_id       = frame_name_;
+		transform.child_frame_id = conveyor_frame_id_;
+		transform.stamp          = fawkes::Time();
 
-    transform.frame_id = frame_name_;
-    transform.child_frame_id = conveyor_frame_id_;
-    transform.stamp = fawkes::Time();
+		transform.setOrigin(fawkes::tf::Vector3(trans[0], trans[1], trans[2]));
+		fawkes::tf::Quaternion q /*(rot[0], rot[1], rot[2], rot[3])*/;
+		q.setEuler(M_PI_2, M_PI_2, M_PI);
+		transform.setRotation(q);
 
-    transform.setOrigin(fawkes::tf::Vector3(trans[0], trans[1], trans[2]));
-    fawkes::tf::Quaternion q /*(rot[0], rot[1], rot[2], rot[3])*/;
-    q.setEuler(M_PI_2, M_PI_2, M_PI);
-    transform.setRotation(q);
+		tf_publisher->send_transform(transform);
+		pos_if_->msgq_pop();
+	}
 
-    tf_publisher->send_transform(transform);
-    pos_if_->msgq_pop();
-  }
-
-  loopcount_++;
+	loopcount_++;
 }
 
-void GazsimConveyorThread::on_conveyor_vision_msg(
-    ConstConveyorVisionResultPtr &msg) {
-  last_msg_.CopyFrom(*msg);
-  new_data_ = true;
+void
+GazsimConveyorThread::on_conveyor_vision_msg(ConstConveyorVisionResultPtr &msg)
+{
+	last_msg_.CopyFrom(*msg);
+	new_data_ = true;
 }

--- a/src/plugins/gazebo/gazsim-conveyor/gazsim_conveyor_thread.h
+++ b/src/plugins/gazebo/gazsim-conveyor/gazsim_conveyor_thread.h
@@ -34,10 +34,9 @@
 //#include <interfaces/Position3DInterface.h>
 #include <interfaces/ConveyorPoseInterface.h>
 #include <interfaces/SwitchInterface.h>
+#include <llsf_msgs/ConveyorVisionResult.pb.h>
 #include <plugins/gazebo/aspect/gazebo.h>
 #include <utils/time/time.h>
-
-#include <llsf_msgs/ConveyorVisionResult.pb.h>
 
 // from Gazebo
 #include <gazebo/msgs/MessageTypes.hh>
@@ -47,8 +46,7 @@
 #define MAX_LOOP_COUNT_TO_INVISIBLE 5
 #define CFG_PREFIX "/plugins/conveyor_pose"
 
-typedef const boost::shared_ptr<llsf_msgs::ConveyorVisionResult const>
-    ConstConveyorVisionResultPtr;
+typedef const boost::shared_ptr<llsf_msgs::ConveyorVisionResult const> ConstConveyorVisionResultPtr;
 
 class GazsimConveyorThread : public fawkes::Thread,
                              public fawkes::BlockedTimingAspect,
@@ -56,37 +54,42 @@ class GazsimConveyorThread : public fawkes::Thread,
                              public fawkes::ConfigurableAspect,
                              public fawkes::BlackBoardAspect,
                              public fawkes::GazeboAspect,
-                             public fawkes::TransformAspect {
+                             public fawkes::TransformAspect
+{
 public:
-  GazsimConveyorThread();
+	GazsimConveyorThread();
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  fawkes::ConveyorPoseInterface *pos_if_;
-  fawkes::SwitchInterface *switch_if_;
-  // fawkes::ConveyorConfigInterface *conv_config_if_;
+	fawkes::ConveyorPoseInterface *pos_if_;
+	fawkes::SwitchInterface *      switch_if_;
+	// fawkes::ConveyorConfigInterface *conv_config_if_;
 
-  std::string conveyor_if_name_;
-  std::string frame_name_;
-  std::string cfg_if_prefix_;
-  std::string conveyor_frame_id_;
+	std::string conveyor_if_name_;
+	std::string frame_name_;
+	std::string cfg_if_prefix_;
+	std::string conveyor_frame_id_;
 
-  gazebo::transport::SubscriberPtr conveyor_vision_sub_;
-  void on_conveyor_vision_msg(ConstConveyorVisionResultPtr &msg);
+	gazebo::transport::SubscriberPtr conveyor_vision_sub_;
+	void                             on_conveyor_vision_msg(ConstConveyorVisionResultPtr &msg);
 
-  int32_t loopcount_;
+	int32_t loopcount_;
 
-  // copy of last msg to write the interface in the next loop
-  llsf_msgs::ConveyorVisionResult last_msg_;
-  bool new_data_;
-  const double shelf_offset_x = 0.295;
+	// copy of last msg to write the interface in the next loop
+	llsf_msgs::ConveyorVisionResult last_msg_;
+	bool                            new_data_;
+	const double                    shelf_offset_x = 0.295;
 };
 
 #endif

--- a/src/plugins/gazebo/gazsim-gripper/gazsim_gripper_plugin.cpp
+++ b/src/plugins/gazebo/gazsim-gripper/gazsim_gripper_plugin.cpp
@@ -29,14 +29,16 @@ using namespace fawkes;
 /** Plugin to simulate gripper
  * @author Frederik Zwilling
  */
-class GazsimGripperPlugin : public fawkes::Plugin {
+class GazsimGripperPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimGripperPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new GazsimGripperThread());
-  }
+	GazsimGripperPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new GazsimGripperThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Simulation of a Gripper")

--- a/src/plugins/gazebo/gazsim-gripper/gazsim_gripper_thread.cpp
+++ b/src/plugins/gazebo/gazsim-gripper/gazsim_gripper_thread.cpp
@@ -22,7 +22,6 @@
 
 #include "gazsim_gripper_thread.h"
 
-#include <boost/lexical_cast.hpp>
 #include <config/change_handler.h>
 #include <core/threading/mutex_locker.h>
 #include <core/threading/read_write_lock.h>
@@ -33,6 +32,7 @@
 #include <interfaces/LedInterface.h>
 #include <utils/math/angle.h>
 
+#include <boost/lexical_cast.hpp>
 #include <cmath>
 #include <cstdarg>
 #include <unistd.h>
@@ -49,186 +49,189 @@ using namespace gazebo;
 /** Constructor. */
 
 GazsimGripperThread::GazsimGripperThread()
-    : Thread("GazsimGripperThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT_EXEC) {
-  set_name("GazsimGripperThread()");
+: Thread("GazsimGripperThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT_EXEC)
+{
+	set_name("GazsimGripperThread()");
 }
 
-void GazsimGripperThread::init() {
-  logger->log_debug(name(),
-                    "Initializing Simulation of the Light Front Plugin");
+void
+GazsimGripperThread::init()
+{
+	logger->log_debug(name(), "Initializing Simulation of the Light Front Plugin");
 
-  gripper_if_name_ = config->get_string("/gazsim/gripper/if-name");
-  arduino_if_name_ = config->get_string("/gazsim/gripper/arduino-if-name");
-  cfg_prefix_ = config->get_string("/gazsim/gripper/cfg-prefix");
+	gripper_if_name_ = config->get_string("/gazsim/gripper/if-name");
+	arduino_if_name_ = config->get_string("/gazsim/gripper/arduino-if-name");
+	cfg_prefix_      = config->get_string("/gazsim/gripper/cfg-prefix");
 
-  set_gripper_pub_ = gazebonode->Advertise<msgs::Int>(
-      config->get_string("/gazsim/topics/gripper"));
-  set_conveyor_pub_ = gazebonode->Advertise<msgs::Int>(
-      config->get_string("/gazsim/topics/conveyor"));
-  gripper_has_puck_sub_ = gazebonode->Subscribe(
-      config->get_string("/gazsim/topics/gripper-has-puck"),
-      &GazsimGripperThread::on_has_puck_msg, this);
+	set_gripper_pub_ = gazebonode->Advertise<msgs::Int>(config->get_string("/gazsim/topics/gripper"));
+	set_conveyor_pub_ =
+	  gazebonode->Advertise<msgs::Int>(config->get_string("/gazsim/topics/conveyor"));
+	gripper_has_puck_sub_ =
+	  gazebonode->Subscribe(config->get_string("/gazsim/topics/gripper-has-puck"),
+	                        &GazsimGripperThread::on_has_puck_msg,
+	                        this);
 
-  // setup gripper if with default values
-  gripper_if_ = blackboard->open_for_writing<AX12GripperInterface>(
-      gripper_if_name_.c_str());
-  gripper_if_->set_calibrated(true);
-  gripper_if_->set_min_left(config->get_float(cfg_prefix_ + "left_min"));
-  gripper_if_->set_max_left(config->get_float(cfg_prefix_ + "left_max"));
-  gripper_if_->set_min_right(config->get_float(cfg_prefix_ + "right_min"));
-  gripper_if_->set_max_right(config->get_float(cfg_prefix_ + "right_max"));
-  gripper_if_->set_left_margin(config->get_float(cfg_prefix_ + "left_margin"));
-  gripper_if_->set_right_margin(
-      config->get_float(cfg_prefix_ + "right_margin"));
-  gripper_if_->set_max_left_velocity(0);
-  gripper_if_->set_max_right_velocity(0);
-  gripper_if_->set_left_velocity(0);
-  gripper_if_->set_right_velocity(0);
-  gripper_if_->set_final(true);
-  gripper_if_->write();
+	// setup gripper if with default values
+	gripper_if_ = blackboard->open_for_writing<AX12GripperInterface>(gripper_if_name_.c_str());
+	gripper_if_->set_calibrated(true);
+	gripper_if_->set_min_left(config->get_float(cfg_prefix_ + "left_min"));
+	gripper_if_->set_max_left(config->get_float(cfg_prefix_ + "left_max"));
+	gripper_if_->set_min_right(config->get_float(cfg_prefix_ + "right_min"));
+	gripper_if_->set_max_right(config->get_float(cfg_prefix_ + "right_max"));
+	gripper_if_->set_left_margin(config->get_float(cfg_prefix_ + "left_margin"));
+	gripper_if_->set_right_margin(config->get_float(cfg_prefix_ + "right_margin"));
+	gripper_if_->set_max_left_velocity(0);
+	gripper_if_->set_max_right_velocity(0);
+	gripper_if_->set_left_velocity(0);
+	gripper_if_->set_right_velocity(0);
+	gripper_if_->set_final(true);
+	gripper_if_->write();
 
-  cfg_prefix_ = "/arduino/";
-  arduino_if_ =
-      blackboard->open_for_writing<ArduinoInterface>(arduino_if_name_.c_str());
-  arduino_if_->set_x_position(0);
-  arduino_if_->set_y_position(arduino_if_->y_max() / 2.);
-  arduino_if_->set_y_position(0);
+	cfg_prefix_ = "/arduino/";
+	arduino_if_ = blackboard->open_for_writing<ArduinoInterface>(arduino_if_name_.c_str());
+	arduino_if_->set_x_position(0);
+	arduino_if_->set_y_position(arduino_if_->y_max() / 2.);
+	arduino_if_->set_y_position(0);
 
-  arduino_if_->set_final(true);
-  arduino_if_->write();
+	arduino_if_->set_final(true);
+	arduino_if_->write();
 }
 
-void GazsimGripperThread::finalize() { blackboard->close(gripper_if_); }
-
-void GazsimGripperThread::loop() {
-  // gripper_if_->set_final(__servo_if_left->is_final() &&
-  // __servo_if_right->is_final());
-
-  // process interface messages
-  while (!gripper_if_->msgq_empty()) {
-    if (gripper_if_->msgq_first_is<AX12GripperInterface::CalibrateMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::GotoMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::TimedGotoMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::ParkMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::SetEnabledMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_->msgq_first_is<
-                   AX12GripperInterface::SetVelocityMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::OpenMessage>()) {
-      send_gripper_msg(1);
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::CloseMessage>()) {
-      send_gripper_msg(0);
-      gripper_if_->set_holds_puck(false);
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::SetTorqueMessage>()) {
-      AX12GripperInterface::SetTorqueMessage *msg =
-          gripper_if_->msgq_first(msg);
-      if (msg->torque() < 0.2) {
-        send_gripper_msg(0);
-        gripper_if_->set_holds_puck(false);
-      }
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::CloseLoadMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::Open_AngleMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::SetMarginMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::CenterMessage>()) {
-      // nothing to do here, the puck is always centered in the simulation
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::StopLeftMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::StopRightMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::StopMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::FlushMessage>()) {
-      logger->log_warn(name(), "%s is not implemented in the simulation.",
-                       gripper_if_->msgq_first()->type());
-    } else if (gripper_if_
-                   ->msgq_first_is<AX12GripperInterface::RelGotoZMessage>()) {
-      // nothing to do
-    } else {
-      logger->log_warn(name(), "Unknown AX12 message received");
-    }
-
-    gripper_if_->msgq_pop();
-    gripper_if_->write();
-  }
-
-  while (!arduino_if_->msgq_empty()) {
-    if (arduino_if_->msgq_first_is<ArduinoInterface::MoveXYZAbsMessage>()) {
-      ArduinoInterface::MoveXYZAbsMessage *msg = arduino_if_->msgq_first(msg);
-      arduino_if_->set_x_position(msg->x());
-      arduino_if_->set_y_position(msg->y());
-      arduino_if_->set_z_position(msg->z());
-    } else if (arduino_if_
-                   ->msgq_first_is<ArduinoInterface::MoveXYZRelMessage>()) {
-      ArduinoInterface::MoveXYZRelMessage *msg = arduino_if_->msgq_first(msg);
-      arduino_if_->set_x_position(arduino_if_->x_position() + msg->x());
-      arduino_if_->set_y_position(arduino_if_->y_position() + msg->y());
-      arduino_if_->set_z_position(arduino_if_->z_position() + msg->z());
-
-      msgs::Int s;
-      s.set_data(arduino_if_->z_position() + msg->z());
-      set_conveyor_pub_->Publish(s);
-      //    } else if (
-      //    arduino_if_->msgq_first_is<ArduinoInterface::MoveUpwardsMessage>() )
-      //    {
-      //      ArduinoInterface::MoveUpwardsMessage *msg =
-      //      arduino_if_->msgq_first(msg); arduino_if_->set_z_position(
-      //      arduino_if_->z_position() - msg->num_mm() ); msgs::Int s;
-      //      s.set_data( - msg->num_mm() );
-      //      set_conveyor_pub_->Publish( s );
-    } else {
-      logger->log_warn(name(), "Unknown Arduino message received");
-    }
-    arduino_if_->msgq_pop();
-    arduino_if_->write();
-  }
+void
+GazsimGripperThread::finalize()
+{
+	blackboard->close(gripper_if_);
 }
 
-void GazsimGripperThread::send_gripper_msg(int value) {
-  // send message to gazebo
-  // 0 means close and 1 open
-  msgs::Int msg;
-  msg.set_data(value);
-  set_gripper_pub_->Publish(msg);
+void
+GazsimGripperThread::loop()
+{
+	// gripper_if_->set_final(__servo_if_left->is_final() &&
+	// __servo_if_right->is_final());
+
+	// process interface messages
+	while (!gripper_if_->msgq_empty()) {
+		if (gripper_if_->msgq_first_is<AX12GripperInterface::CalibrateMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::GotoMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::TimedGotoMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::ParkMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::SetEnabledMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::SetVelocityMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::OpenMessage>()) {
+			send_gripper_msg(1);
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::CloseMessage>()) {
+			send_gripper_msg(0);
+			gripper_if_->set_holds_puck(false);
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::SetTorqueMessage>()) {
+			AX12GripperInterface::SetTorqueMessage *msg = gripper_if_->msgq_first(msg);
+			if (msg->torque() < 0.2) {
+				send_gripper_msg(0);
+				gripper_if_->set_holds_puck(false);
+			}
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::CloseLoadMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::Open_AngleMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::SetMarginMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::CenterMessage>()) {
+			// nothing to do here, the puck is always centered in the simulation
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::StopLeftMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::StopRightMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::StopMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::FlushMessage>()) {
+			logger->log_warn(name(),
+			                 "%s is not implemented in the simulation.",
+			                 gripper_if_->msgq_first()->type());
+		} else if (gripper_if_->msgq_first_is<AX12GripperInterface::RelGotoZMessage>()) {
+			// nothing to do
+		} else {
+			logger->log_warn(name(), "Unknown AX12 message received");
+		}
+
+		gripper_if_->msgq_pop();
+		gripper_if_->write();
+	}
+
+	while (!arduino_if_->msgq_empty()) {
+		if (arduino_if_->msgq_first_is<ArduinoInterface::MoveXYZAbsMessage>()) {
+			ArduinoInterface::MoveXYZAbsMessage *msg = arduino_if_->msgq_first(msg);
+			arduino_if_->set_x_position(msg->x());
+			arduino_if_->set_y_position(msg->y());
+			arduino_if_->set_z_position(msg->z());
+		} else if (arduino_if_->msgq_first_is<ArduinoInterface::MoveXYZRelMessage>()) {
+			ArduinoInterface::MoveXYZRelMessage *msg = arduino_if_->msgq_first(msg);
+			arduino_if_->set_x_position(arduino_if_->x_position() + msg->x());
+			arduino_if_->set_y_position(arduino_if_->y_position() + msg->y());
+			arduino_if_->set_z_position(arduino_if_->z_position() + msg->z());
+
+			msgs::Int s;
+			s.set_data(arduino_if_->z_position() + msg->z());
+			set_conveyor_pub_->Publish(s);
+			//    } else if (
+			//    arduino_if_->msgq_first_is<ArduinoInterface::MoveUpwardsMessage>() )
+			//    {
+			//      ArduinoInterface::MoveUpwardsMessage *msg =
+			//      arduino_if_->msgq_first(msg); arduino_if_->set_z_position(
+			//      arduino_if_->z_position() - msg->num_mm() ); msgs::Int s;
+			//      s.set_data( - msg->num_mm() );
+			//      set_conveyor_pub_->Publish( s );
+		} else {
+			logger->log_warn(name(), "Unknown Arduino message received");
+		}
+		arduino_if_->msgq_pop();
+		arduino_if_->write();
+	}
 }
 
-void GazsimGripperThread::on_has_puck_msg(ConstIntPtr &msg) {
-  // 1 means the gripper has a puck 0 not
-  gripper_if_->set_holds_puck(msg->data() > 0);
-  gripper_if_->write();
+void
+GazsimGripperThread::send_gripper_msg(int value)
+{
+	// send message to gazebo
+	// 0 means close and 1 open
+	msgs::Int msg;
+	msg.set_data(value);
+	set_gripper_pub_->Publish(msg);
+}
+
+void
+GazsimGripperThread::on_has_puck_msg(ConstIntPtr &msg)
+{
+	// 1 means the gripper has a puck 0 not
+	gripper_if_->set_holds_puck(msg->data() > 0);
+	gripper_if_->write();
 }

--- a/src/plugins/gazebo/gazsim-gripper/gazsim_gripper_thread.h
+++ b/src/plugins/gazebo/gazsim-gripper/gazsim_gripper_thread.h
@@ -51,33 +51,38 @@ class GazsimGripperThread : public fawkes::Thread,
                             public fawkes::LoggingAspect,
                             public fawkes::ConfigurableAspect,
                             public fawkes::BlackBoardAspect,
-                            public fawkes::GazeboAspect {
+                            public fawkes::GazeboAspect
+{
 public:
-  GazsimGripperThread();
+	GazsimGripperThread();
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  fawkes::AX12GripperInterface *gripper_if_;
-  fawkes::ArduinoInterface *arduino_if_;
+	fawkes::AX12GripperInterface *gripper_if_;
+	fawkes::ArduinoInterface *    arduino_if_;
 
-  std::string gripper_if_name_;
-  std::string arduino_if_name_;
-  std::string cfg_prefix_;
+	std::string gripper_if_name_;
+	std::string arduino_if_name_;
+	std::string cfg_prefix_;
 
-  // Publisher to sent msgs to gazebo
-  gazebo::transport::PublisherPtr set_gripper_pub_;
-  gazebo::transport::PublisherPtr set_conveyor_pub_;
-  gazebo::transport::SubscriberPtr gripper_has_puck_sub_;
+	// Publisher to sent msgs to gazebo
+	gazebo::transport::PublisherPtr  set_gripper_pub_;
+	gazebo::transport::PublisherPtr  set_conveyor_pub_;
+	gazebo::transport::SubscriberPtr gripper_has_puck_sub_;
 
-  void send_gripper_msg(int value);
-  void on_has_puck_msg(ConstIntPtr &msg);
+	void send_gripper_msg(int value);
+	void on_has_puck_msg(ConstIntPtr &msg);
 };
 
 #endif

--- a/src/plugins/gazebo/gazsim-llsf-control/gazsim_llsf_control_plugin.cpp
+++ b/src/plugins/gazebo/gazsim-llsf-control/gazsim_llsf_control_plugin.cpp
@@ -18,9 +18,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "gazsim_llsf_control_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -29,14 +29,16 @@ using namespace fawkes;
  *
  * @author Frederik Zwilling
  */
-class GazsimLlsfControlPlugin : public fawkes::Plugin {
+class GazsimLlsfControlPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimLlsfControlPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new LlsfControlSimThread());
-  }
+	GazsimLlsfControlPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new LlsfControlSimThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Makes control of a llsf game in gazebo")

--- a/src/plugins/gazebo/gazsim-llsf-control/gazsim_llsf_control_thread.cpp
+++ b/src/plugins/gazebo/gazsim-llsf-control/gazsim_llsf_control_thread.cpp
@@ -20,19 +20,18 @@
 
 #include "gazsim_llsf_control_thread.h"
 
+#include <aspect/logging.h>
+#include <interfaces/Position3DInterface.h>
+#include <tf/types.h>
+
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/transport/Node.hh>
+#include <gazebo/transport/transport.hh>
 #include <math.h>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <tf/types.h>
-
-#include <interfaces/Position3DInterface.h>
-
-#include <aspect/logging.h>
-#include <gazebo/msgs/msgs.hh>
-#include <gazebo/transport/Node.hh>
-#include <gazebo/transport/transport.hh>
 
 using namespace fawkes;
 using namespace gazebo;
@@ -45,104 +44,110 @@ using namespace gazebo;
 
 /** Constructor. */
 LlsfControlSimThread::LlsfControlSimThread()
-    : Thread("LlsfControlSimThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE) {}
-
-void LlsfControlSimThread::init() {
-  logger->log_debug(name(), "Initializing LLSF-Control Plugin");
-
-  // create subscriber
-  game_state_sub_ = gazebo_world_node->Subscribe(
-      config->get_string("/gazsim/topics/game-state"),
-      &LlsfControlSimThread::on_game_state_msg, this);
-
-  // Create Publisher
-  set_game_state_pub_ = gazebo_world_node->Advertise<llsf_msgs::SetGameState>(
-      config->get_string("/gazsim/topics/set-game-state"));
-  set_game_phase_pub_ = gazebo_world_node->Advertise<llsf_msgs::SetGamePhase>(
-      config->get_string("/gazsim/topics/set-game-phase"));
-  set_team_name_pub_ = gazebo_world_node->Advertise<llsf_msgs::SetTeamName>(
-      config->get_string("/gazsim/topics/set-team-name"));
-
-  // read config values
-  post_game_simulation_shutdown_ =
-      config->get_bool("/gazsim/llsf-control/simulation-shutdown-after-game");
-  team_cyan_name_ = config->get_string("/gazsim/llsf-control/team-cyan-name");
-  team_magenta_name_ =
-      config->get_string("/gazsim/llsf-control/team-magenta-name");
-  fawkes_path_ = config->get_string("/gazsim/llsf-control/fawkes-path");
-  simulation_shutdown_script_ =
-      config->get_string("/gazsim/llsf-control/simulation-shutdown-script");
-  start_game_automatically_ =
-      config->get_bool("/gazsim/llsf-control/start-game-automatically");
-  time_to_wait_before_start_ =
-      config->get_float("/gazsim/llsf-control/time-to-wait-before-start");
-  time_to_wait_before_set_team_ =
-      config->get_float("/gazsim/llsf-control/time-to-wait-before-set-team");
-  time_to_wait_before_shutdown_ =
-      config->get_float("/gazsim/llsf-control/time-to-wait-before-shutdown");
-
-  start_sent_ = false;
-  team_sent_ = false;
-  start_time_.set_clock(clock);
-  start_time_.stamp();
-  logger->log_info(name(), "Startup");
-  shutdown_initiated_ = false;
+: Thread("LlsfControlSimThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE)
+{
 }
 
-void LlsfControlSimThread::finalize() {}
+void
+LlsfControlSimThread::init()
+{
+	logger->log_debug(name(), "Initializing LLSF-Control Plugin");
 
-void LlsfControlSimThread::loop() {
-  fawkes::Time now(clock);
-  if (!team_sent_ && (now - &start_time_) > time_to_wait_before_set_team_) {
-    logger->log_info(name(), "Setting teams");
-    // set team names
-    llsf_msgs::SetTeamName msg_team_cyan;
-    msg_team_cyan.set_team_name(team_cyan_name_);
-    msg_team_cyan.set_team_color(llsf_msgs::Team::CYAN);
-    set_team_name_pub_->Publish(msg_team_cyan);
+	// create subscriber
+	game_state_sub_ = gazebo_world_node->Subscribe(config->get_string("/gazsim/topics/game-state"),
+	                                               &LlsfControlSimThread::on_game_state_msg,
+	                                               this);
 
-    llsf_msgs::SetTeamName msg_team_magenta;
-    msg_team_magenta.set_team_name(team_magenta_name_);
-    msg_team_magenta.set_team_color(llsf_msgs::Team::MAGENTA);
-    set_team_name_pub_->Publish(msg_team_magenta);
+	// Create Publisher
+	set_game_state_pub_ = gazebo_world_node->Advertise<llsf_msgs::SetGameState>(
+	  config->get_string("/gazsim/topics/set-game-state"));
+	set_game_phase_pub_ = gazebo_world_node->Advertise<llsf_msgs::SetGamePhase>(
+	  config->get_string("/gazsim/topics/set-game-phase"));
+	set_team_name_pub_ = gazebo_world_node->Advertise<llsf_msgs::SetTeamName>(
+	  config->get_string("/gazsim/topics/set-team-name"));
 
-    // start setup phase
-    llsf_msgs::SetGameState msg_state;
-    msg_state.set_state(llsf_msgs::GameState::RUNNING);
-    set_game_state_pub_->Publish(msg_state);
-    team_sent_ = true;
-  }
-  if (!start_sent_ && (now - &start_time_) > time_to_wait_before_start_) {
-    logger->log_info(name(), "Starting game");
-    // let the refbox start the game
-    llsf_msgs::SetGamePhase msg_phase;
-    msg_phase.set_phase(llsf_msgs::GameState::EXPLORATION);
-    set_game_phase_pub_->Publish(msg_phase);
+	// read config values
+	post_game_simulation_shutdown_ =
+	  config->get_bool("/gazsim/llsf-control/simulation-shutdown-after-game");
+	team_cyan_name_    = config->get_string("/gazsim/llsf-control/team-cyan-name");
+	team_magenta_name_ = config->get_string("/gazsim/llsf-control/team-magenta-name");
+	fawkes_path_       = config->get_string("/gazsim/llsf-control/fawkes-path");
+	simulation_shutdown_script_ =
+	  config->get_string("/gazsim/llsf-control/simulation-shutdown-script");
+	start_game_automatically_  = config->get_bool("/gazsim/llsf-control/start-game-automatically");
+	time_to_wait_before_start_ = config->get_float("/gazsim/llsf-control/time-to-wait-before-start");
+	time_to_wait_before_set_team_ =
+	  config->get_float("/gazsim/llsf-control/time-to-wait-before-set-team");
+	time_to_wait_before_shutdown_ =
+	  config->get_float("/gazsim/llsf-control/time-to-wait-before-shutdown");
 
-    start_sent_ = true;
-  }
-
-  if (shutdown_initiated_ &&
-      (now - &shutdown_initiated_time_) > time_to_wait_before_shutdown_) {
-    logger->log_info(name(), "shutting down");
-    std::string command = fawkes_path_ + simulation_shutdown_script_;
-    int schnurz = system(command.c_str());
-    // just avoid warning that the return value of system() is ignored
-    schnurz++;
-  }
+	start_sent_ = false;
+	team_sent_  = false;
+	start_time_.set_clock(clock);
+	start_time_.stamp();
+	logger->log_info(name(), "Startup");
+	shutdown_initiated_ = false;
 }
 
-void LlsfControlSimThread::on_game_state_msg(ConstGameStatePtr &msg) {
-  // logger->log_info(name(), "Got GameState message");
-  if (msg->phase() == llsf_msgs::GameState::POST_GAME) {
-    if (post_game_simulation_shutdown_ && !shutdown_initiated_) {
-      logger->log_info(name(), "set shutdown timer %f",
-                       time_to_wait_before_shutdown_);
-      // countdown for simulation shutdown
-      shutdown_initiated_time_.set_clock(clock);
-      shutdown_initiated_time_.stamp();
-      shutdown_initiated_ = true;
-    }
-  }
+void
+LlsfControlSimThread::finalize()
+{
+}
+
+void
+LlsfControlSimThread::loop()
+{
+	fawkes::Time now(clock);
+	if (!team_sent_ && (now - &start_time_) > time_to_wait_before_set_team_) {
+		logger->log_info(name(), "Setting teams");
+		// set team names
+		llsf_msgs::SetTeamName msg_team_cyan;
+		msg_team_cyan.set_team_name(team_cyan_name_);
+		msg_team_cyan.set_team_color(llsf_msgs::Team::CYAN);
+		set_team_name_pub_->Publish(msg_team_cyan);
+
+		llsf_msgs::SetTeamName msg_team_magenta;
+		msg_team_magenta.set_team_name(team_magenta_name_);
+		msg_team_magenta.set_team_color(llsf_msgs::Team::MAGENTA);
+		set_team_name_pub_->Publish(msg_team_magenta);
+
+		// start setup phase
+		llsf_msgs::SetGameState msg_state;
+		msg_state.set_state(llsf_msgs::GameState::RUNNING);
+		set_game_state_pub_->Publish(msg_state);
+		team_sent_ = true;
+	}
+	if (!start_sent_ && (now - &start_time_) > time_to_wait_before_start_) {
+		logger->log_info(name(), "Starting game");
+		// let the refbox start the game
+		llsf_msgs::SetGamePhase msg_phase;
+		msg_phase.set_phase(llsf_msgs::GameState::EXPLORATION);
+		set_game_phase_pub_->Publish(msg_phase);
+
+		start_sent_ = true;
+	}
+
+	if (shutdown_initiated_ && (now - &shutdown_initiated_time_) > time_to_wait_before_shutdown_) {
+		logger->log_info(name(), "shutting down");
+		std::string command = fawkes_path_ + simulation_shutdown_script_;
+		int         schnurz = system(command.c_str());
+		// just avoid warning that the return value of system() is ignored
+		schnurz++;
+	}
+}
+
+void
+LlsfControlSimThread::on_game_state_msg(ConstGameStatePtr &msg)
+{
+	// logger->log_info(name(), "Got GameState message");
+	if (msg->phase() == llsf_msgs::GameState::POST_GAME) {
+		if (post_game_simulation_shutdown_ && !shutdown_initiated_) {
+			logger->log_info(name(), "set shutdown timer %f", time_to_wait_before_shutdown_);
+			// countdown for simulation shutdown
+			shutdown_initiated_time_.set_clock(clock);
+			shutdown_initiated_time_.stamp();
+			shutdown_initiated_ = true;
+		}
+	}
 }

--- a/src/plugins/gazebo/gazsim-llsf-control/gazsim_llsf_control_thread.h
+++ b/src/plugins/gazebo/gazsim-llsf-control/gazsim_llsf_control_thread.h
@@ -32,8 +32,9 @@
 #include <llsf_msgs/GameState.pb.h>
 #include <llsf_msgs/Team.pb.h>
 #include <plugins/gazebo/aspect/gazebo.h>
-#include <string.h>
 #include <utils/time/time.h>
+
+#include <string.h>
 
 // from Gazebo
 #include <gazebo/msgs/MessageTypes.hh>
@@ -44,13 +45,10 @@ namespace fawkes {
 class Position3DInterface;
 }
 
-typedef const boost::shared_ptr<llsf_msgs::GameState const> ConstGameStatePtr;
-typedef const boost::shared_ptr<llsf_msgs::SetGameState const>
-    ConstSetGameStatePtr;
-typedef const boost::shared_ptr<llsf_msgs::SetGamePhase const>
-    ConstSetGamePhasePtr;
-typedef const boost::shared_ptr<llsf_msgs::SetTeamName const>
-    ConstSetTeamNamePtr;
+typedef const boost::shared_ptr<llsf_msgs::GameState const>    ConstGameStatePtr;
+typedef const boost::shared_ptr<llsf_msgs::SetGameState const> ConstSetGameStatePtr;
+typedef const boost::shared_ptr<llsf_msgs::SetGamePhase const> ConstSetGamePhasePtr;
+typedef const boost::shared_ptr<llsf_msgs::SetTeamName const>  ConstSetTeamNamePtr;
 
 class LlsfControlSimThread : public fawkes::Thread,
                              public fawkes::ClockAspect,
@@ -58,43 +56,44 @@ class LlsfControlSimThread : public fawkes::Thread,
                              public fawkes::ConfigurableAspect,
                              public fawkes::BlackBoardAspect,
                              public fawkes::BlockedTimingAspect,
-                             public fawkes::GazeboAspect {
+                             public fawkes::GazeboAspect
+{
 public:
-  LlsfControlSimThread();
+	LlsfControlSimThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  // suscribers for gazebo nodes (refbox messages forwarded by
-  // gazsim-llsfrbcomm)
-  gazebo::transport::SubscriberPtr game_state_sub_;
-  // Publisher to start the refbox
-  gazebo::transport::PublisherPtr set_game_state_pub_;
-  gazebo::transport::PublisherPtr set_game_phase_pub_;
-  gazebo::transport::PublisherPtr set_team_name_pub_;
+	// suscribers for gazebo nodes (refbox messages forwarded by
+	// gazsim-llsfrbcomm)
+	gazebo::transport::SubscriberPtr game_state_sub_;
+	// Publisher to start the refbox
+	gazebo::transport::PublisherPtr set_game_state_pub_;
+	gazebo::transport::PublisherPtr set_game_phase_pub_;
+	gazebo::transport::PublisherPtr set_team_name_pub_;
 
-  // config values
-  bool start_game_automatically_;
-  float time_to_wait_before_start_;
-  float time_to_wait_before_set_team_;
-  bool post_game_simulation_shutdown_;
-  float time_to_wait_before_shutdown_;
-  std::string fawkes_path_;
-  std::string simulation_shutdown_script_;
-  std::string team_cyan_name_;
-  std::string team_magenta_name_;
+	// config values
+	bool        start_game_automatically_;
+	float       time_to_wait_before_start_;
+	float       time_to_wait_before_set_team_;
+	bool        post_game_simulation_shutdown_;
+	float       time_to_wait_before_shutdown_;
+	std::string fawkes_path_;
+	std::string simulation_shutdown_script_;
+	std::string team_cyan_name_;
+	std::string team_magenta_name_;
 
-  // handler functions
-  void on_game_state_msg(ConstGameStatePtr &msg);
+	// handler functions
+	void on_game_state_msg(ConstGameStatePtr &msg);
 
-  // helper variables
-  fawkes::Time start_time_;
-  fawkes::Time shutdown_initiated_time_;
-  bool team_sent_;
-  bool start_sent_;
-  bool shutdown_initiated_;
+	// helper variables
+	fawkes::Time start_time_;
+	fawkes::Time shutdown_initiated_time_;
+	bool         team_sent_;
+	bool         start_sent_;
+	bool         shutdown_initiated_;
 };
 
 #endif

--- a/src/plugins/gazebo/gazsim-llsfrbcomm/gazsim_llsfrbcomm_plugin.cpp
+++ b/src/plugins/gazebo/gazsim-llsfrbcomm/gazsim_llsfrbcomm_plugin.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "gazsim_llsfrbcomm_thread.h"
+
 #include <core/plugin.h>
 
 using namespace fawkes;
@@ -33,14 +34,16 @@ using namespace fawkes;
  *       Protobuf communication over the gazebo node
  * @author Frederik Zwilling, Tim Niemueller
  */
-class GazsimLLSFRbCommPlugin : public fawkes::Plugin {
+class GazsimLLSFRbCommPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimLLSFRbCommPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new GazsimLLSFRbCommThread());
-  }
+	GazsimLLSFRbCommPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new GazsimLLSFRbCommThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Adapter PB Refbox Comm - PB Gazebo Comm")

--- a/src/plugins/gazebo/gazsim-llsfrbcomm/gazsim_llsfrbcomm_thread.cpp
+++ b/src/plugins/gazebo/gazsim-llsfrbcomm/gazsim_llsfrbcomm_thread.cpp
@@ -23,14 +23,14 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <aspect/blocked_timing.h>
-#include <protobuf_comm/client.h>
-#include <protobuf_comm/message_register.h>
-
 #include "gazsim_llsfrbcomm_thread.h"
+
+#include <aspect/blocked_timing.h>
 #include <llsf_msgs/GameState.pb.h>
 #include <llsf_msgs/MachineInfo.pb.h>
 #include <llsf_msgs/PuckInfo.pb.h>
+#include <protobuf_comm/client.h>
+#include <protobuf_comm/message_register.h>
 
 using namespace fawkes;
 using namespace protobuf_comm;
@@ -45,81 +45,92 @@ using namespace protobuf_comm;
 
 /** Constructor. */
 GazsimLLSFRbCommThread::GazsimLLSFRbCommThread()
-    : Thread("GazsimLLSFRbCommThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE) {}
+: Thread("GazsimLLSFRbCommThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE)
+{
+}
 
 /** Destructor. */
-GazsimLLSFRbCommThread::~GazsimLLSFRbCommThread() {}
-
-void GazsimLLSFRbCommThread::init() {
-  // logger->log_info(name(), "GazsimLLSFRbComm initialized");
-
-  // read config values
-  refbox_host_ = config->get_string("/gazsim/llsf-rb-comm/refbox-host");
-  refbox_port_ = config->get_uint("/gazsim/llsf-rb-comm/refbox-port");
-  proto_dirs_ = config->get_strings("/gazsim/proto-dirs");
-  // resolve proto paths
-  try {
-    proto_dirs_ = config->get_strings("/clips-protobuf/proto-dirs");
-    for (size_t i = 0; i < proto_dirs_.size(); ++i) {
-      std::string::size_type pos;
-      if ((pos = proto_dirs_[i].find("@BASEDIR@")) != std::string::npos) {
-        proto_dirs_[i].replace(pos, 9, BASEDIR);
-      }
-      if ((pos = proto_dirs_[i].find("@FAWKES_BASEDIR@")) !=
-          std::string::npos) {
-        proto_dirs_[i].replace(pos, 16, FAWKES_BASEDIR);
-      }
-      if ((pos = proto_dirs_[i].find("@RESDIR@")) != std::string::npos) {
-        proto_dirs_[i].replace(pos, 8, RESDIR);
-      }
-      if ((pos = proto_dirs_[i].find("@CONFDIR@")) != std::string::npos) {
-        proto_dirs_[i].replace(pos, 9, CONFDIR);
-      }
-      if (proto_dirs_[i][proto_dirs_.size() - 1] != '/') {
-        proto_dirs_[i] += "/";
-      }
-    }
-  } catch (Exception &e) {
-    logger->log_warn(
-        name(), "Failed to load proto paths from config, exception follows");
-    logger->log_warn(name(), e);
-  }
-
-  // prepare client
-  create_client();
-  client_->async_connect(refbox_host_.c_str(), refbox_port_);
-  // this invokes the connect in the loop
-  disconnected_recently_ = true;
-
-  // create publisher and subscriber for connection with gazebo node
-  machine_info_pub_ = gazebo_world_node->Advertise<llsf_msgs::MachineInfo>(
-      config->get_string("/gazsim/topics/machine-info"));
-  game_state_pub_ = gazebo_world_node->Advertise<llsf_msgs::GameState>(
-      config->get_string("/gazsim/topics/game-state"));
-  puck_info_pub_ = gazebo_world_node->Advertise<llsf_msgs::PuckInfo>(
-      config->get_string("/gazsim/topics/puck-info"));
-  time_sync_sub_ = gazebo_world_node->Subscribe(
-      config->get_string("/gazsim/topics/time"),
-      &GazsimLLSFRbCommThread::on_time_sync_msg, this);
-  set_game_state_sub_ = gazebo_world_node->Subscribe(
-      config->get_string("/gazsim/topics/set-game-state"),
-      &GazsimLLSFRbCommThread::on_set_game_state_msg, this);
-  set_game_phase_sub_ = gazebo_world_node->Subscribe(
-      config->get_string("/gazsim/topics/set-game-phase"),
-      &GazsimLLSFRbCommThread::on_set_game_phase_msg, this);
-  set_team_name_sub_ = gazebo_world_node->Subscribe(
-      config->get_string("/gazsim/topics/set-team-name"),
-      &GazsimLLSFRbCommThread::on_set_team_name_msg, this);
+GazsimLLSFRbCommThread::~GazsimLLSFRbCommThread()
+{
 }
 
-void GazsimLLSFRbCommThread::finalize() {
-  delete message_register_;
-  delete client_;
+void
+GazsimLLSFRbCommThread::init()
+{
+	// logger->log_info(name(), "GazsimLLSFRbComm initialized");
+
+	// read config values
+	refbox_host_ = config->get_string("/gazsim/llsf-rb-comm/refbox-host");
+	refbox_port_ = config->get_uint("/gazsim/llsf-rb-comm/refbox-port");
+	proto_dirs_  = config->get_strings("/gazsim/proto-dirs");
+	// resolve proto paths
+	try {
+		proto_dirs_ = config->get_strings("/clips-protobuf/proto-dirs");
+		for (size_t i = 0; i < proto_dirs_.size(); ++i) {
+			std::string::size_type pos;
+			if ((pos = proto_dirs_[i].find("@BASEDIR@")) != std::string::npos) {
+				proto_dirs_[i].replace(pos, 9, BASEDIR);
+			}
+			if ((pos = proto_dirs_[i].find("@FAWKES_BASEDIR@")) != std::string::npos) {
+				proto_dirs_[i].replace(pos, 16, FAWKES_BASEDIR);
+			}
+			if ((pos = proto_dirs_[i].find("@RESDIR@")) != std::string::npos) {
+				proto_dirs_[i].replace(pos, 8, RESDIR);
+			}
+			if ((pos = proto_dirs_[i].find("@CONFDIR@")) != std::string::npos) {
+				proto_dirs_[i].replace(pos, 9, CONFDIR);
+			}
+			if (proto_dirs_[i][proto_dirs_.size() - 1] != '/') {
+				proto_dirs_[i] += "/";
+			}
+		}
+	} catch (Exception &e) {
+		logger->log_warn(name(), "Failed to load proto paths from config, exception follows");
+		logger->log_warn(name(), e);
+	}
+
+	// prepare client
+	create_client();
+	client_->async_connect(refbox_host_.c_str(), refbox_port_);
+	// this invokes the connect in the loop
+	disconnected_recently_ = true;
+
+	// create publisher and subscriber for connection with gazebo node
+	machine_info_pub_ = gazebo_world_node->Advertise<llsf_msgs::MachineInfo>(
+	  config->get_string("/gazsim/topics/machine-info"));
+	game_state_pub_ = gazebo_world_node->Advertise<llsf_msgs::GameState>(
+	  config->get_string("/gazsim/topics/game-state"));
+	puck_info_pub_ = gazebo_world_node->Advertise<llsf_msgs::PuckInfo>(
+	  config->get_string("/gazsim/topics/puck-info"));
+	time_sync_sub_ = gazebo_world_node->Subscribe(config->get_string("/gazsim/topics/time"),
+	                                              &GazsimLLSFRbCommThread::on_time_sync_msg,
+	                                              this);
+	set_game_state_sub_ =
+	  gazebo_world_node->Subscribe(config->get_string("/gazsim/topics/set-game-state"),
+	                               &GazsimLLSFRbCommThread::on_set_game_state_msg,
+	                               this);
+	set_game_phase_sub_ =
+	  gazebo_world_node->Subscribe(config->get_string("/gazsim/topics/set-game-phase"),
+	                               &GazsimLLSFRbCommThread::on_set_game_phase_msg,
+	                               this);
+	set_team_name_sub_ =
+	  gazebo_world_node->Subscribe(config->get_string("/gazsim/topics/set-team-name"),
+	                               &GazsimLLSFRbCommThread::on_set_team_name_msg,
+	                               this);
 }
 
-void GazsimLLSFRbCommThread::loop() {
-  /*if(disconnected_recently_)
+void
+GazsimLLSFRbCommThread::finalize()
+{
+	delete message_register_;
+	delete client_;
+}
+
+void
+GazsimLLSFRbCommThread::loop()
+{
+	/*if(disconnected_recently_)
   {
     disconnected_recently_ = false;
     //connect
@@ -130,17 +141,20 @@ void GazsimLLSFRbCommThread::loop() {
 
 /** Handler for successful connection to the client
  */
-void GazsimLLSFRbCommThread::client_connected() {
-  logger->log_info(name(), "Connected to Refbox");
+void
+GazsimLLSFRbCommThread::client_connected()
+{
+	logger->log_info(name(), "Connected to Refbox");
 }
 
 /** Handler for loss of connection to client
  * @param error boost error code
  */
-void GazsimLLSFRbCommThread::client_disconnected(
-    const boost::system::error_code &error) {
-  logger->log_info(name(), "Disconnected");
-  create_client();
+void
+GazsimLLSFRbCommThread::client_disconnected(const boost::system::error_code &error)
+{
+	logger->log_info(name(), "Disconnected");
+	create_client();
 }
 
 /** Handler for incoming msg from client
@@ -148,92 +162,103 @@ void GazsimLLSFRbCommThread::client_disconnected(
  * @param msg_type type of protobuf msg
  * @param msg pointer to protobuf msg
  */
-void GazsimLLSFRbCommThread::client_msg(
-    uint16_t comp_id, uint16_t msg_type,
-    std::shared_ptr<google::protobuf::Message> msg) {
-  // logger->log_info(name(), "Message");
-  // logger->log_info(name(), msg->GetTypeName().c_str());
+void
+GazsimLLSFRbCommThread::client_msg(uint16_t                                   comp_id,
+                                   uint16_t                                   msg_type,
+                                   std::shared_ptr<google::protobuf::Message> msg)
+{
+	// logger->log_info(name(), "Message");
+	// logger->log_info(name(), msg->GetTypeName().c_str());
 
-  // Filter wanted messages
-  if (msg->GetTypeName() == "llsf_msgs.MachineInfo") {
-    // logger->log_info(name(), "Sending MachineInfo to gazebo");
-    machine_info_pub_->Publish(*msg);
-    return;
-  }
+	// Filter wanted messages
+	if (msg->GetTypeName() == "llsf_msgs.MachineInfo") {
+		// logger->log_info(name(), "Sending MachineInfo to gazebo");
+		machine_info_pub_->Publish(*msg);
+		return;
+	}
 
-  if (msg->GetTypeName() == "llsf_msgs.GameState") {
-    // logger->log_info(name(), "Sending GameState to gazebo");
-    game_state_pub_->Publish(*msg);
-    return;
-  }
+	if (msg->GetTypeName() == "llsf_msgs.GameState") {
+		// logger->log_info(name(), "Sending GameState to gazebo");
+		game_state_pub_->Publish(*msg);
+		return;
+	}
 
-  if (msg->GetTypeName() == "llsf_msgs.PuckInfo") {
-    // logger->log_info(name(), "Sending PuckInfo to gazebo");
-    puck_info_pub_->Publish(*msg);
-    return;
-  }
+	if (msg->GetTypeName() == "llsf_msgs.PuckInfo") {
+		// logger->log_info(name(), "Sending PuckInfo to gazebo");
+		puck_info_pub_->Publish(*msg);
+		return;
+	}
 }
 
-void GazsimLLSFRbCommThread::create_client() {
-  // create message register with all messages to listen for
-  message_register_ = new protobuf_comm::MessageRegister(proto_dirs_);
+void
+GazsimLLSFRbCommThread::create_client()
+{
+	// create message register with all messages to listen for
+	message_register_ = new protobuf_comm::MessageRegister(proto_dirs_);
 
-  // create client and register handlers
-  client_ = new ProtobufStreamClient(message_register_);
-  client_->signal_connected().connect(
-      boost::bind(&GazsimLLSFRbCommThread::client_connected, this));
-  client_->signal_disconnected().connect(
-      boost::bind(&GazsimLLSFRbCommThread::client_disconnected, this,
-                  boost::asio::placeholders::error));
-  client_->signal_received().connect(
-      boost::bind(&GazsimLLSFRbCommThread::client_msg, this, _1, _2, _3));
+	// create client and register handlers
+	client_ = new ProtobufStreamClient(message_register_);
+	client_->signal_connected().connect(boost::bind(&GazsimLLSFRbCommThread::client_connected, this));
+	client_->signal_disconnected().connect(boost::bind(&GazsimLLSFRbCommThread::client_disconnected,
+	                                                   this,
+	                                                   boost::asio::placeholders::error));
+	client_->signal_received().connect(
+	  boost::bind(&GazsimLLSFRbCommThread::client_msg, this, _1, _2, _3));
 
-  // this invokes the connect in the loop
-  disconnected_recently_ = true;
+	// this invokes the connect in the loop
+	disconnected_recently_ = true;
 }
 
-void GazsimLLSFRbCommThread::on_time_sync_msg(ConstSimTimePtr &msg) {
-  // logger->log_info(name(), "Sending Simulation Time");
+void
+GazsimLLSFRbCommThread::on_time_sync_msg(ConstSimTimePtr &msg)
+{
+	// logger->log_info(name(), "Sending Simulation Time");
 
-  // provide time source with newest message
-  if (!client_->connected()) {
-    return;
-  }
-  // fill msg for refbox with info from gazsim_msg
-  llsf_msgs::SimTimeSync to_rb;
-  llsf_msgs::Time *time = to_rb.mutable_sim_time();
-  time->set_sec(msg->sim_time_sec());
-  time->set_nsec(msg->sim_time_nsec());
-  to_rb.set_real_time_factor(msg->real_time_factor());
-  to_rb.set_paused(msg->paused());
+	// provide time source with newest message
+	if (!client_->connected()) {
+		return;
+	}
+	// fill msg for refbox with info from gazsim_msg
+	llsf_msgs::SimTimeSync to_rb;
+	llsf_msgs::Time *      time = to_rb.mutable_sim_time();
+	time->set_sec(msg->sim_time_sec());
+	time->set_nsec(msg->sim_time_nsec());
+	to_rb.set_real_time_factor(msg->real_time_factor());
+	to_rb.set_paused(msg->paused());
 
-  // send it and make refbox able to handle the msg
-  client_->send(to_rb);
+	// send it and make refbox able to handle the msg
+	client_->send(to_rb);
 }
 
-void GazsimLLSFRbCommThread::on_set_game_state_msg(ConstSetGameStatePtr &msg) {
-  // logger->log_info(name(), "Sending SetGameState to refbox");
-  if (!client_->connected()) {
-    return;
-  }
-  llsf_msgs::SetGameState to_rb = *msg;
-  client_->send(to_rb);
+void
+GazsimLLSFRbCommThread::on_set_game_state_msg(ConstSetGameStatePtr &msg)
+{
+	// logger->log_info(name(), "Sending SetGameState to refbox");
+	if (!client_->connected()) {
+		return;
+	}
+	llsf_msgs::SetGameState to_rb = *msg;
+	client_->send(to_rb);
 }
 
-void GazsimLLSFRbCommThread::on_set_game_phase_msg(ConstSetGamePhasePtr &msg) {
-  // logger->log_info(name(), "Sending SetGamePhase to refbox");
-  if (!client_->connected()) {
-    return;
-  }
-  llsf_msgs::SetGamePhase to_rb = *msg;
-  client_->send(to_rb);
+void
+GazsimLLSFRbCommThread::on_set_game_phase_msg(ConstSetGamePhasePtr &msg)
+{
+	// logger->log_info(name(), "Sending SetGamePhase to refbox");
+	if (!client_->connected()) {
+		return;
+	}
+	llsf_msgs::SetGamePhase to_rb = *msg;
+	client_->send(to_rb);
 }
 
-void GazsimLLSFRbCommThread::on_set_team_name_msg(ConstSetTeamNamePtr &msg) {
-  // logger->log_info(name(), "Sending SetTeamName to refbox");
-  if (!client_->connected()) {
-    return;
-  }
-  llsf_msgs::SetTeamName to_rb = *msg;
-  client_->send(to_rb);
+void
+GazsimLLSFRbCommThread::on_set_team_name_msg(ConstSetTeamNamePtr &msg)
+{
+	// logger->log_info(name(), "Sending SetTeamName to refbox");
+	if (!client_->connected()) {
+		return;
+	}
+	llsf_msgs::SetTeamName to_rb = *msg;
+	client_->send(to_rb);
 }

--- a/src/plugins/gazebo/gazsim-llsfrbcomm/gazsim_llsfrbcomm_thread.h
+++ b/src/plugins/gazebo/gazsim-llsfrbcomm/gazsim_llsfrbcomm_thread.h
@@ -29,7 +29,6 @@
 #include <aspect/blocked_timing.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
-#include <boost/asio.hpp>
 #include <core/threading/thread.h>
 #include <google/protobuf/message.h>
 #include <llsf_msgs/GameInfo.pb.h>
@@ -42,22 +41,20 @@
 #include <protobuf_comm/client.h>
 #include <protobuf_comm/message_register.h>
 
+#include <boost/asio.hpp>
+
 // from Gazebo
+#include "../msgs/SimTime.pb.h"
+
 #include <gazebo/msgs/MessageTypes.hh>
 #include <gazebo/transport/TransportTypes.hh>
 #include <gazebo/transport/transport.hh>
 
-#include "../msgs/SimTime.pb.h"
-
-typedef const boost::shared_ptr<llsf_msgs::MachineInfo const>
-    ConstMachineInfoPtr;
-typedef const boost::shared_ptr<gazsim_msgs::SimTime const> ConstSimTimePtr;
-typedef const boost::shared_ptr<llsf_msgs::SetGameState const>
-    ConstSetGameStatePtr;
-typedef const boost::shared_ptr<llsf_msgs::SetGamePhase const>
-    ConstSetGamePhasePtr;
-typedef const boost::shared_ptr<llsf_msgs::SetTeamName const>
-    ConstSetTeamNamePtr;
+typedef const boost::shared_ptr<llsf_msgs::MachineInfo const>  ConstMachineInfoPtr;
+typedef const boost::shared_ptr<gazsim_msgs::SimTime const>    ConstSimTimePtr;
+typedef const boost::shared_ptr<llsf_msgs::SetGameState const> ConstSetGameStatePtr;
+typedef const boost::shared_ptr<llsf_msgs::SetGamePhase const> ConstSetGamePhasePtr;
+typedef const boost::shared_ptr<llsf_msgs::SetTeamName const>  ConstSetTeamNamePtr;
 
 namespace protobuf_comm {
 class ProtobufStreamClient;
@@ -67,52 +64,57 @@ class GazsimLLSFRbCommThread : public fawkes::Thread,
                                public fawkes::BlockedTimingAspect,
                                public fawkes::ConfigurableAspect,
                                public fawkes::GazeboAspect,
-                               public fawkes::LoggingAspect {
+                               public fawkes::LoggingAspect
+{
 public:
-  GazsimLLSFRbCommThread();
-  ~GazsimLLSFRbCommThread();
+	GazsimLLSFRbCommThread();
+	~GazsimLLSFRbCommThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  void client_connected();
-  void client_disconnected(const boost::system::error_code &error);
-  void client_msg(uint16_t comp_id, uint16_t msg_type,
-                  std::shared_ptr<google::protobuf::Message> msg);
+	void client_connected();
+	void client_disconnected(const boost::system::error_code &error);
+	void
+	client_msg(uint16_t comp_id, uint16_t msg_type, std::shared_ptr<google::protobuf::Message> msg);
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  protobuf_comm::ProtobufStreamClient *client_;
-  protobuf_comm::MessageRegister *message_register_;
+	protobuf_comm::ProtobufStreamClient *client_;
+	protobuf_comm::MessageRegister *     message_register_;
 
-  // config values
-  std::vector<std::string> proto_dirs_;
-  std::string refbox_host_;
-  unsigned int refbox_port_;
+	// config values
+	std::vector<std::string> proto_dirs_;
+	std::string              refbox_host_;
+	unsigned int             refbox_port_;
 
-  // Publisher and subscriber for the connection to gazebo
-  gazebo::transport::PublisherPtr machine_info_pub_;
-  gazebo::transport::PublisherPtr game_state_pub_;
-  gazebo::transport::PublisherPtr puck_info_pub_;
-  gazebo::transport::SubscriberPtr time_sync_sub_;
-  gazebo::transport::SubscriberPtr set_game_state_sub_;
-  gazebo::transport::SubscriberPtr set_game_phase_sub_;
-  gazebo::transport::SubscriberPtr set_team_name_sub_;
+	// Publisher and subscriber for the connection to gazebo
+	gazebo::transport::PublisherPtr  machine_info_pub_;
+	gazebo::transport::PublisherPtr  game_state_pub_;
+	gazebo::transport::PublisherPtr  puck_info_pub_;
+	gazebo::transport::SubscriberPtr time_sync_sub_;
+	gazebo::transport::SubscriberPtr set_game_state_sub_;
+	gazebo::transport::SubscriberPtr set_game_phase_sub_;
+	gazebo::transport::SubscriberPtr set_team_name_sub_;
 
-  // handler methods
-  void on_time_sync_msg(ConstSimTimePtr &msg);
-  void on_set_game_state_msg(ConstSetGameStatePtr &msg);
-  void on_set_game_phase_msg(ConstSetGamePhasePtr &msg);
-  void on_set_team_name_msg(ConstSetTeamNamePtr &msg);
+	// handler methods
+	void on_time_sync_msg(ConstSimTimePtr &msg);
+	void on_set_game_state_msg(ConstSetGameStatePtr &msg);
+	void on_set_game_phase_msg(ConstSetGamePhasePtr &msg);
+	void on_set_team_name_msg(ConstSetTeamNamePtr &msg);
 
-  // helper variables
-  bool disconnected_recently_;
+	// helper variables
+	bool disconnected_recently_;
 
-  void create_client();
+	void create_client();
 };
 
 #endif

--- a/src/plugins/gazebo/gazsim-navgraph-generator/gazsim_navgraph_generator_plugin.cpp
+++ b/src/plugins/gazebo/gazsim-navgraph-generator/gazsim_navgraph_generator_plugin.cpp
@@ -19,23 +19,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "gazsim_navgraph_generator_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Plugin to generate navgraph without exploration phase in simulation
  * @author David Schmidt
  */
-class GazsimNavgraphGeneratorPlugin : public fawkes::Plugin {
+class GazsimNavgraphGeneratorPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimNavgraphGeneratorPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new GazsimNavgraphGeneratorThread());
-  }
+	GazsimNavgraphGeneratorPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new GazsimNavgraphGeneratorThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Gazsim Navgraph Generator Plugin for generating navgraph "

--- a/src/plugins/gazebo/gazsim-navgraph-generator/gazsim_navgraph_generator_thread.cpp
+++ b/src/plugins/gazebo/gazsim-navgraph-generator/gazsim_navgraph_generator_thread.cpp
@@ -19,11 +19,12 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
+#include "gazsim_navgraph_generator_thread.h"
+
 #include <interfaces/NavGraphWithMPSGeneratorInterface.h>
+
 #include <string>
 #include <unordered_map>
-
-#include "gazsim_navgraph_generator_thread.h"
 
 using namespace fawkes;
 
@@ -34,140 +35,152 @@ using namespace fawkes;
 
 /** Constructor. */
 GazsimNavgraphGeneratorThread::GazsimNavgraphGeneratorThread()
-    : Thread("GazsimNavgraphGeneratorThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE),
-      task_finished_(false), computation_is_running_(false) {}
-
-void GazsimNavgraphGeneratorThread::init() {
-  logger->log_debug(name(), "Initializing GazsimNavgraphGenerator Plugin");
-
-  // read config values
-  tags_ = config->get_strings("/gazsim/navgraph-generator/all-active-tags");
-  related_mps_ = config->get_strings("/gazsim/navgraph-generator/related-mps");
-  nav_gen_if_name_ =
-      config->get_string("/gazsim/navgraph-generator/nav-gen-if-name");
-
-  // open interfaces
-  nav_gen_if_ =
-      blackboard->open_for_reading<fawkes::NavGraphWithMPSGeneratorInterface>(
-          nav_gen_if_name_.data());
-
-  // subscribing to gazebo tag messages
-  for (unsigned i = 0; i < tags_.size(); ++i)
-    subscriber_tags_.push_back(gazebo_world_node->Subscribe(
-        tags_[i], &GazsimNavgraphGeneratorThread::on_tag_msg, this));
-  tag_msgs_.clear();
-
-  // sort the mpsIDs to the tagIDs in mps_id_
-  get_mpsID_by_tagID();
+: Thread("GazsimNavgraphGeneratorThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE),
+  task_finished_(false),
+  computation_is_running_(false)
+{
 }
 
-void GazsimNavgraphGeneratorThread::finalize() {}
+void
+GazsimNavgraphGeneratorThread::init()
+{
+	logger->log_debug(name(), "Initializing GazsimNavgraphGenerator Plugin");
 
-void GazsimNavgraphGeneratorThread::loop() {
-  // check if navgraph is already computed
-  if (task_finished_)
-    return;
-  // check if computation of navgraph is running
-  if (computation_is_running_) {
-    nav_gen_if_->read();
-    if (nav_gen_if_->is_final()) {
-      task_finished_ = true;
-      computation_is_running_ = false;
-      blackboard->close(nav_gen_if_);
-      logger->log_info(name(), "Navgraph is generated!");
-    }
-    return;
-  }
-  // check if all tag-messages were received
-  if (tag_msgs_.size() < tags_.size())
-    return;
+	// read config values
+	tags_            = config->get_strings("/gazsim/navgraph-generator/all-active-tags");
+	related_mps_     = config->get_strings("/gazsim/navgraph-generator/related-mps");
+	nav_gen_if_name_ = config->get_string("/gazsim/navgraph-generator/nav-gen-if-name");
 
-  // check if the transform map nedded by navgraph-generator exists otherwise
-  // wait
-  if (!tf_listener->frame_exists("map")) {
-    logger->log_debug(name(), "Waiting until frame map exists");
-    return;
-  }
+	// open interfaces
+	nav_gen_if_ = blackboard->open_for_reading<fawkes::NavGraphWithMPSGeneratorInterface>(
+	  nav_gen_if_name_.data());
 
-  // send the position of all tags
-  for (std::map<int, gazebo::msgs::Pose>::iterator it = tag_msgs_.begin();
-       it != tag_msgs_.end(); ++it) {
-    //		logger->log_info(name(), "tag %i gets sent to
-    // NavgraphGenerator.",
-    //		                 (*it).first);
-    send_station_msg((*it).first, (*it).second);
-  }
-  bool *allFalse = new bool[24];
-  for (int i = 0; i < 24; ++i)
-    allFalse[i] = false;
-  NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage
-      *delete_explo_navgraph_msg =
-          new NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage(
-              allFalse);
-  // delete_explo_navgraph_msg->set_zones(allFalse);
-  nav_gen_if_->msgq_enqueue(delete_explo_navgraph_msg);
-  compute_msg_ = new NavGraphWithMPSGeneratorInterface::ComputeMessage();
-  nav_gen_if_->msgq_enqueue(compute_msg_);
-  computation_is_running_ = true;
+	// subscribing to gazebo tag messages
+	for (unsigned i = 0; i < tags_.size(); ++i)
+		subscriber_tags_.push_back(
+		  gazebo_world_node->Subscribe(tags_[i], &GazsimNavgraphGeneratorThread::on_tag_msg, this));
+	tag_msgs_.clear();
 
-  logger->log_info(name(), "Start unsubscribing!");
-  while (!subscriber_tags_.empty()) {
-    // subscriber_tags_.back()->Unsubscribe();
-    // gazebo 4.x seems to unsubscribe by deleting pointer on next line
-    subscriber_tags_.pop_back();
-  }
-  logger->log_info(name(), "Finished unsubscribing!");
+	// sort the mpsIDs to the tagIDs in mps_id_
+	get_mpsID_by_tagID();
 }
 
-void GazsimNavgraphGeneratorThread::on_tag_msg(ConstPosePtr &msg) {
-  int underscore = msg->name().find('_');
-  int id = std::atoi(msg->name().substr(underscore + 1).data());
-  if (msg->position().x() > -1 && msg->position().x() < 1 &&
-      msg->position().y() < 0)
-    return;
-  tag_msgs_[id].CopyFrom(*msg);
+void
+GazsimNavgraphGeneratorThread::finalize()
+{
 }
 
-void GazsimNavgraphGeneratorThread::get_mpsID_by_tagID() {
-  if (tags_.size() != related_mps_.size()) {
-    logger->log_error(name(),
-                      "There are %zu tags defined, but %zu!=%zu related mps!",
-                      tags_.size(), related_mps_.size(), tags_.size());
-    return;
-  }
-  for (unsigned i = 0; i < tags_.size(); ++i) {
-    int underscore = tags_[i].find('_');
-    int slash = tags_[i].substr(underscore + 1).find('/');
-    int id = std::atoi(tags_[i].substr(underscore + 1, slash).data());
-    mps_id_[id] = related_mps_[i];
-    //		logger->log_info(name(), "Full tag name:  %s", tags_[i].data());
-    //		logger->log_info(name(), "Extracted id:   %i", id);
-    //		logger->log_info(name(), "Related MPS-ID: %s",
-    // mps_id_[id].data());
-  }
+void
+GazsimNavgraphGeneratorThread::loop()
+{
+	// check if navgraph is already computed
+	if (task_finished_)
+		return;
+	// check if computation of navgraph is running
+	if (computation_is_running_) {
+		nav_gen_if_->read();
+		if (nav_gen_if_->is_final()) {
+			task_finished_          = true;
+			computation_is_running_ = false;
+			blackboard->close(nav_gen_if_);
+			logger->log_info(name(), "Navgraph is generated!");
+		}
+		return;
+	}
+	// check if all tag-messages were received
+	if (tag_msgs_.size() < tags_.size())
+		return;
+
+	// check if the transform map nedded by navgraph-generator exists otherwise
+	// wait
+	if (!tf_listener->frame_exists("map")) {
+		logger->log_debug(name(), "Waiting until frame map exists");
+		return;
+	}
+
+	// send the position of all tags
+	for (std::map<int, gazebo::msgs::Pose>::iterator it = tag_msgs_.begin(); it != tag_msgs_.end();
+	     ++it) {
+		//		logger->log_info(name(), "tag %i gets sent to
+		// NavgraphGenerator.",
+		//		                 (*it).first);
+		send_station_msg((*it).first, (*it).second);
+	}
+	bool *allFalse = new bool[24];
+	for (int i = 0; i < 24; ++i)
+		allFalse[i] = false;
+	NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage *delete_explo_navgraph_msg =
+	  new NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage(allFalse);
+	// delete_explo_navgraph_msg->set_zones(allFalse);
+	nav_gen_if_->msgq_enqueue(delete_explo_navgraph_msg);
+	compute_msg_ = new NavGraphWithMPSGeneratorInterface::ComputeMessage();
+	nav_gen_if_->msgq_enqueue(compute_msg_);
+	computation_is_running_ = true;
+
+	logger->log_info(name(), "Start unsubscribing!");
+	while (!subscriber_tags_.empty()) {
+		// subscriber_tags_.back()->Unsubscribe();
+		// gazebo 4.x seems to unsubscribe by deleting pointer on next line
+		subscriber_tags_.pop_back();
+	}
+	logger->log_info(name(), "Finished unsubscribing!");
 }
 
-void GazsimNavgraphGeneratorThread::send_station_msg(int id,
-                                                     gazebo::msgs::Pose pose) {
-  NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage *stationMsg =
-      new NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage();
-  stationMsg->set_name(mps_id_[id].data());
-  stationMsg->set_side(NavGraphWithMPSGeneratorInterface::Side::INPUT);
-  stationMsg->set_frame("map");
-  stationMsg->set_tag_translation(0, pose.position().x());
-  stationMsg->set_tag_translation(1, pose.position().y());
-  stationMsg->set_tag_translation(2, pose.position().z());
-  stationMsg->set_tag_rotation(0, pose.orientation().x());
-  stationMsg->set_tag_rotation(1, pose.orientation().y());
-  stationMsg->set_tag_rotation(2, pose.orientation().z());
-  stationMsg->set_tag_rotation(3, pose.orientation().w());
-  /*
+void
+GazsimNavgraphGeneratorThread::on_tag_msg(ConstPosePtr &msg)
+{
+	int underscore = msg->name().find('_');
+	int id         = std::atoi(msg->name().substr(underscore + 1).data());
+	if (msg->position().x() > -1 && msg->position().x() < 1 && msg->position().y() < 0)
+		return;
+	tag_msgs_[id].CopyFrom(*msg);
+}
+
+void
+GazsimNavgraphGeneratorThread::get_mpsID_by_tagID()
+{
+	if (tags_.size() != related_mps_.size()) {
+		logger->log_error(name(),
+		                  "There are %zu tags defined, but %zu!=%zu related mps!",
+		                  tags_.size(),
+		                  related_mps_.size(),
+		                  tags_.size());
+		return;
+	}
+	for (unsigned i = 0; i < tags_.size(); ++i) {
+		int underscore = tags_[i].find('_');
+		int slash      = tags_[i].substr(underscore + 1).find('/');
+		int id         = std::atoi(tags_[i].substr(underscore + 1, slash).data());
+		mps_id_[id]    = related_mps_[i];
+		//		logger->log_info(name(), "Full tag name:  %s", tags_[i].data());
+		//		logger->log_info(name(), "Extracted id:   %i", id);
+		//		logger->log_info(name(), "Related MPS-ID: %s",
+		// mps_id_[id].data());
+	}
+}
+
+void
+GazsimNavgraphGeneratorThread::send_station_msg(int id, gazebo::msgs::Pose pose)
+{
+	NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage *stationMsg =
+	  new NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage();
+	stationMsg->set_name(mps_id_[id].data());
+	stationMsg->set_side(NavGraphWithMPSGeneratorInterface::Side::INPUT);
+	stationMsg->set_frame("map");
+	stationMsg->set_tag_translation(0, pose.position().x());
+	stationMsg->set_tag_translation(1, pose.position().y());
+	stationMsg->set_tag_translation(2, pose.position().z());
+	stationMsg->set_tag_rotation(0, pose.orientation().x());
+	stationMsg->set_tag_rotation(1, pose.orientation().y());
+	stationMsg->set_tag_rotation(2, pose.orientation().z());
+	stationMsg->set_tag_rotation(3, pose.orientation().w());
+	/*
    double tag_orientation=fawkes::tf::get_yaw(pose);
    logger->log_info(name(),"ID:%i",id);
    logger->log_info(name(),"Name:%s",mps_id_[id].data());
    logger->log_info(name(),"Position:%f,%f,%f",pose.position().x(),pose.position().y(),pose.position().z());
    logger->log_info(name(),"Rotation:%f",tag_orientation);
    */
-  nav_gen_if_->msgq_enqueue(stationMsg);
+	nav_gen_if_->msgq_enqueue(stationMsg);
 }

--- a/src/plugins/gazebo/gazsim-navgraph-generator/gazsim_navgraph_generator_thread.h
+++ b/src/plugins/gazebo/gazsim-navgraph-generator/gazsim_navgraph_generator_thread.h
@@ -41,41 +41,42 @@ class GazsimNavgraphGeneratorThread : public fawkes::Thread,
                                       public fawkes::BlackBoardAspect,
                                       public fawkes::BlockedTimingAspect,
                                       public fawkes::TransformAspect,
-                                      public fawkes::GazeboAspect {
+                                      public fawkes::GazeboAspect
+{
 public:
-  GazsimNavgraphGeneratorThread();
+	GazsimNavgraphGeneratorThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  // controlling flags
-  bool task_finished_;
-  bool computation_is_running_;
-  fawkes::NavGraphWithMPSGeneratorInterface::ComputeMessage *compute_msg_;
+	// controlling flags
+	bool                                                       task_finished_;
+	bool                                                       computation_is_running_;
+	fawkes::NavGraphWithMPSGeneratorInterface::ComputeMessage *compute_msg_;
 
-  // Subscribers to receive tag positions from gazebo
-  std::vector<std::string> tags_;
-  std::vector<std::string> related_mps_;
-  std::vector<gazebo::transport::SubscriberPtr> subscriber_tags_;
+	// Subscribers to receive tag positions from gazebo
+	std::vector<std::string>                      tags_;
+	std::vector<std::string>                      related_mps_;
+	std::vector<gazebo::transport::SubscriberPtr> subscriber_tags_;
 
-  // navgraph generator interface
-  std::string nav_gen_if_name_;
-  fawkes::NavGraphWithMPSGeneratorInterface *nav_gen_if_;
+	// navgraph generator interface
+	std::string                                nav_gen_if_name_;
+	fawkes::NavGraphWithMPSGeneratorInterface *nav_gen_if_;
 
-  // list of poses of the tags
-  std::map<int, gazebo::msgs::Pose> tag_msgs_;
+	// list of poses of the tags
+	std::map<int, gazebo::msgs::Pose> tag_msgs_;
 
-  // handler function for incoming messages about the tag positions
-  void on_tag_msg(ConstPosePtr &msg);
+	// handler function for incoming messages about the tag positions
+	void on_tag_msg(ConstPosePtr &msg);
 
-  // extract mpsID ordered by tagID
-  std::map<int, std::string> mps_id_;
-  void get_mpsID_by_tagID();
+	// extract mpsID ordered by tagID
+	std::map<int, std::string> mps_id_;
+	void                       get_mpsID_by_tagID();
 
-  // send station msg with pose information to navgraph generator
-  void send_station_msg(int id, gazebo::msgs::Pose pose);
+	// send station msg with pose information to navgraph generator
+	void send_station_msg(int id, gazebo::msgs::Pose pose);
 };
 
 #endif

--- a/src/plugins/gazebo/gazsim-tag-vision/gazsim_tag_vision_plugin.cpp
+++ b/src/plugins/gazebo/gazsim-tag-vision/gazsim_tag_vision_plugin.cpp
@@ -18,9 +18,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "gazsim_tag_vision_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -29,14 +29,16 @@ using namespace fawkes;
  *
  * @author Frederik Zwilling
  */
-class GazsimTagVisionPlugin : public fawkes::Plugin {
+class GazsimTagVisionPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  GazsimTagVisionPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new TagVisionSimThread());
-  }
+	GazsimTagVisionPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new TagVisionSimThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Simulation of the TagVision results")

--- a/src/plugins/gazebo/gazsim-tag-vision/gazsim_tag_vision_thread.cpp
+++ b/src/plugins/gazebo/gazsim-tag-vision/gazsim_tag_vision_thread.cpp
@@ -20,20 +20,19 @@
 
 #include "gazsim_tag_vision_thread.h"
 
+#include <aspect/logging.h>
+#include <interfaces/Position3DInterface.h>
+#include <interfaces/SwitchInterface.h>
+#include <tf/types.h>
+
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/transport/Node.hh>
+#include <gazebo/transport/transport.hh>
 #include <math.h>
 #include <set>
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
-#include <tf/types.h>
-
-#include <interfaces/Position3DInterface.h>
-#include <interfaces/SwitchInterface.h>
-
-#include <aspect/logging.h>
-#include <gazebo/msgs/msgs.hh>
-#include <gazebo/transport/Node.hh>
-#include <gazebo/transport/transport.hh>
 
 using namespace fawkes;
 using namespace gazebo;
@@ -47,170 +46,166 @@ using namespace gazebo;
 
 /** Constructor. */
 TagVisionSimThread::TagVisionSimThread()
-    : Thread("TagVisionSimThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS),
-      TransformAspect(TransformAspect::BOTH, "tags") {}
-
-void TagVisionSimThread::init() {
-  logger->log_debug(name(), "Initializing TagVisionSim Plugin");
-
-  // read config values
-  gazebo_topic_ = config->get_string("/gazsim/topics/tag-vision");
-  tag_if_name_prefix_ =
-      config->get_string("/gazsim/tag-vision/tag-if-name-prefix");
-  info_if_name_ = config->get_string("/gazsim/tag-vision/info-if-name");
-  sim_frame_name_ = config->get_string("/gazsim/tag-vision/frame");
-  frame_name_ = config->get_string("/plugins/tag_vision/frame");
-  number_interfaces_ = config->get_int("/gazsim/tag-vision/number-interfaces");
-  visibility_history_increase_per_update_ = config->get_int(
-      "/gazsim/tag-vision/visibility-history-increase-per-update");
-
-  // open interfaces
-  info_if_ = blackboard->open_for_writing<fawkes::TagVisionInterface>(
-      info_if_name_.c_str());
-  for (int i = 0; i < number_interfaces_; i++) {
-    std::ostringstream ss;
-    ss << tag_if_name_prefix_.c_str() << i;
-    tag_pos_ifs_[i] = blackboard->open_for_writing<fawkes::Position3DInterface>(
-        ss.str().c_str());
-  }
-
-  // subscribing to gazebo tag-vision messages
-  tag_vision_sub_ = gazebonode->Subscribe(
-      gazebo_topic_, &TagVisionSimThread::on_tag_vision_msg, this);
-
-  new_data_ = false;
+: Thread("TagVisionSimThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS),
+  TransformAspect(TransformAspect::BOTH, "tags")
+{
 }
 
-void TagVisionSimThread::finalize() {
-  for (std::map<int, Position3DInterface *>::iterator it = tag_pos_ifs_.begin();
-       it != tag_pos_ifs_.end(); it++) {
-    blackboard->close(it->second);
-  }
-  blackboard->close(info_if_);
+void
+TagVisionSimThread::init()
+{
+	logger->log_debug(name(), "Initializing TagVisionSim Plugin");
+
+	// read config values
+	gazebo_topic_       = config->get_string("/gazsim/topics/tag-vision");
+	tag_if_name_prefix_ = config->get_string("/gazsim/tag-vision/tag-if-name-prefix");
+	info_if_name_       = config->get_string("/gazsim/tag-vision/info-if-name");
+	sim_frame_name_     = config->get_string("/gazsim/tag-vision/frame");
+	frame_name_         = config->get_string("/plugins/tag_vision/frame");
+	number_interfaces_  = config->get_int("/gazsim/tag-vision/number-interfaces");
+	visibility_history_increase_per_update_ =
+	  config->get_int("/gazsim/tag-vision/visibility-history-increase-per-update");
+
+	// open interfaces
+	info_if_ = blackboard->open_for_writing<fawkes::TagVisionInterface>(info_if_name_.c_str());
+	for (int i = 0; i < number_interfaces_; i++) {
+		std::ostringstream ss;
+		ss << tag_if_name_prefix_.c_str() << i;
+		tag_pos_ifs_[i] = blackboard->open_for_writing<fawkes::Position3DInterface>(ss.str().c_str());
+	}
+
+	// subscribing to gazebo tag-vision messages
+	tag_vision_sub_ =
+	  gazebonode->Subscribe(gazebo_topic_, &TagVisionSimThread::on_tag_vision_msg, this);
+
+	new_data_ = false;
 }
 
-void TagVisionSimThread::loop() {
-  if (new_data_) {
-    new_data_ = false;
-    // go through all visible tags and write the data into the interfaces
-    std::set<int> used_ifs;
-    for (int i = 0; i < last_msg_.pose_size(); i++) {
-      gazebo::msgs::Pose pose = last_msg_.pose(i);
-      int tag_id = pose.id();
-      // find associated interface or unused interface index
-      int if_index = -1;
-      if (map_id_if_.find(tag_id) != map_id_if_.end()) {
-        if_index = map_id_if_[tag_id];
-      } else {
-        for (int j = 0; j < number_interfaces_; j++) {
-          if (tag_pos_ifs_[j]->visibility_history() <= 0) {
-            if_index = j;
-            map_id_if_[tag_id] = if_index;
-            break;
-          }
-        }
-      }
-      if (if_index == -1) {
-        // no interface left to write data
-        logger->log_info(name(), "Not enough interfaces to write all tag-poses "
-                                 "to the blackboard.\n");
-        continue;
-      }
-
-      tf::Pose pose_sim_frame(
-          tf::Quaternion(pose.orientation().x(), pose.orientation().y(),
-                         pose.orientation().z(), pose.orientation().w()),
-          tf::Vector3(pose.position().x(), pose.position().y(),
-                      pose.position().z()));
-      Time time(clock);
-      tf::Stamped<tf::Pose> spose_sim_frame(pose_sim_frame, time,
-                                            sim_frame_name_);
-      tf::Stamped<tf::Pose> spose_tag_frame;
-      tf_listener->transform_pose(frame_name_, spose_sim_frame,
-                                  spose_tag_frame);
-
-      // check if nan values are contained
-      if (std::isnan(spose_tag_frame.getOrigin().x()) ||
-          std::isnan(spose_tag_frame.getOrigin().y()) ||
-          std::isnan(spose_tag_frame.getOrigin().z()) ||
-          std::isnan(spose_tag_frame.getRotation().x()) ||
-          std::isnan(spose_tag_frame.getRotation().y()) ||
-          std::isnan(spose_tag_frame.getRotation().z()) ||
-          std::isnan(spose_tag_frame.getRotation().w())) {
-        // skip this tag
-        logger->log_error(
-            name(),
-            "Tag orientation or position is malformed, skipping this tag!");
-        continue;
-      }
-
-      tag_pos_ifs_[if_index]->set_translation(0,
-                                              spose_tag_frame.getOrigin().x());
-      tag_pos_ifs_[if_index]->set_translation(1,
-                                              spose_tag_frame.getOrigin().y());
-      tag_pos_ifs_[if_index]->set_translation(2,
-                                              spose_tag_frame.getOrigin().z());
-      tag_pos_ifs_[if_index]->set_rotation(0,
-                                           spose_tag_frame.getRotation().x());
-      tag_pos_ifs_[if_index]->set_rotation(1,
-                                           spose_tag_frame.getRotation().y());
-      tag_pos_ifs_[if_index]->set_rotation(2,
-                                           spose_tag_frame.getRotation().z());
-      tag_pos_ifs_[if_index]->set_rotation(3,
-                                           spose_tag_frame.getRotation().w());
-      tag_pos_ifs_[if_index]->set_frame(frame_name_.c_str());
-
-      // compute visibility history
-      int current_vis_hist = tag_pos_ifs_[if_index]->visibility_history();
-      if (current_vis_hist < 0) {
-        current_vis_hist = 0;
-      }
-      current_vis_hist += visibility_history_increase_per_update_;
-      tag_pos_ifs_[if_index]->set_visibility_history(current_vis_hist);
-      tag_pos_ifs_[if_index]->write();
-      info_if_->set_tag_id(if_index, tag_id);
-      used_ifs.insert(if_index);
-
-      // publish the transform
-      try {
-        tf::Transform transform(spose_tag_frame.getRotation(),
-                                spose_tag_frame.getOrigin());
-        std::string tag_frame_name =
-            std::string("tag_") + std::to_string(if_index);
-        tf::StampedTransform stamped_transform(transform, time, frame_name_,
-                                               tag_frame_name);
-        tf_publisher->send_transform(stamped_transform);
-      } catch (fawkes::Exception &e) {
-        logger->log_warn(name(), "Failed to send transform, exception follows");
-        logger->log_warn(name(), e);
-      }
-    }
-    // clear tags which became unvisibe and count visible tags
-    int number_found_tags = 0;
-    for (int i = 0; i < number_interfaces_; i++) {
-      if (used_ifs.find(i) == used_ifs.end()) {
-        // compute visibility history
-        int current_vis_hist = tag_pos_ifs_[i]->visibility_history();
-        if (current_vis_hist > 0) {
-          current_vis_hist = 0;
-        }
-        map_id_if_.erase(info_if_->tag_id(i));
-        current_vis_hist -= visibility_history_increase_per_update_;
-        tag_pos_ifs_[i]->set_visibility_history(current_vis_hist);
-        tag_pos_ifs_[i]->write();
-        info_if_->set_tag_id(i, 0);
-      } else {
-        number_found_tags++;
-      }
-    }
-    info_if_->set_tags_visible(number_found_tags);
-    info_if_->write();
-  }
+void
+TagVisionSimThread::finalize()
+{
+	for (std::map<int, Position3DInterface *>::iterator it = tag_pos_ifs_.begin();
+	     it != tag_pos_ifs_.end();
+	     it++) {
+		blackboard->close(it->second);
+	}
+	blackboard->close(info_if_);
 }
 
-void TagVisionSimThread::on_tag_vision_msg(ConstPosesStampedPtr &msg) {
-  // logger->log_info(name(), "Got new TagVision result from gazebo.\n");
-  last_msg_.CopyFrom(*msg);
-  new_data_ = true;
+void
+TagVisionSimThread::loop()
+{
+	if (new_data_) {
+		new_data_ = false;
+		// go through all visible tags and write the data into the interfaces
+		std::set<int> used_ifs;
+		for (int i = 0; i < last_msg_.pose_size(); i++) {
+			gazebo::msgs::Pose pose   = last_msg_.pose(i);
+			int                tag_id = pose.id();
+			// find associated interface or unused interface index
+			int if_index = -1;
+			if (map_id_if_.find(tag_id) != map_id_if_.end()) {
+				if_index = map_id_if_[tag_id];
+			} else {
+				for (int j = 0; j < number_interfaces_; j++) {
+					if (tag_pos_ifs_[j]->visibility_history() <= 0) {
+						if_index           = j;
+						map_id_if_[tag_id] = if_index;
+						break;
+					}
+				}
+			}
+			if (if_index == -1) {
+				// no interface left to write data
+				logger->log_info(name(),
+				                 "Not enough interfaces to write all tag-poses "
+				                 "to the blackboard.\n");
+				continue;
+			}
+
+			tf::Pose              pose_sim_frame(tf::Quaternion(pose.orientation().x(),
+                                             pose.orientation().y(),
+                                             pose.orientation().z(),
+                                             pose.orientation().w()),
+                              tf::Vector3(pose.position().x(),
+                                          pose.position().y(),
+                                          pose.position().z()));
+			Time                  time(clock);
+			tf::Stamped<tf::Pose> spose_sim_frame(pose_sim_frame, time, sim_frame_name_);
+			tf::Stamped<tf::Pose> spose_tag_frame;
+			tf_listener->transform_pose(frame_name_, spose_sim_frame, spose_tag_frame);
+
+			// check if nan values are contained
+			if (std::isnan(spose_tag_frame.getOrigin().x()) || std::isnan(spose_tag_frame.getOrigin().y())
+			    || std::isnan(spose_tag_frame.getOrigin().z())
+			    || std::isnan(spose_tag_frame.getRotation().x())
+			    || std::isnan(spose_tag_frame.getRotation().y())
+			    || std::isnan(spose_tag_frame.getRotation().z())
+			    || std::isnan(spose_tag_frame.getRotation().w())) {
+				// skip this tag
+				logger->log_error(name(), "Tag orientation or position is malformed, skipping this tag!");
+				continue;
+			}
+
+			tag_pos_ifs_[if_index]->set_translation(0, spose_tag_frame.getOrigin().x());
+			tag_pos_ifs_[if_index]->set_translation(1, spose_tag_frame.getOrigin().y());
+			tag_pos_ifs_[if_index]->set_translation(2, spose_tag_frame.getOrigin().z());
+			tag_pos_ifs_[if_index]->set_rotation(0, spose_tag_frame.getRotation().x());
+			tag_pos_ifs_[if_index]->set_rotation(1, spose_tag_frame.getRotation().y());
+			tag_pos_ifs_[if_index]->set_rotation(2, spose_tag_frame.getRotation().z());
+			tag_pos_ifs_[if_index]->set_rotation(3, spose_tag_frame.getRotation().w());
+			tag_pos_ifs_[if_index]->set_frame(frame_name_.c_str());
+
+			// compute visibility history
+			int current_vis_hist = tag_pos_ifs_[if_index]->visibility_history();
+			if (current_vis_hist < 0) {
+				current_vis_hist = 0;
+			}
+			current_vis_hist += visibility_history_increase_per_update_;
+			tag_pos_ifs_[if_index]->set_visibility_history(current_vis_hist);
+			tag_pos_ifs_[if_index]->write();
+			info_if_->set_tag_id(if_index, tag_id);
+			used_ifs.insert(if_index);
+
+			// publish the transform
+			try {
+				tf::Transform        transform(spose_tag_frame.getRotation(), spose_tag_frame.getOrigin());
+				std::string          tag_frame_name = std::string("tag_") + std::to_string(if_index);
+				tf::StampedTransform stamped_transform(transform, time, frame_name_, tag_frame_name);
+				tf_publisher->send_transform(stamped_transform);
+			} catch (fawkes::Exception &e) {
+				logger->log_warn(name(), "Failed to send transform, exception follows");
+				logger->log_warn(name(), e);
+			}
+		}
+		// clear tags which became unvisibe and count visible tags
+		int number_found_tags = 0;
+		for (int i = 0; i < number_interfaces_; i++) {
+			if (used_ifs.find(i) == used_ifs.end()) {
+				// compute visibility history
+				int current_vis_hist = tag_pos_ifs_[i]->visibility_history();
+				if (current_vis_hist > 0) {
+					current_vis_hist = 0;
+				}
+				map_id_if_.erase(info_if_->tag_id(i));
+				current_vis_hist -= visibility_history_increase_per_update_;
+				tag_pos_ifs_[i]->set_visibility_history(current_vis_hist);
+				tag_pos_ifs_[i]->write();
+				info_if_->set_tag_id(i, 0);
+			} else {
+				number_found_tags++;
+			}
+		}
+		info_if_->set_tags_visible(number_found_tags);
+		info_if_->write();
+	}
+}
+
+void
+TagVisionSimThread::on_tag_vision_msg(ConstPosesStampedPtr &msg)
+{
+	// logger->log_info(name(), "Got new TagVision result from gazebo.\n");
+	last_msg_.CopyFrom(*msg);
+	new_data_ = true;
 }

--- a/src/plugins/gazebo/gazsim-tag-vision/gazsim_tag_vision_thread.h
+++ b/src/plugins/gazebo/gazsim-tag-vision/gazsim_tag_vision_thread.h
@@ -30,8 +30,9 @@
 #include <core/threading/thread.h>
 #include <interfaces/Position3DInterface.h>
 #include <interfaces/TagVisionInterface.h>
-#include <map>
 #include <plugins/gazebo/aspect/gazebo.h>
+
+#include <map>
 #include <vector>
 
 // from Gazebo
@@ -50,41 +51,42 @@ class TagVisionSimThread : public fawkes::Thread,
                            public fawkes::BlackBoardAspect,
                            public fawkes::BlockedTimingAspect,
                            public fawkes::GazeboAspect,
-                           public fawkes::TransformAspect {
+                           public fawkes::TransformAspect
+{
 public:
-  TagVisionSimThread();
+	TagVisionSimThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  // Subscriber to receive tag positions from gazebo
-  gazebo::transport::SubscriberPtr tag_vision_sub_;
+	// Subscriber to receive tag positions from gazebo
+	gazebo::transport::SubscriberPtr tag_vision_sub_;
 
-  // interfaces to publish the positions
-  std::map<int, fawkes::Position3DInterface *> tag_pos_ifs_;
-  // switch interface for enableing/disableing
-  fawkes::TagVisionInterface *info_if_;
+	// interfaces to publish the positions
+	std::map<int, fawkes::Position3DInterface *> tag_pos_ifs_;
+	// switch interface for enableing/disableing
+	fawkes::TagVisionInterface *info_if_;
 
-  // handler function for incoming messages about the machine light signals
-  void on_tag_vision_msg(ConstPosesStampedPtr &msg);
+	// handler function for incoming messages about the machine light signals
+	void on_tag_vision_msg(ConstPosesStampedPtr &msg);
 
-  // copy of last msg to write the interface in the next loop
-  gazebo::msgs::PosesStamped last_msg_;
-  bool new_data_;
+	// copy of last msg to write the interface in the next loop
+	gazebo::msgs::PosesStamped last_msg_;
+	bool                       new_data_;
 
-  // config values
-  std::string gazebo_topic_;
-  std::string tag_if_name_prefix_;
-  std::string info_if_name_;
-  std::string sim_frame_name_;
-  std::string frame_name_;
-  int number_interfaces_;
-  int visibility_history_increase_per_update_;
+	// config values
+	std::string gazebo_topic_;
+	std::string tag_if_name_prefix_;
+	std::string info_if_name_;
+	std::string sim_frame_name_;
+	std::string frame_name_;
+	int         number_interfaces_;
+	int         visibility_history_increase_per_update_;
 
-  // assignment tag-id to interface-index
-  std::map<int, int> map_id_if_;
+	// assignment tag-id to interface-index
+	std::map<int, int> map_id_if_;
 };
 
 #endif

--- a/src/plugins/laser_front_dist/laser_front_dist_plugin.cpp
+++ b/src/plugins/laser_front_dist/laser_front_dist_plugin.cpp
@@ -19,23 +19,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "laser_front_dist_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /**Calculates distance to object in front with average of laser beams in front.
  * @author Frederik Zwilling
  */
-class LaserFrontDistPlugin : public fawkes::Plugin {
+class LaserFrontDistPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor
+	/** Constructor
    * @param config Fakwes configuration
    */
-  LaserFrontDistPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new LaserFrontDistThread());
-  }
+	LaserFrontDistPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new LaserFrontDistThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Calculates distance to object in front with average of "

--- a/src/plugins/laser_front_dist/laser_front_dist_thread.cpp
+++ b/src/plugins/laser_front_dist/laser_front_dist_thread.cpp
@@ -22,10 +22,12 @@
  */
 
 #include "laser_front_dist_thread.h"
-#include <cmath>
+
 #include <interfaces/Laser360Interface.h>
 #include <interfaces/Position3DInterface.h>
 #include <tf/types.h>
+
+#include <cmath>
 
 using namespace fawkes;
 
@@ -35,64 +37,68 @@ using namespace fawkes;
  */
 
 LaserFrontDistThread::LaserFrontDistThread()
-    : Thread("LaserFrontDistThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL),
-      TransformAspect(TransformAspect::ONLY_PUBLISHER, "laser-front-dist") {}
-
-void LaserFrontDistThread::init() {
-  // read config values
-  beams_used_ = config->get_int("plugins/laser-front-dist/number_beams_used");
-  target_frame_ = config->get_string("plugins/laser-front-dist/target_frame");
-  // open interfaces
-  if_laser_ = blackboard->open_for_reading<Laser360Interface>(
-      config->get_string("plugins/laser-front-dist/input_laser_interface")
-          .c_str());
-  if_result_ = blackboard->open_for_writing<Position3DInterface>(
-      config->get_string("plugins/laser-front-dist/output_result_interface")
-          .c_str());
+: Thread("LaserFrontDistThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL),
+  TransformAspect(TransformAspect::ONLY_PUBLISHER, "laser-front-dist")
+{
 }
 
-void LaserFrontDistThread::loop() {
-  // calculate average:
-  if_laser_->read();
-  float sum = 0.0;
-  for (int i = 0; i < beams_used_ / 2 + beams_used_ % 2; i++) {
-    if (!std::isnormal(if_laser_->distances(i))) {
-      // this is invalid
-      if_result_->set_visibility_history(-1);
-      if_result_->write();
-      return;
-    }
-    sum += if_laser_->distances(i);
-  }
-  for (int i = 0; i < beams_used_ / 2; i++) {
-    if (!std::isnormal(if_laser_->distances(359 - i))) {
-      // this is invalid
-      if_result_->set_visibility_history(-1);
-      if_result_->write();
-      return;
-    }
-    sum += if_laser_->distances(359 - i);
-  }
-  float average = sum / (float)beams_used_;
-  frame_ = if_laser_->frame();
-
-  // publish transform
-  tf::Transform transform(tf::create_quaternion_from_yaw(M_PI),
-                          tf::Vector3(average, 0, 0));
-  Time time(clock);
-  tf::StampedTransform stamped_transform(transform, time, frame_.c_str(),
-                                         target_frame_.c_str());
-  tf_publisher->send_transform(stamped_transform);
-
-  // write result
-  if_result_->set_visibility_history(1);
-  if_result_->set_translation(0, average);
-  if_result_->set_frame(frame_.c_str());
-  if_result_->write();
+void
+LaserFrontDistThread::init()
+{
+	// read config values
+	beams_used_   = config->get_int("plugins/laser-front-dist/number_beams_used");
+	target_frame_ = config->get_string("plugins/laser-front-dist/target_frame");
+	// open interfaces
+	if_laser_ = blackboard->open_for_reading<Laser360Interface>(
+	  config->get_string("plugins/laser-front-dist/input_laser_interface").c_str());
+	if_result_ = blackboard->open_for_writing<Position3DInterface>(
+	  config->get_string("plugins/laser-front-dist/output_result_interface").c_str());
 }
 
-void LaserFrontDistThread::finalize() {
-  blackboard->close(if_laser_);
-  blackboard->close(if_result_);
+void
+LaserFrontDistThread::loop()
+{
+	// calculate average:
+	if_laser_->read();
+	float sum = 0.0;
+	for (int i = 0; i < beams_used_ / 2 + beams_used_ % 2; i++) {
+		if (!std::isnormal(if_laser_->distances(i))) {
+			// this is invalid
+			if_result_->set_visibility_history(-1);
+			if_result_->write();
+			return;
+		}
+		sum += if_laser_->distances(i);
+	}
+	for (int i = 0; i < beams_used_ / 2; i++) {
+		if (!std::isnormal(if_laser_->distances(359 - i))) {
+			// this is invalid
+			if_result_->set_visibility_history(-1);
+			if_result_->write();
+			return;
+		}
+		sum += if_laser_->distances(359 - i);
+	}
+	float average = sum / (float)beams_used_;
+	frame_        = if_laser_->frame();
+
+	// publish transform
+	tf::Transform        transform(tf::create_quaternion_from_yaw(M_PI), tf::Vector3(average, 0, 0));
+	Time                 time(clock);
+	tf::StampedTransform stamped_transform(transform, time, frame_.c_str(), target_frame_.c_str());
+	tf_publisher->send_transform(stamped_transform);
+
+	// write result
+	if_result_->set_visibility_history(1);
+	if_result_->set_translation(0, average);
+	if_result_->set_frame(frame_.c_str());
+	if_result_->write();
+}
+
+void
+LaserFrontDistThread::finalize()
+{
+	blackboard->close(if_laser_);
+	blackboard->close(if_result_);
 }

--- a/src/plugins/laser_front_dist/laser_front_dist_thread.h
+++ b/src/plugins/laser_front_dist/laser_front_dist_thread.h
@@ -45,26 +45,30 @@ class LaserFrontDistThread : public fawkes::Thread,
                              public fawkes::ClockAspect,
                              public fawkes::ConfigurableAspect,
                              public fawkes::BlackBoardAspect,
-                             public fawkes::TransformAspect {
-
+                             public fawkes::TransformAspect
+{
 public:
-  LaserFrontDistThread();
+	LaserFrontDistThread();
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  // Define class member variables here
-  fawkes::Laser360Interface *if_laser_;
-  fawkes::Position3DInterface *if_result_;
-  std::string frame_;
-  int beams_used_;
-  std::string target_frame_;
+	// Define class member variables here
+	fawkes::Laser360Interface *  if_laser_;
+	fawkes::Position3DInterface *if_result_;
+	std::string                  frame_;
+	int                          beams_used_;
+	std::string                  target_frame_;
 };
 
 #endif

--- a/src/plugins/marker_writer/marker_writer_plugin.cpp
+++ b/src/plugins/marker_writer/marker_writer_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "marker_writer_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Visualize selected Position3dInterfaces in RVIZ
  * @author Daniel Ewert
  */
-class MarkerWriterPlugin : public fawkes::Plugin {
+class MarkerWriterPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  MarkerWriterPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new MarkerWriterThread());
-  }
+	MarkerWriterPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new MarkerWriterThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("write markers to rviz")

--- a/src/plugins/marker_writer/marker_writer_thread.cpp
+++ b/src/plugins/marker_writer/marker_writer_thread.cpp
@@ -21,10 +21,11 @@
 
 #include "marker_writer_thread.h"
 
-#include <cmath>
 #include <interfaces/Position3DInterface.h>
 #include <ros/ros.h>
 #include <visualization_msgs/MarkerArray.h>
+
+#include <cmath>
 
 #define CFG_PREFIX "/plugins/markerwriter/"
 
@@ -38,112 +39,119 @@ using namespace std;
 
 /** Constructor. */
 MarkerWriterThread::MarkerWriterThread()
-    : Thread("MarkerWriterThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL) {
-
-  pub_ = new ros::Publisher();
+: Thread("MarkerWriterThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
+	pub_ = new ros::Publisher();
 }
 
-void MarkerWriterThread::init() {
-  cfg_duration_ = config->get_float(CFG_PREFIX "display_duration");
-  cfg_ignore_visibillity_ =
-      config->get_bool(CFG_PREFIX "ignore_visibility_history");
+void
+MarkerWriterThread::init()
+{
+	cfg_duration_           = config->get_float(CFG_PREFIX "display_duration");
+	cfg_ignore_visibillity_ = config->get_bool(CFG_PREFIX "ignore_visibility_history");
 
-  *pub_ = rosnode->advertise<visualization_msgs::MarkerArray>(
-      "Position3dInterface_marker_array", 100);
+	*pub_ =
+	  rosnode->advertise<visualization_msgs::MarkerArray>("Position3dInterface_marker_array", 100);
 
-  string wildcard_pattern = config->get_string(CFG_PREFIX "wildcard_pattern");
-  pos_ifs_ = blackboard->open_multiple_for_reading<Position3DInterface>(
-      wildcard_pattern.c_str());
-  for (Position3DInterface *pos_if : pos_ifs_) {
-    logger->log_debug(name(), "visualizing %s", pos_if->id());
-  }
+	string wildcard_pattern = config->get_string(CFG_PREFIX "wildcard_pattern");
+	pos_ifs_ = blackboard->open_multiple_for_reading<Position3DInterface>(wildcard_pattern.c_str());
+	for (Position3DInterface *pos_if : pos_ifs_) {
+		logger->log_debug(name(), "visualizing %s", pos_if->id());
+	}
 }
 
-bool MarkerWriterThread::prepare_finalize_user() { return true; }
-
-void MarkerWriterThread::finalize() {
-  for (Position3DInterface *pos_if : pos_ifs_) {
-    blackboard->close(pos_if);
-  }
-  pub_->shutdown();
-  delete pub_;
-  delete &pos_ifs_;
+bool
+MarkerWriterThread::prepare_finalize_user()
+{
+	return true;
 }
 
-void MarkerWriterThread::loop() {
-  unsigned int idnum = 0;
-  visualization_msgs::MarkerArray m;
-  for (Position3DInterface *pos_if : pos_ifs_) {
-    pos_if->read();
+void
+MarkerWriterThread::finalize()
+{
+	for (Position3DInterface *pos_if : pos_ifs_) {
+		blackboard->close(pos_if);
+	}
+	pub_->shutdown();
+	delete pub_;
+	delete &pos_ifs_;
+}
 
-    if (cfg_ignore_visibillity_ || pos_if->visibility_history() > 0) {
-      visualization_msgs::Marker text;
-      text.header.frame_id = "/base_link";
-      text.header.stamp = ros::Time::now();
-      text.ns = "robotino";
-      text.id = idnum++;
-      text.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-      text.action = visualization_msgs::Marker::ADD;
-      text.pose.position.x = pos_if->translation(0);
-      text.pose.position.y = pos_if->translation(1);
-      text.pose.position.z = pos_if->translation(2) + 0.13;
-      text.pose.orientation.w = 1.;
-      text.scale.z = 0.05; // 5cm high
-      text.color.r = text.color.g = text.color.b = 1.0f;
-      text.color.a = 1.0;
-      text.lifetime = ros::Duration(cfg_duration_, 0);
-      text.text = pos_if->id();
-      m.markers.push_back(text);
+void
+MarkerWriterThread::loop()
+{
+	unsigned int                    idnum = 0;
+	visualization_msgs::MarkerArray m;
+	for (Position3DInterface *pos_if : pos_ifs_) {
+		pos_if->read();
 
-      visualization_msgs::Marker sphere;
-      sphere.header.frame_id = "/base_link";
-      sphere.header.stamp = ros::Time::now();
-      sphere.ns = "robotino";
-      sphere.id = idnum++;
-      sphere.type = visualization_msgs::Marker::CYLINDER;
-      sphere.action = visualization_msgs::Marker::ADD;
-      sphere.pose.position.x = pos_if->translation(0);
-      sphere.pose.position.y = pos_if->translation(1);
-      sphere.pose.position.z = pos_if->translation(2);
-      sphere.pose.orientation.w = 1.;
-      sphere.scale.x = sphere.scale.y = 0.08;
-      sphere.scale.z = 0.09;
-      sphere.color.r = 1.f;
-      sphere.color.g = 0.f;
-      sphere.color.b = 0.f;
-      sphere.color.a = 1.0;
-      sphere.lifetime = ros::Duration(cfg_duration_, 0);
-      m.markers.push_back(sphere);
+		if (cfg_ignore_visibillity_ || pos_if->visibility_history() > 0) {
+			visualization_msgs::Marker text;
+			text.header.frame_id    = "/base_link";
+			text.header.stamp       = ros::Time::now();
+			text.ns                 = "robotino";
+			text.id                 = idnum++;
+			text.type               = visualization_msgs::Marker::TEXT_VIEW_FACING;
+			text.action             = visualization_msgs::Marker::ADD;
+			text.pose.position.x    = pos_if->translation(0);
+			text.pose.position.y    = pos_if->translation(1);
+			text.pose.position.z    = pos_if->translation(2) + 0.13;
+			text.pose.orientation.w = 1.;
+			text.scale.z            = 0.05; // 5cm high
+			text.color.r = text.color.g = text.color.b = 1.0f;
+			text.color.a                               = 1.0;
+			text.lifetime                              = ros::Duration(cfg_duration_, 0);
+			text.text                                  = pos_if->id();
+			m.markers.push_back(text);
 
-      if (pos_if->rotation(0) != 0 || pos_if->rotation(1) != 0 ||
-          pos_if->rotation(2) != 0) {
-        // if object has a orientation visualize it
-        visualization_msgs::Marker arrow;
-        arrow.header.frame_id = "/base_link";
-        arrow.header.stamp = ros::Time::now();
-        arrow.ns = "robotino";
-        arrow.id = idnum++;
-        arrow.type = visualization_msgs::Marker::ARROW;
-        arrow.action = visualization_msgs::Marker::ADD;
-        arrow.pose.position.x = pos_if->translation(0);
-        arrow.pose.position.y = pos_if->translation(1);
-        arrow.pose.position.z = pos_if->translation(2);
-        arrow.pose.orientation.x = pos_if->rotation(0);
-        arrow.pose.orientation.y = pos_if->rotation(1);
-        arrow.pose.orientation.z = pos_if->rotation(2);
-        arrow.pose.orientation.w = 1.;
-        arrow.scale.x = sphere.scale.y = 0.08;
-        arrow.scale.z = 0.09;
-        arrow.color.r = 1.f;
-        arrow.color.g = 1.f;
-        arrow.color.b = 0.f;
-        arrow.color.a = 1.0;
-        arrow.lifetime = ros::Duration(cfg_duration_, 0);
+			visualization_msgs::Marker sphere;
+			sphere.header.frame_id    = "/base_link";
+			sphere.header.stamp       = ros::Time::now();
+			sphere.ns                 = "robotino";
+			sphere.id                 = idnum++;
+			sphere.type               = visualization_msgs::Marker::CYLINDER;
+			sphere.action             = visualization_msgs::Marker::ADD;
+			sphere.pose.position.x    = pos_if->translation(0);
+			sphere.pose.position.y    = pos_if->translation(1);
+			sphere.pose.position.z    = pos_if->translation(2);
+			sphere.pose.orientation.w = 1.;
+			sphere.scale.x = sphere.scale.y = 0.08;
+			sphere.scale.z                  = 0.09;
+			sphere.color.r                  = 1.f;
+			sphere.color.g                  = 0.f;
+			sphere.color.b                  = 0.f;
+			sphere.color.a                  = 1.0;
+			sphere.lifetime                 = ros::Duration(cfg_duration_, 0);
+			m.markers.push_back(sphere);
 
-        m.markers.push_back(arrow);
-      }
-    }
-    pub_->publish(m);
-  }
+			if (pos_if->rotation(0) != 0 || pos_if->rotation(1) != 0 || pos_if->rotation(2) != 0) {
+				// if object has a orientation visualize it
+				visualization_msgs::Marker arrow;
+				arrow.header.frame_id    = "/base_link";
+				arrow.header.stamp       = ros::Time::now();
+				arrow.ns                 = "robotino";
+				arrow.id                 = idnum++;
+				arrow.type               = visualization_msgs::Marker::ARROW;
+				arrow.action             = visualization_msgs::Marker::ADD;
+				arrow.pose.position.x    = pos_if->translation(0);
+				arrow.pose.position.y    = pos_if->translation(1);
+				arrow.pose.position.z    = pos_if->translation(2);
+				arrow.pose.orientation.x = pos_if->rotation(0);
+				arrow.pose.orientation.y = pos_if->rotation(1);
+				arrow.pose.orientation.z = pos_if->rotation(2);
+				arrow.pose.orientation.w = 1.;
+				arrow.scale.x = sphere.scale.y = 0.08;
+				arrow.scale.z                  = 0.09;
+				arrow.color.r                  = 1.f;
+				arrow.color.g                  = 1.f;
+				arrow.color.b                  = 0.f;
+				arrow.color.a                  = 1.0;
+				arrow.lifetime                 = ros::Duration(cfg_duration_, 0);
+
+				m.markers.push_back(arrow);
+			}
+		}
+		pub_->publish(m);
+	}
 }

--- a/src/plugins/marker_writer/marker_writer_thread.h
+++ b/src/plugins/marker_writer/marker_writer_thread.h
@@ -45,26 +45,30 @@ class MarkerWriterThread : public fawkes::Thread,
                            public fawkes::LoggingAspect,
                            public fawkes::ConfigurableAspect,
                            public fawkes::BlackBoardAspect,
-                           public fawkes::ROSAspect {
-
+                           public fawkes::ROSAspect
+{
 public:
-  MarkerWriterThread();
+	MarkerWriterThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual bool prepare_finalize_user();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual bool prepare_finalize_user();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  std::list<fawkes::Position3DInterface *> pos_ifs_;
+	std::list<fawkes::Position3DInterface *> pos_ifs_;
 
-  ros::Publisher *pub_;
-  float cfg_duration_;
-  bool cfg_ignore_visibillity_;
+	ros::Publisher *pub_;
+	float           cfg_duration_;
+	bool            cfg_ignore_visibillity_;
 };
 
 #endif

--- a/src/plugins/motor-led/motor_led_plugin.cpp
+++ b/src/plugins/motor-led/motor_led_plugin.cpp
@@ -20,25 +20,27 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "motor_led_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Plugin to indicate motor status by LED.
  * @author Tim Niemueller
  */
-class MotorLedPlugin : public fawkes::Plugin {
+class MotorLedPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  MotorLedPlugin(Configuration *config) : Plugin(config) {
-    std::string cfg_driver = config->get_string("/hardware/robotino/driver");
+	MotorLedPlugin(Configuration *config) : Plugin(config)
+	{
+		std::string cfg_driver = config->get_string("/hardware/robotino/driver");
 
-    thread_list.push_back(new MotorLedThread());
-  }
+		thread_list.push_back(new MotorLedThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Indicate motor status through LED")

--- a/src/plugins/motor-led/motor_led_thread.cpp
+++ b/src/plugins/motor-led/motor_led_thread.cpp
@@ -33,44 +33,48 @@ using namespace fawkes;
 
 /** Constructor. */
 MotorLedThread::MotorLedThread()
-    : Thread("MotorLedThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT) {}
-
-void MotorLedThread::init() {
-  cfg_motor_ifid_ = config->get_string("/motor-led/motor-interface-id");
-  cfg_rsens_ifid_ = config->get_string("/motor-led/sensor-interface-id");
-  cfg_digital_out_ = config->get_uint("/motor-led/digital-out");
-
-  motor_if_ =
-      blackboard->open_for_reading<MotorInterface>(cfg_motor_ifid_.c_str());
-  rsens_if_ = blackboard->open_for_reading<RobotinoSensorInterface>(
-      cfg_rsens_ifid_.c_str());
+: Thread("MotorLedThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT)
+{
 }
 
-void MotorLedThread::finalize() {
-  blackboard->close(motor_if_);
-  blackboard->close(rsens_if_);
+void
+MotorLedThread::init()
+{
+	cfg_motor_ifid_  = config->get_string("/motor-led/motor-interface-id");
+	cfg_rsens_ifid_  = config->get_string("/motor-led/sensor-interface-id");
+	cfg_digital_out_ = config->get_uint("/motor-led/digital-out");
+
+	motor_if_ = blackboard->open_for_reading<MotorInterface>(cfg_motor_ifid_.c_str());
+	rsens_if_ = blackboard->open_for_reading<RobotinoSensorInterface>(cfg_rsens_ifid_.c_str());
 }
 
-void MotorLedThread::loop() {
-  if (rsens_if_->has_writer()) {
-    motor_if_->read();
-    rsens_if_->read();
+void
+MotorLedThread::finalize()
+{
+	blackboard->close(motor_if_);
+	blackboard->close(rsens_if_);
+}
 
-    // -1: to map port names to interface positions
+void
+MotorLedThread::loop()
+{
+	if (rsens_if_->has_writer()) {
+		motor_if_->read();
+		rsens_if_->read();
 
-    if (motor_if_->motor_state() == MotorInterface::MOTOR_DISABLED &&
-        !rsens_if_->is_digital_out(cfg_digital_out_ - 1)) {
-      RobotinoSensorInterface::SetDigitalOutputMessage *msg =
-          new RobotinoSensorInterface::SetDigitalOutputMessage(cfg_digital_out_,
-                                                               true);
-      rsens_if_->msgq_enqueue(msg);
-    } else if (motor_if_->motor_state() == MotorInterface::MOTOR_ENABLED &&
-               rsens_if_->is_digital_out(cfg_digital_out_ - 1)) {
-      RobotinoSensorInterface::SetDigitalOutputMessage *msg =
-          new RobotinoSensorInterface::SetDigitalOutputMessage(cfg_digital_out_,
-                                                               false);
-      rsens_if_->msgq_enqueue(msg);
-    }
-  }
+		// -1: to map port names to interface positions
+
+		if (motor_if_->motor_state() == MotorInterface::MOTOR_DISABLED
+		    && !rsens_if_->is_digital_out(cfg_digital_out_ - 1)) {
+			RobotinoSensorInterface::SetDigitalOutputMessage *msg =
+			  new RobotinoSensorInterface::SetDigitalOutputMessage(cfg_digital_out_, true);
+			rsens_if_->msgq_enqueue(msg);
+		} else if (motor_if_->motor_state() == MotorInterface::MOTOR_ENABLED
+		           && rsens_if_->is_digital_out(cfg_digital_out_ - 1)) {
+			RobotinoSensorInterface::SetDigitalOutputMessage *msg =
+			  new RobotinoSensorInterface::SetDigitalOutputMessage(cfg_digital_out_, false);
+			rsens_if_->msgq_enqueue(msg);
+		}
+	}
 }

--- a/src/plugins/motor-led/motor_led_thread.h
+++ b/src/plugins/motor-led/motor_led_thread.h
@@ -37,25 +37,30 @@ class MotorLedThread : public fawkes::Thread,
                        public fawkes::LoggingAspect,
                        public fawkes::ConfigurableAspect,
                        public fawkes::BlockedTimingAspect,
-                       public fawkes::BlackBoardAspect {
+                       public fawkes::BlackBoardAspect
+{
 public:
-  MotorLedThread();
+	MotorLedThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  std::string cfg_motor_ifid_;
-  std::string cfg_rsens_ifid_;
-  unsigned int cfg_digital_out_;
+	std::string  cfg_motor_ifid_;
+	std::string  cfg_rsens_ifid_;
+	unsigned int cfg_digital_out_;
 
-  fawkes::MotorInterface *motor_if_;
-  fawkes::RobotinoSensorInterface *rsens_if_;
+	fawkes::MotorInterface *         motor_if_;
+	fawkes::RobotinoSensorInterface *rsens_if_;
 };
 
 #endif

--- a/src/plugins/mps-laser-gen/mps-laser-gen_plugin.cpp
+++ b/src/plugins/mps-laser-gen/mps-laser-gen_plugin.cpp
@@ -19,23 +19,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "mps-laser-gen_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Plugin to generate virtual laser data based on known MPS positions.
  * @author Tim Niemueller
  */
-class MPSLaserGenPlugin : public fawkes::Plugin {
+class MPSLaserGenPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor
+	/** Constructor
    * @param config Fakwes configuration
    */
-  MPSLaserGenPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new MPSLaserGenThread());
-  }
+	MPSLaserGenPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new MPSLaserGenThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Generate virtual laser data for known MPS")

--- a/src/plugins/mps-laser-gen/mps-laser-gen_thread.cpp
+++ b/src/plugins/mps-laser-gen/mps-laser-gen_thread.cpp
@@ -24,12 +24,11 @@
 #include "mps-laser-gen_thread.h"
 
 #include <navgraph/navgraph.h>
+#include <ros/ros.h>
 #include <tf/types.h>
 #include <utils/math/angle.h>
 #include <utils/math/lines.h>
 #include <utils/time/time.h>
-
-#include <ros/ros.h>
 #include <visualization_msgs/MarkerArray.h>
 
 #include <Eigen/Geometry>
@@ -37,18 +36,19 @@
 using namespace fawkes;
 
 /// @cond INTERNAL
-class MPS {
+class MPS
+{
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  Eigen::Vector2f center;
-  Eigen::Vector2f corners[4];
+	Eigen::Vector2f center;
+	Eigen::Vector2f corners[4];
 
-  unsigned int closest_idx;
-  unsigned int adjacent_1;
-  unsigned int adjacent_2;
+	unsigned int closest_idx;
+	unsigned int adjacent_1;
+	unsigned int adjacent_2;
 
-  float bearing;
+	float bearing;
 };
 /// @endcond
 
@@ -58,212 +58,217 @@ public:
  */
 
 MPSLaserGenThread::MPSLaserGenThread()
-    : Thread("MPSLaserGenThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_ACQUIRE),
-      TransformAspect(TransformAspect::ONLY_LISTENER) {}
-
-void MPSLaserGenThread::init() {
-  vispub_ = rosnode->advertise<visualization_msgs::MarkerArray>(
-      "visualization_marker_array", 100, /* latching */ true);
-
-  laser_if_ = blackboard->open_for_writing<Laser360Interface>("Laser MPS");
+: Thread("MPSLaserGenThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_ACQUIRE),
+  TransformAspect(TransformAspect::ONLY_LISTENER)
+{
 }
 
-void MPSLaserGenThread::loop() {
-  navgraph.lock();
-  std::vector<fawkes::NavGraphNode> nodes = navgraph->nodes();
-  navgraph.unlock();
+void
+MPSLaserGenThread::init()
+{
+	vispub_ = rosnode->advertise<visualization_msgs::MarkerArray>("visualization_marker_array",
+	                                                              100,
+	                                                              /* latching */ true);
 
-  const float mps_length = 0.70;
-  const float mps_width = 0.34;
-
-  const float mps_length_2 = mps_length / 2.;
-  const float mps_width_2 = mps_width / 2.;
-
-  std::string global_frame = "map";
-  std::string sensor_frame = "base_link";
-
-  float data[360];
-  for (unsigned int i = 0; i < 360; ++i)
-    data[i] = std::numeric_limits<float>::quiet_NaN();
-
-  fawkes::Time source_time(0, 0);
-  tf::StampedTransform tf_transform;
-  try {
-    tf_listener->lookup_transform(sensor_frame, global_frame, source_time,
-                                  tf_transform);
-  } catch (Exception &e) {
-    laser_if_->set_frame(sensor_frame.c_str());
-    laser_if_->set_distances(data);
-    laser_if_->write();
-    logger->log_warn(
-        name(), "Failed to acquire transform for sensor frame, skipping loop");
-    return;
-  }
-
-  Eigen::Rotation2Df sensor_rotation(tf::get_yaw(tf_transform.getRotation()));
-  Eigen::Translation2f sensor_translation(tf_transform.getOrigin().x(),
-                                          tf_transform.getOrigin().y());
-
-  Eigen::Transform<float, 2, Eigen::Affine> transform =
-      sensor_translation * sensor_rotation;
-
-  visualization_msgs::MarkerArray m;
-  // #if ROS_VERSION_MINIMUM(1,10,0)
-  //   {
-  // 	  visualization_msgs::Marker delop;
-  // 	  delop.header.frame_id = "map";
-  // 	  delop.header.stamp = ros::Time::now();
-  // 	  delop.ns = "mps-laser-gen";
-  // 	  delop.id = 0;
-  // 	  delop.action = 3; // visualization_msgs::Marker::DELETEALL;
-  // 	  m.markers.push_back(delop);
-  //   }
-  // #endif
-  size_t id_num = 0;
-
-  std::map<std::string, MPS> mpses;
-
-  for (const fawkes::NavGraphNode &n : nodes) {
-    if (n.has_property("mps") && n.property_as_bool("mps")) {
-      float ori = 0.;
-      if (n.has_property("orientation")) {
-        ori = n.property_as_float("orientation");
-      }
-
-      MPS mps;
-      mps.center = transform * Eigen::Vector2f(n.x(), n.y());
-      mps.corners[0] =
-          sensor_rotation * Eigen::Vector2f(mps_width_2, -mps_length_2);
-      mps.corners[1] =
-          sensor_rotation * Eigen::Vector2f(-mps_width_2, -mps_length_2);
-      mps.corners[2] =
-          sensor_rotation * Eigen::Vector2f(-mps_width_2, mps_length_2);
-      mps.corners[3] =
-          sensor_rotation * Eigen::Vector2f(mps_width_2, mps_length_2);
-
-      Eigen::Rotation2Df rot(ori);
-
-      mps.corners[0] = (rot * mps.corners[0]) + mps.center;
-      mps.corners[1] = (rot * mps.corners[1]) + mps.center;
-      mps.corners[2] = (rot * mps.corners[2]) + mps.center;
-      mps.corners[3] = (rot * mps.corners[3]) + mps.center;
-
-      float dists[4] = {mps.corners[0].norm(), mps.corners[1].norm(),
-                        mps.corners[2].norm(), mps.corners[3].norm()};
-      mps.closest_idx = 0;
-      for (unsigned int i = 1; i < 4; ++i) {
-        if (dists[i] < dists[mps.closest_idx])
-          mps.closest_idx = i;
-      }
-
-      mps.adjacent_1 = (mps.closest_idx == 0) ? 3 : mps.closest_idx - 1;
-      mps.adjacent_2 = (mps.closest_idx == 3) ? 0 : mps.closest_idx + 1;
-
-      mps.bearing = atan2f(mps.corners[mps.closest_idx][1],
-                           mps.corners[mps.closest_idx][0]);
-      // logger->log_info(name(), "Station %s bearing %f", n.name().c_str(),
-      // mps.bearing);
-
-      mpses[n.name()] = mps;
-
-      {
-        visualization_msgs::Marker sphere;
-        sphere.header.frame_id = sensor_frame;
-        sphere.header.stamp = ros::Time::now();
-        sphere.ns = "mps-laser-gen";
-        sphere.id = id_num++;
-        sphere.type = visualization_msgs::Marker::SPHERE;
-        sphere.action = visualization_msgs::Marker::ADD;
-        sphere.pose.position.x = mps.center[0];
-        sphere.pose.position.y = mps.center[1];
-        sphere.pose.position.z = 0.;
-        sphere.pose.orientation.w = 1.;
-        sphere.scale.x = sphere.scale.y = sphere.scale.z = 0.1;
-        sphere.color.r = 0.f;
-        sphere.color.g = 1.f;
-        sphere.color.b = 0.f;
-        sphere.color.a = 1.0;
-        sphere.lifetime = ros::Duration(0, 0);
-        m.markers.push_back(sphere);
-      }
-
-      for (unsigned int i = 0; i < 4; ++i) {
-        visualization_msgs::Marker sphere;
-        sphere.header.frame_id = sensor_frame;
-        sphere.header.stamp = ros::Time::now();
-        sphere.ns = "mps-laser-gen";
-        sphere.id = id_num++;
-        sphere.type = visualization_msgs::Marker::SPHERE;
-        sphere.action = visualization_msgs::Marker::ADD;
-        sphere.pose.position.x = mps.corners[i][0];
-        sphere.pose.position.y = mps.corners[i][1];
-        sphere.pose.position.z = 0.;
-        sphere.pose.orientation.w = 1.;
-        sphere.scale.x = sphere.scale.y = sphere.scale.z = 0.05;
-        if (i == mps.closest_idx) {
-          sphere.color.r = 0.f;
-          sphere.color.b = 1.f;
-        } else if (i == mps.adjacent_1 || i == mps.adjacent_2) {
-          sphere.color.r = 1.f;
-          sphere.color.b = 1.f;
-        } else {
-          sphere.color.r = 1.f;
-          sphere.color.b = 0.f;
-        }
-        sphere.color.g = 0.f;
-        sphere.color.a = 1.0;
-        sphere.lifetime = ros::Duration(0, 0);
-        m.markers.push_back(sphere);
-      }
-    }
-  }
-
-  for (unsigned int i = 0; i < 360; ++i) {
-    float a = normalize_mirror_rad(deg2rad(i));
-
-    for (const auto &mps : mpses) {
-      if ((a - mps.second.bearing) < 0.3) {
-        // Consider
-        Eigen::Vector2f beam(20., 0);
-        beam = Eigen::Rotation2Df(a) * beam;
-        Eigen::Vector2f intersect_1 =
-            line_segm_intersection(mps.second.corners[mps.second.closest_idx],
-                                   mps.second.corners[mps.second.adjacent_1],
-                                   Eigen::Vector2f(0, 0), beam);
-        if (intersect_1.allFinite()) {
-          float l = intersect_1.norm();
-          if (std::isnan(data[i]) || l < data[i])
-            data[i] = l;
-        }
-
-        Eigen::Vector2f intersect_2 =
-            line_segm_intersection(mps.second.corners[mps.second.closest_idx],
-                                   mps.second.corners[mps.second.adjacent_2],
-                                   Eigen::Vector2f(0, 0), beam);
-        if (intersect_2.allFinite()) {
-          float l = intersect_2.norm();
-          if (std::isnan(data[i]) || l < data[i])
-            data[i] = l;
-        }
-      }
-    }
-  }
-  laser_if_->set_frame(sensor_frame.c_str());
-  laser_if_->set_distances(data);
-  laser_if_->write();
-
-  vispub_.publish(m);
+	laser_if_ = blackboard->open_for_writing<Laser360Interface>("Laser MPS");
 }
 
-void MPSLaserGenThread::finalize() {
-  float data[360];
-  for (unsigned int i = 0; i < 360; ++i)
-    data[i] = std::numeric_limits<float>::quiet_NaN();
-  laser_if_->set_frame("");
-  laser_if_->set_distances(data);
-  laser_if_->write();
+void
+MPSLaserGenThread::loop()
+{
+	navgraph.lock();
+	std::vector<fawkes::NavGraphNode> nodes = navgraph->nodes();
+	navgraph.unlock();
 
-  vispub_.shutdown();
-  blackboard->close(laser_if_);
+	const float mps_length = 0.70;
+	const float mps_width  = 0.34;
+
+	const float mps_length_2 = mps_length / 2.;
+	const float mps_width_2  = mps_width / 2.;
+
+	std::string global_frame = "map";
+	std::string sensor_frame = "base_link";
+
+	float data[360];
+	for (unsigned int i = 0; i < 360; ++i)
+		data[i] = std::numeric_limits<float>::quiet_NaN();
+
+	fawkes::Time         source_time(0, 0);
+	tf::StampedTransform tf_transform;
+	try {
+		tf_listener->lookup_transform(sensor_frame, global_frame, source_time, tf_transform);
+	} catch (Exception &e) {
+		laser_if_->set_frame(sensor_frame.c_str());
+		laser_if_->set_distances(data);
+		laser_if_->write();
+		logger->log_warn(name(), "Failed to acquire transform for sensor frame, skipping loop");
+		return;
+	}
+
+	Eigen::Rotation2Df   sensor_rotation(tf::get_yaw(tf_transform.getRotation()));
+	Eigen::Translation2f sensor_translation(tf_transform.getOrigin().x(),
+	                                        tf_transform.getOrigin().y());
+
+	Eigen::Transform<float, 2, Eigen::Affine> transform = sensor_translation * sensor_rotation;
+
+	visualization_msgs::MarkerArray m;
+	// #if ROS_VERSION_MINIMUM(1,10,0)
+	//   {
+	// 	  visualization_msgs::Marker delop;
+	// 	  delop.header.frame_id = "map";
+	// 	  delop.header.stamp = ros::Time::now();
+	// 	  delop.ns = "mps-laser-gen";
+	// 	  delop.id = 0;
+	// 	  delop.action = 3; // visualization_msgs::Marker::DELETEALL;
+	// 	  m.markers.push_back(delop);
+	//   }
+	// #endif
+	size_t id_num = 0;
+
+	std::map<std::string, MPS> mpses;
+
+	for (const fawkes::NavGraphNode &n : nodes) {
+		if (n.has_property("mps") && n.property_as_bool("mps")) {
+			float ori = 0.;
+			if (n.has_property("orientation")) {
+				ori = n.property_as_float("orientation");
+			}
+
+			MPS mps;
+			mps.center     = transform * Eigen::Vector2f(n.x(), n.y());
+			mps.corners[0] = sensor_rotation * Eigen::Vector2f(mps_width_2, -mps_length_2);
+			mps.corners[1] = sensor_rotation * Eigen::Vector2f(-mps_width_2, -mps_length_2);
+			mps.corners[2] = sensor_rotation * Eigen::Vector2f(-mps_width_2, mps_length_2);
+			mps.corners[3] = sensor_rotation * Eigen::Vector2f(mps_width_2, mps_length_2);
+
+			Eigen::Rotation2Df rot(ori);
+
+			mps.corners[0] = (rot * mps.corners[0]) + mps.center;
+			mps.corners[1] = (rot * mps.corners[1]) + mps.center;
+			mps.corners[2] = (rot * mps.corners[2]) + mps.center;
+			mps.corners[3] = (rot * mps.corners[3]) + mps.center;
+
+			float dists[4]  = {mps.corners[0].norm(),
+                        mps.corners[1].norm(),
+                        mps.corners[2].norm(),
+                        mps.corners[3].norm()};
+			mps.closest_idx = 0;
+			for (unsigned int i = 1; i < 4; ++i) {
+				if (dists[i] < dists[mps.closest_idx])
+					mps.closest_idx = i;
+			}
+
+			mps.adjacent_1 = (mps.closest_idx == 0) ? 3 : mps.closest_idx - 1;
+			mps.adjacent_2 = (mps.closest_idx == 3) ? 0 : mps.closest_idx + 1;
+
+			mps.bearing = atan2f(mps.corners[mps.closest_idx][1], mps.corners[mps.closest_idx][0]);
+			// logger->log_info(name(), "Station %s bearing %f", n.name().c_str(),
+			// mps.bearing);
+
+			mpses[n.name()] = mps;
+
+			{
+				visualization_msgs::Marker sphere;
+				sphere.header.frame_id    = sensor_frame;
+				sphere.header.stamp       = ros::Time::now();
+				sphere.ns                 = "mps-laser-gen";
+				sphere.id                 = id_num++;
+				sphere.type               = visualization_msgs::Marker::SPHERE;
+				sphere.action             = visualization_msgs::Marker::ADD;
+				sphere.pose.position.x    = mps.center[0];
+				sphere.pose.position.y    = mps.center[1];
+				sphere.pose.position.z    = 0.;
+				sphere.pose.orientation.w = 1.;
+				sphere.scale.x = sphere.scale.y = sphere.scale.z = 0.1;
+				sphere.color.r                                   = 0.f;
+				sphere.color.g                                   = 1.f;
+				sphere.color.b                                   = 0.f;
+				sphere.color.a                                   = 1.0;
+				sphere.lifetime                                  = ros::Duration(0, 0);
+				m.markers.push_back(sphere);
+			}
+
+			for (unsigned int i = 0; i < 4; ++i) {
+				visualization_msgs::Marker sphere;
+				sphere.header.frame_id    = sensor_frame;
+				sphere.header.stamp       = ros::Time::now();
+				sphere.ns                 = "mps-laser-gen";
+				sphere.id                 = id_num++;
+				sphere.type               = visualization_msgs::Marker::SPHERE;
+				sphere.action             = visualization_msgs::Marker::ADD;
+				sphere.pose.position.x    = mps.corners[i][0];
+				sphere.pose.position.y    = mps.corners[i][1];
+				sphere.pose.position.z    = 0.;
+				sphere.pose.orientation.w = 1.;
+				sphere.scale.x = sphere.scale.y = sphere.scale.z = 0.05;
+				if (i == mps.closest_idx) {
+					sphere.color.r = 0.f;
+					sphere.color.b = 1.f;
+				} else if (i == mps.adjacent_1 || i == mps.adjacent_2) {
+					sphere.color.r = 1.f;
+					sphere.color.b = 1.f;
+				} else {
+					sphere.color.r = 1.f;
+					sphere.color.b = 0.f;
+				}
+				sphere.color.g  = 0.f;
+				sphere.color.a  = 1.0;
+				sphere.lifetime = ros::Duration(0, 0);
+				m.markers.push_back(sphere);
+			}
+		}
+	}
+
+	for (unsigned int i = 0; i < 360; ++i) {
+		float a = normalize_mirror_rad(deg2rad(i));
+
+		for (const auto &mps : mpses) {
+			if ((a - mps.second.bearing) < 0.3) {
+				// Consider
+				Eigen::Vector2f beam(20., 0);
+				beam = Eigen::Rotation2Df(a) * beam;
+				Eigen::Vector2f intersect_1 =
+				  line_segm_intersection(mps.second.corners[mps.second.closest_idx],
+				                         mps.second.corners[mps.second.adjacent_1],
+				                         Eigen::Vector2f(0, 0),
+				                         beam);
+				if (intersect_1.allFinite()) {
+					float l = intersect_1.norm();
+					if (std::isnan(data[i]) || l < data[i])
+						data[i] = l;
+				}
+
+				Eigen::Vector2f intersect_2 =
+				  line_segm_intersection(mps.second.corners[mps.second.closest_idx],
+				                         mps.second.corners[mps.second.adjacent_2],
+				                         Eigen::Vector2f(0, 0),
+				                         beam);
+				if (intersect_2.allFinite()) {
+					float l = intersect_2.norm();
+					if (std::isnan(data[i]) || l < data[i])
+						data[i] = l;
+				}
+			}
+		}
+	}
+	laser_if_->set_frame(sensor_frame.c_str());
+	laser_if_->set_distances(data);
+	laser_if_->write();
+
+	vispub_.publish(m);
+}
+
+void
+MPSLaserGenThread::finalize()
+{
+	float data[360];
+	for (unsigned int i = 0; i < 360; ++i)
+		data[i] = std::numeric_limits<float>::quiet_NaN();
+	laser_if_->set_frame("");
+	laser_if_->set_distances(data);
+	laser_if_->write();
+
+	vispub_.shutdown();
+	blackboard->close(laser_if_);
 }

--- a/src/plugins/mps-laser-gen/mps-laser-gen_thread.h
+++ b/src/plugins/mps-laser-gen/mps-laser-gen_thread.h
@@ -30,15 +30,15 @@
 #include <aspect/logging.h>
 #include <aspect/tf.h>
 #include <core/threading/thread.h>
+#include <interfaces/Laser360Interface.h>
 #include <navgraph/aspect/navgraph.h>
 #include <plugins/ros/aspect/ros.h>
+#include <ros/publisher.h>
 
 #include <string>
 
-#include <interfaces/Laser360Interface.h>
-#include <ros/publisher.h>
-
-namespace fawkes {}
+namespace fawkes {
+}
 
 class MPSLaserGenThread : public fawkes::Thread,
                           public fawkes::BlockedTimingAspect,
@@ -47,22 +47,26 @@ class MPSLaserGenThread : public fawkes::Thread,
                           public fawkes::BlackBoardAspect,
                           public fawkes::NavGraphAspect,
                           public fawkes::ROSAspect,
-                          public fawkes::TransformAspect {
-
+                          public fawkes::TransformAspect
+{
 public:
-  MPSLaserGenThread();
+	MPSLaserGenThread();
 
-  virtual void init();
-  virtual void finalize();
-  virtual void loop();
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  fawkes::Laser360Interface *laser_if_;
-  ros::Publisher vispub_;
+	fawkes::Laser360Interface *laser_if_;
+	ros::Publisher             vispub_;
 };
 
 #endif

--- a/src/plugins/navgraph-generator-mps/navgraph_generator_mps_plugin.cpp
+++ b/src/plugins/navgraph-generator-mps/navgraph_generator_mps_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "navgraph_generator_mps_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Automatically generate navgraph for MPS
  * @author Tim Niemueller
  */
-class NavGraphGeneratorMPSPlugin : public fawkes::Plugin {
+class NavGraphGeneratorMPSPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  NavGraphGeneratorMPSPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new NavGraphGeneratorMPSThread());
-  }
+	NavGraphGeneratorMPSPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new NavGraphGeneratorMPSThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Generate navgraph for MPS game")

--- a/src/plugins/navgraph-generator-mps/navgraph_generator_mps_thread.cpp
+++ b/src/plugins/navgraph-generator-mps/navgraph_generator_mps_thread.cpp
@@ -24,12 +24,13 @@
 #include <blackboard/utils/on_message_waker.h>
 #include <core/threading/mutex_locker.h>
 #include <interfaces/NavGraphWithMPSGeneratorInterface.h>
-#include <limits>
-#include <memory>
 #include <navgraph/navgraph.h>
 #include <navgraph/yaml_navgraph.h>
 #include <utils/math/angle.h>
 #include <utils/math/eigen.h>
+
+#include <limits>
+#include <memory>
 
 using namespace fawkes;
 
@@ -41,133 +42,135 @@ using namespace fawkes;
 namespace fawkes {
 namespace workaround {
 static inline Eigen::Vector3f
-pointAt(const Eigen::ParametrizedLine<float, 3> &l, const float k) {
+pointAt(const Eigen::ParametrizedLine<float, 3> &l, const float k)
+{
 #if EIGEN_VERSION_AT_LEAST(3, 2, 0)
-  return l.pointAt(k);
+	return l.pointAt(k);
 #else
-  return l.origin() + (l.direction() * k);
+	return l.origin() + (l.direction() * k);
 #endif
 }
 } // namespace workaround
 } // namespace fawkes
 
-std::map<uint16_t, std::vector<Eigen::Vector2i>>
-    NavGraphGeneratorMPSThread::zone_blocking_ = {
-        {0,
-         {
-             // 0°
-             {-1, 0}, //
-             {1, 0}   // x|x
-         }},
-        {45,
-         {         // 45°
-          {1, 0},  //
-          {1, 1},  //  xx
-          {0, 1},  // x\x
-          {0, -1}, // xx
-          {-1, -1},
-          {-1, 0}}},
-        {90,
-         {
-             // 90°
-             {0, 1}, //  x
-             {0, -1} //  -
-         }},         //  x
-        {135,
-         {{0, 1},     // 135°
-          {-1, 1},    //
-          {-1, 0},    // xx
-          {1, 0},     // x/x
-          {1, -1},    //  xx
-          {0, -1}}}}; // 180°-315° is the same, see constructor.
+std::map<uint16_t, std::vector<Eigen::Vector2i>> NavGraphGeneratorMPSThread::zone_blocking_ = {
+  {0,
+   {
+     // 0°
+     {-1, 0}, //
+     {1, 0}   // x|x
+   }},
+  {45,
+   {         // 45°
+    {1, 0},  //
+    {1, 1},  //  xx
+    {0, 1},  // x\x
+    {0, -1}, // xx
+    {-1, -1},
+    {-1, 0}}},
+  {90,
+   {
+     // 90°
+     {0, 1}, //  x
+     {0, -1} //  -
+   }},       //  x
+  {135,
+   {{0, 1},     // 135°
+    {-1, 1},    //
+    {-1, 0},    // xx
+    {1, 0},     // x/x
+    {1, -1},    //  xx
+    {0, -1}}}}; // 180°-315° is the same, see constructor.
 
 std::vector<Eigen::Vector2i> NavGraphGeneratorMPSThread::reserved_zones_ = {
-    {-5, 2}, {5, 2}, {-7, 1}, {-6, 1}, {-5, 1}, {5, 1}, {6, 1}, {7, 1},
+  {-5, 2},
+  {5, 2},
+  {-7, 1},
+  {-6, 1},
+  {-5, 1},
+  {5, 1},
+  {6, 1},
+  {7, 1},
 };
 
 /** Constructor. */
 NavGraphGeneratorMPSThread::NavGraphGeneratorMPSThread()
-    : Thread("NavGraphGeneratorMPSThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlackBoardInterfaceListener("NavGraphGeneratorMPSThread") {
-  zone_blocking_[180] = zone_blocking_[0];
-  zone_blocking_[225] = zone_blocking_[45];
-  zone_blocking_[270] = zone_blocking_[90];
-  zone_blocking_[315] = zone_blocking_[135];
+: Thread("NavGraphGeneratorMPSThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlackBoardInterfaceListener("NavGraphGeneratorMPSThread")
+{
+	zone_blocking_[180] = zone_blocking_[0];
+	zone_blocking_[225] = zone_blocking_[45];
+	zone_blocking_[270] = zone_blocking_[90];
+	zone_blocking_[315] = zone_blocking_[135];
 }
 
 /** Destructor. */
-NavGraphGeneratorMPSThread::~NavGraphGeneratorMPSThread() {}
+NavGraphGeneratorMPSThread::~NavGraphGeneratorMPSThread()
+{
+}
 
-void NavGraphGeneratorMPSThread::init() {
-  cfg_global_frame_ = config->get_string("/frames/fixed");
-  cfg_mps_width_ = config->get_float("/navgraph-generator-mps/mps-width");
-  cfg_mps_length_ = config->get_float("/navgraph-generator-mps/mps-length");
-  cfg_mps_approach_dist_ =
-      config->get_float("/navgraph-generator-mps/approach-distance");
-  cfg_mps_corner_obst_ =
-      config->get_bool("/navgraph-generator-mps/add-corners-as-obstacles");
+void
+NavGraphGeneratorMPSThread::init()
+{
+	cfg_global_frame_      = config->get_string("/frames/fixed");
+	cfg_mps_width_         = config->get_float("/navgraph-generator-mps/mps-width");
+	cfg_mps_length_        = config->get_float("/navgraph-generator-mps/mps-length");
+	cfg_mps_approach_dist_ = config->get_float("/navgraph-generator-mps/approach-distance");
+	cfg_mps_corner_obst_   = config->get_bool("/navgraph-generator-mps/add-corners-as-obstacles");
 
-  cfg_map_min_dist_ =
-      config->get_float("/navgraph-generator-mps/map-cell-min-dist");
-  cfg_map_point_max_dist_ =
-      config->get_float("/navgraph-generator-mps/map-point-max-dist");
-  cfg_num_wait_zones_ =
-      size_t(config->get_uint("/navgraph-generator-mps/num-wait-zones"));
+	cfg_map_min_dist_       = config->get_float("/navgraph-generator-mps/map-cell-min-dist");
+	cfg_map_point_max_dist_ = config->get_float("/navgraph-generator-mps/map-point-max-dist");
+	cfg_num_wait_zones_     = size_t(config->get_uint("/navgraph-generator-mps/num-wait-zones"));
 
-  std::string algorithm =
-      config->get_string("/navgraph-generator-mps/algorithm");
-  if (algorithm == "voronoi") {
-    cfg_algorithm_ = NavGraphGeneratorInterface::ALGORITHM_VORONOI;
-  } else if (algorithm == "grid") {
-    cfg_algorithm_ = NavGraphGeneratorInterface::ALGORITHM_GRID;
-    const std::string prefix("/navgraph-generator-mps/grid/");
-    std::unique_ptr<Configuration::ValueIterator> i(config->search(prefix));
-    while (i->next()) {
-      const std::string path(i->path());
-      cfg_algo_params_[path.substr(prefix.length())] = i->get_as_string();
-    }
-  }
+	std::string algorithm = config->get_string("/navgraph-generator-mps/algorithm");
+	if (algorithm == "voronoi") {
+		cfg_algorithm_ = NavGraphGeneratorInterface::ALGORITHM_VORONOI;
+	} else if (algorithm == "grid") {
+		cfg_algorithm_ = NavGraphGeneratorInterface::ALGORITHM_GRID;
+		const std::string                             prefix("/navgraph-generator-mps/grid/");
+		std::unique_ptr<Configuration::ValueIterator> i(config->search(prefix));
+		while (i->next()) {
+			const std::string path(i->path());
+			cfg_algo_params_[path.substr(prefix.length())] = i->get_as_string();
+		}
+	}
 
-  std::string base_graph_file;
-  try {
-    base_graph_file = config->get_string("/navgraph-generator-mps/base-graph");
-  } catch (Exception &e) {
-  } // ignored, no base graph
+	std::string base_graph_file;
+	try {
+		base_graph_file = config->get_string("/navgraph-generator-mps/base-graph");
+	} catch (Exception &e) {
+	} // ignored, no base graph
 
-  base_graph_ = NULL;
-  if (!base_graph_file.empty()) {
-    if (base_graph_file[0] != '/') {
-      base_graph_file = std::string(CONFDIR) + "/" + base_graph_file;
-    }
-    base_graph_ = load_yaml_navgraph(base_graph_file);
-  } else {
-    logger->log_warn(name(), "No base graph configured");
-  }
+	base_graph_ = NULL;
+	if (!base_graph_file.empty()) {
+		if (base_graph_file[0] != '/') {
+			base_graph_file = std::string(CONFDIR) + "/" + base_graph_file;
+		}
+		base_graph_ = load_yaml_navgraph(base_graph_file);
+	} else {
+		logger->log_warn(name(), "No base graph configured");
+	}
 
-  std::vector<float> p1 =
-      config->get_floats("/navgraph-generator-mps/bounding-box/p1");
-  std::vector<float> p2 =
-      config->get_floats("/navgraph-generator-mps/bounding-box/p2");
-  cfg_bounding_box_p1_[0] = p1[0];
-  cfg_bounding_box_p1_[1] = p1[1];
-  cfg_bounding_box_p2_[0] = p2[0];
-  cfg_bounding_box_p2_[1] = p2[1];
+	std::vector<float> p1   = config->get_floats("/navgraph-generator-mps/bounding-box/p1");
+	std::vector<float> p2   = config->get_floats("/navgraph-generator-mps/bounding-box/p2");
+	cfg_bounding_box_p1_[0] = p1[0];
+	cfg_bounding_box_p1_[1] = p1[1];
+	cfg_bounding_box_p2_[0] = p2[0];
+	cfg_bounding_box_p2_[1] = p2[1];
 
-  exp_zones_.resize(24, true);
+	exp_zones_.resize(24, true);
 
-  navgen_if_ = blackboard->open_for_reading<NavGraphGeneratorInterface>(
-      "/navgraph-generator");
+	navgen_if_ = blackboard->open_for_reading<NavGraphGeneratorInterface>("/navgraph-generator");
 
-  navgen_mps_if_ =
-      blackboard->open_for_writing<NavGraphWithMPSGeneratorInterface>(
-          "/navgraph-generator-mps");
+	navgen_mps_if_ =
+	  blackboard->open_for_writing<NavGraphWithMPSGeneratorInterface>("/navgraph-generator-mps");
 
-  compute_msgid_ = 0;
+	compute_msgid_ = 0;
 
-  bbil_add_data_interface(navgen_if_);
-  blackboard->register_listener(this, BlackBoard::BBIL_FLAG_DATA);
+	bbil_add_data_interface(navgen_if_);
+	blackboard->register_listener(this, BlackBoard::BBIL_FLAG_DATA);
 
-  /* For testing
+	/* For testing
   tf::Quaternion q = tf::create_quaternion_from_yaw(deg2rad(45));
   double tag_pos[3] = {1.0,0.,0.};
   double tag_ori[4] = {q.x(), q.y(), q.z(), q.w()};
@@ -175,238 +178,242 @@ void NavGraphGeneratorMPSThread::init() {
   generate_navgraph();
   */
 
-  msg_waker_ = new BlackBoardOnMessageWaker(blackboard, navgen_mps_if_, this);
+	msg_waker_ = new BlackBoardOnMessageWaker(blackboard, navgen_mps_if_, this);
 }
 
-void NavGraphGeneratorMPSThread::finalize() {
-  delete msg_waker_;
+void
+NavGraphGeneratorMPSThread::finalize()
+{
+	delete msg_waker_;
 
-  blackboard->unregister_listener(this);
-  bbil_remove_data_interface(navgen_if_);
+	blackboard->unregister_listener(this);
+	bbil_remove_data_interface(navgen_if_);
 
-  blackboard->close(navgen_mps_if_);
-  blackboard->close(navgen_if_);
+	blackboard->close(navgen_mps_if_);
+	blackboard->close(navgen_if_);
 
-  delete base_graph_;
+	delete base_graph_;
 }
 
-void NavGraphGeneratorMPSThread::loop() {
-  while (!navgen_mps_if_->msgq_empty()) {
-    if (navgen_mps_if_->msgq_first_is<
-            NavGraphWithMPSGeneratorInterface::ClearMessage>()) {
-      stations_.clear();
+void
+NavGraphGeneratorMPSThread::loop()
+{
+	while (!navgen_mps_if_->msgq_empty()) {
+		if (navgen_mps_if_->msgq_first_is<NavGraphWithMPSGeneratorInterface::ClearMessage>()) {
+			stations_.clear();
 
-    } else if (navgen_mps_if_->msgq_first_is<NavGraphWithMPSGeneratorInterface::
-                                                 UpdateStationByTagMessage>()) {
-      NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage *m =
-          navgen_mps_if_->msgq_first<
-              NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage>();
-      logger->log_warn(name(), "Updating station %s from tag", m->name());
+		} else if (navgen_mps_if_
+		             ->msgq_first_is<NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage>()) {
+			NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage *m =
+			  navgen_mps_if_->msgq_first<NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage>();
+			logger->log_warn(name(), "Updating station %s from tag", m->name());
 
-      update_station(m->name(),
-                     (m->side() == NavGraphWithMPSGeneratorInterface::INPUT),
-                     m->frame(), m->tag_translation(), m->tag_rotation(),
-                     Eigen::Vector2i{m->zone_coords(0), m->zone_coords(1)});
+			update_station(m->name(),
+			               (m->side() == NavGraphWithMPSGeneratorInterface::INPUT),
+			               m->frame(),
+			               m->tag_translation(),
+			               m->tag_rotation(),
+			               Eigen::Vector2i{m->zone_coords(0), m->zone_coords(1)});
 
-    } else if (navgen_mps_if_
-                   ->msgq_first_is<NavGraphWithMPSGeneratorInterface::
-                                       SetExplorationZonesMessage>()) {
-      NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage *m =
-          navgen_mps_if_->msgq_first<
-              NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage>();
-      for (size_t i = 0; i < std::min(m->maxlenof_zones(), exp_zones_.size());
-           ++i) {
-        exp_zones_[i] = m->is_zones(i);
-      }
+		} else if (navgen_mps_if_
+		             ->msgq_first_is<NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage>()) {
+			NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage *m =
+			  navgen_mps_if_->msgq_first<NavGraphWithMPSGeneratorInterface::SetExplorationZonesMessage>();
+			for (size_t i = 0; i < std::min(m->maxlenof_zones(), exp_zones_.size()); ++i) {
+				exp_zones_[i] = m->is_zones(i);
+			}
 
-    } else if (navgen_mps_if_->msgq_first_is<NavGraphWithMPSGeneratorInterface::
-                                                 GenerateWaitZonesMessage>()) {
-      wait_zones_.clear();
-      std::vector<Eigen::Vector2i> blocked_zones;
-      for (auto &entry : stations_) {
-        blocked_zones.push_back(entry.second.zone);
-        blocked_zones.insert(blocked_zones.end(),
-                             entry.second.blocked_zones.begin(),
-                             entry.second.blocked_zones.end());
-      }
+		} else if (navgen_mps_if_
+		             ->msgq_first_is<NavGraphWithMPSGeneratorInterface::GenerateWaitZonesMessage>()) {
+			wait_zones_.clear();
+			std::vector<Eigen::Vector2i> blocked_zones;
+			for (auto &entry : stations_) {
+				blocked_zones.push_back(entry.second.zone);
+				blocked_zones.insert(blocked_zones.end(),
+				                     entry.second.blocked_zones.begin(),
+				                     entry.second.blocked_zones.end());
+			}
 
-      std::vector<Eigen::Vector2i> free_zones_left, free_zones_right;
+			std::vector<Eigen::Vector2i> free_zones_left, free_zones_right;
 
-      int x_min, x_max, y_min, y_max;
-      if (cfg_bounding_box_p1_.x() < cfg_bounding_box_p2_.x()) {
-        x_min = int(cfg_bounding_box_p1_.x());
-        x_max = int(cfg_bounding_box_p2_.x());
-      } else {
-        x_min = int(cfg_bounding_box_p2_.x());
-        x_max = int(cfg_bounding_box_p1_.x());
-      }
-      if (cfg_bounding_box_p1_.y() < cfg_bounding_box_p2_.y()) {
-        y_min = int(cfg_bounding_box_p1_.y());
-        y_max = int(cfg_bounding_box_p2_.y());
-      } else {
-        y_min = int(cfg_bounding_box_p2_.y());
-        y_max = int(cfg_bounding_box_p1_.y());
-      }
+			int x_min, x_max, y_min, y_max;
+			if (cfg_bounding_box_p1_.x() < cfg_bounding_box_p2_.x()) {
+				x_min = int(cfg_bounding_box_p1_.x());
+				x_max = int(cfg_bounding_box_p2_.x());
+			} else {
+				x_min = int(cfg_bounding_box_p2_.x());
+				x_max = int(cfg_bounding_box_p1_.x());
+			}
+			if (cfg_bounding_box_p1_.y() < cfg_bounding_box_p2_.y()) {
+				y_min = int(cfg_bounding_box_p1_.y());
+				y_max = int(cfg_bounding_box_p2_.y());
+			} else {
+				y_min = int(cfg_bounding_box_p2_.y());
+				y_max = int(cfg_bounding_box_p1_.y());
+			}
 
-      for (int x = x_min; x <= x_max; ++x) {
-        for (int y = y_min; y <= y_max; ++y) {
-          if (x != 0 && y != 0) {
-            Eigen::Vector2i zn = {x, y};
-            if (std::find(reserved_zones_.begin(), reserved_zones_.end(), zn) ==
-                    reserved_zones_.end() &&
-                std::find(blocked_zones.begin(), blocked_zones.end(), zn) ==
-                    blocked_zones.end()) {
-              // Zone is not reserved or blocked
-              if (x < 0)
-                free_zones_left.push_back(zn);
-              else
-                free_zones_right.push_back(zn);
-            }
-          }
-        }
-      }
+			for (int x = x_min; x <= x_max; ++x) {
+				for (int y = y_min; y <= y_max; ++y) {
+					if (x != 0 && y != 0) {
+						Eigen::Vector2i zn = {x, y};
+						if (std::find(reserved_zones_.begin(), reserved_zones_.end(), zn)
+						      == reserved_zones_.end()
+						    && std::find(blocked_zones.begin(), blocked_zones.end(), zn)
+						         == blocked_zones.end()) {
+							// Zone is not reserved or blocked
+							if (x < 0)
+								free_zones_left.push_back(zn);
+							else
+								free_zones_right.push_back(zn);
+						}
+					}
+				}
+			}
 
-      generate_wait_zones(cfg_num_wait_zones_, free_zones_left);
-      generate_wait_zones(cfg_num_wait_zones_, free_zones_right);
-    } else if (navgen_mps_if_->msgq_first_is<
-                   NavGraphWithMPSGeneratorInterface::ComputeMessage>()) {
-      NavGraphWithMPSGeneratorInterface::ComputeMessage *m =
-          navgen_mps_if_
-              ->msgq_first<NavGraphWithMPSGeneratorInterface::ComputeMessage>();
-      logger->log_info(name(), "Computation started");
-      navgen_mps_if_->set_final(false);
-      navgen_mps_if_->set_msgid(m->id());
-      navgen_mps_if_->write();
-      generate_navgraph();
-    } else {
-      logger->log_warn(name(), "Unknown message received");
-    }
+			generate_wait_zones(cfg_num_wait_zones_, free_zones_left);
+			generate_wait_zones(cfg_num_wait_zones_, free_zones_right);
+		} else if (navgen_mps_if_->msgq_first_is<NavGraphWithMPSGeneratorInterface::ComputeMessage>()) {
+			NavGraphWithMPSGeneratorInterface::ComputeMessage *m =
+			  navgen_mps_if_->msgq_first<NavGraphWithMPSGeneratorInterface::ComputeMessage>();
+			logger->log_info(name(), "Computation started");
+			navgen_mps_if_->set_final(false);
+			navgen_mps_if_->set_msgid(m->id());
+			navgen_mps_if_->write();
+			generate_navgraph();
+		} else {
+			logger->log_warn(name(), "Unknown message received");
+		}
 
-    navgen_mps_if_->msgq_pop();
-  }
+		navgen_mps_if_->msgq_pop();
+	}
 }
 
-void NavGraphGeneratorMPSThread::generate_wait_zones(
-    size_t count, std::vector<Eigen::Vector2i> &free_zones) {
-  std::sort(free_zones.begin(), free_zones.end(),
-            [this](const Eigen::Vector2i &lhs, const Eigen::Vector2i &rhs) {
-              double d_lhs_min = std::numeric_limits<double>::max();
-              double d_rhs_min = std::numeric_limits<double>::max();
-              for (auto &entry : this->stations_) {
-                Eigen::Vector2i &station_zn = entry.second.zone;
+void
+NavGraphGeneratorMPSThread::generate_wait_zones(size_t                        count,
+                                                std::vector<Eigen::Vector2i> &free_zones)
+{
+	std::sort(free_zones.begin(),
+	          free_zones.end(),
+	          [this](const Eigen::Vector2i &lhs, const Eigen::Vector2i &rhs) {
+		          double d_lhs_min = std::numeric_limits<double>::max();
+		          double d_rhs_min = std::numeric_limits<double>::max();
+		          for (auto &entry : this->stations_) {
+			          Eigen::Vector2i &station_zn = entry.second.zone;
 
-                double d_lhs = (lhs - station_zn).norm();
-                if (d_lhs < d_lhs_min)
-                  d_lhs_min = d_lhs;
+			          double d_lhs = (lhs - station_zn).norm();
+			          if (d_lhs < d_lhs_min)
+				          d_lhs_min = d_lhs;
 
-                double d_rhs = (rhs - station_zn).norm();
-                if (d_rhs < d_rhs_min)
-                  d_rhs_min = d_rhs;
-              }
-              return d_lhs_min > d_rhs_min;
-            });
+			          double d_rhs = (rhs - station_zn).norm();
+			          if (d_rhs < d_rhs_min)
+				          d_rhs_min = d_rhs;
+		          }
+		          return d_lhs_min > d_rhs_min;
+	          });
 
-  for (auto it = free_zones.begin();
-       it < free_zones.begin() + count && it < free_zones.end(); ++it) {
-    wait_zones_.push_back(*it);
-  }
+	for (auto it = free_zones.begin(); it < free_zones.begin() + count && it < free_zones.end();
+	     ++it) {
+		wait_zones_.push_back(*it);
+	}
 }
 
 /*
  * 2017 rules: Machine rotation is always a multiple of 45°
  */
-static inline uint16_t quantize_yaw(float yaw) {
-  if (yaw < 0)
-    yaw = 2.0f * float(M_PI) + yaw;
-  uint16_t yaw_discrete = uint16_t(std::round(yaw / float(M_PI) * 4)) * 45;
-  return yaw_discrete == 360 ? 0 : yaw_discrete;
+static inline uint16_t
+quantize_yaw(float yaw)
+{
+	if (yaw < 0)
+		yaw = 2.0f * float(M_PI) + yaw;
+	uint16_t yaw_discrete = uint16_t(std::round(yaw / float(M_PI) * 4)) * 45;
+	return yaw_discrete == 360 ? 0 : yaw_discrete;
 }
 
 std::vector<Eigen::Vector2i>
-NavGraphGeneratorMPSThread::blocked_zones(Eigen::Vector2i zone,
-                                          uint16_t discrete_ori) {
-  std::vector<Eigen::Vector2i> rv;
-  for (const Eigen::Vector2i &offset : zone_blocking_[discrete_ori % 180]) {
-    rv.push_back(zone + offset);
-  }
-  return rv;
+NavGraphGeneratorMPSThread::blocked_zones(Eigen::Vector2i zone, uint16_t discrete_ori)
+{
+	std::vector<Eigen::Vector2i> rv;
+	for (const Eigen::Vector2i &offset : zone_blocking_[discrete_ori % 180]) {
+		rv.push_back(zone + offset);
+	}
+	return rv;
 }
 
-void NavGraphGeneratorMPSThread::update_station(std::string id, bool input,
-                                                std::string frame,
-                                                double tag_pos[3],
-                                                double tag_ori[4],
-                                                Eigen::Vector2i zone) {
-  // **** 1. convert to map frame
-  tf::Stamped<tf::Pose> pose;
+void
+NavGraphGeneratorMPSThread::update_station(std::string     id,
+                                           bool            input,
+                                           std::string     frame,
+                                           double          tag_pos[3],
+                                           double          tag_ori[4],
+                                           Eigen::Vector2i zone)
+{
+	// **** 1. convert to map frame
+	tf::Stamped<tf::Pose> pose;
 
-  try {
-    // Note that we add a correction offset to the centroid X value.
-    // This offset is determined empirically and just turns out to be helpful
-    // in certain situations.
+	try {
+		// Note that we add a correction offset to the centroid X value.
+		// This offset is determined empirically and just turns out to be helpful
+		// in certain situations.
 
-    tf::Stamped<tf::Pose> spose(
-        tf::Pose(tf::Quaternion(tag_ori[0], tag_ori[1], tag_ori[2], tag_ori[3]),
-                 tf::Vector3(tag_pos[0], tag_pos[1], tag_pos[2])),
-        fawkes::Time(0, 0), frame);
-    tf_listener->transform_pose(cfg_global_frame_, spose, pose);
-  } catch (tf::TransformException &e) {
-    logger->log_warn(name(), "Transform exception:");
-    logger->log_warn(name(), e);
-    logger->log_error(name(), "Failed to add station %s: transform failed",
-                      id.c_str());
-    return;
-  }
-  tf::Vector3 tf_pose_pos(pose.getOrigin());
-  tf::Quaternion tf_pose_ori(pose.getRotation());
-  Eigen::Vector3f tag_pose_pos(tf_pose_pos.x(), tf_pose_pos.y(),
-                               tf_pose_pos.z());
+		tf::Stamped<tf::Pose> spose(
+		  tf::Pose(tf::Quaternion(tag_ori[0], tag_ori[1], tag_ori[2], tag_ori[3]),
+		           tf::Vector3(tag_pos[0], tag_pos[1], tag_pos[2])),
+		  fawkes::Time(0, 0),
+		  frame);
+		tf_listener->transform_pose(cfg_global_frame_, spose, pose);
+	} catch (tf::TransformException &e) {
+		logger->log_warn(name(), "Transform exception:");
+		logger->log_warn(name(), e);
+		logger->log_error(name(), "Failed to add station %s: transform failed", id.c_str());
+		return;
+	}
+	tf::Vector3     tf_pose_pos(pose.getOrigin());
+	tf::Quaternion  tf_pose_ori(pose.getRotation());
+	Eigen::Vector3f tag_pose_pos(tf_pose_pos.x(), tf_pose_pos.y(), tf_pose_pos.z());
 
-  // **** 2. project to ground plane
-  Eigen::Vector3f proj_pos;
+	// **** 2. project to ground plane
+	Eigen::Vector3f proj_pos;
 
-  {
-    Eigen::Vector3f plane_normal = Eigen::Vector3f::UnitZ();
-    Eigen::Vector3f plane_origin(0, 0, 0);
-    Eigen::Vector3f po = tag_pose_pos - plane_origin;
-    float lambda = plane_normal.dot(po);
-    proj_pos = tag_pose_pos - (lambda * plane_normal);
-  }
+	{
+		Eigen::Vector3f plane_normal = Eigen::Vector3f::UnitZ();
+		Eigen::Vector3f plane_origin(0, 0, 0);
+		Eigen::Vector3f po     = tag_pose_pos - plane_origin;
+		float           lambda = plane_normal.dot(po);
+		proj_pos               = tag_pose_pos - (lambda * plane_normal);
+	}
 
-  Eigen::Quaternionf proj_ori(
-      Eigen::AngleAxisf(tf::get_yaw(tf_pose_ori), Eigen::Vector3f::UnitZ()));
+	Eigen::Quaternionf proj_ori(
+	  Eigen::AngleAxisf(tf::get_yaw(tf_pose_ori), Eigen::Vector3f::UnitZ()));
 
-  // **** 3. calculate approach points
-  Eigen::Vector3f dir_vec = proj_ori * Eigen::Vector3f::UnitX();
-  Eigen::ParametrizedLine<float, 3> mline(proj_pos, dir_vec);
+	// **** 3. calculate approach points
+	Eigen::Vector3f                   dir_vec = proj_ori * Eigen::Vector3f::UnitX();
+	Eigen::ParametrizedLine<float, 3> mline(proj_pos, dir_vec);
 
-  Eigen::Vector3f input_pos, output_pos, pose_pos;
-  Eigen::Quaternionf input_ori, output_ori, pose_ori;
-  if (input) {
-    input_pos = workaround::pointAt(mline, cfg_mps_approach_dist_);
-    input_ori = proj_ori * Eigen::AngleAxisf(M_PI, Eigen::Vector3f::UnitZ());
-    output_pos =
-        workaround::pointAt(mline, -(cfg_mps_approach_dist_ + cfg_mps_width_));
-    output_ori = proj_ori;
-    pose_pos = workaround::pointAt(mline, -(.5 * cfg_mps_width_));
-    pose_ori = output_ori;
-  } else {
-    output_pos = workaround::pointAt(mline, cfg_mps_approach_dist_);
-    output_ori = proj_ori * Eigen::AngleAxisf(M_PI, Eigen::Vector3f::UnitZ());
-    input_pos =
-        workaround::pointAt(mline, -(cfg_mps_approach_dist_ + cfg_mps_width_));
-    input_ori = proj_ori;
-    pose_pos = workaround::pointAt(mline, -(.5 * cfg_mps_width_));
-    pose_ori = input_ori;
-  }
+	Eigen::Vector3f    input_pos, output_pos, pose_pos;
+	Eigen::Quaternionf input_ori, output_ori, pose_ori;
+	if (input) {
+		input_pos  = workaround::pointAt(mline, cfg_mps_approach_dist_);
+		input_ori  = proj_ori * Eigen::AngleAxisf(M_PI, Eigen::Vector3f::UnitZ());
+		output_pos = workaround::pointAt(mline, -(cfg_mps_approach_dist_ + cfg_mps_width_));
+		output_ori = proj_ori;
+		pose_pos   = workaround::pointAt(mline, -(.5 * cfg_mps_width_));
+		pose_ori   = output_ori;
+	} else {
+		output_pos = workaround::pointAt(mline, cfg_mps_approach_dist_);
+		output_ori = proj_ori * Eigen::AngleAxisf(M_PI, Eigen::Vector3f::UnitZ());
+		input_pos  = workaround::pointAt(mline, -(cfg_mps_approach_dist_ + cfg_mps_width_));
+		input_ori  = proj_ori;
+		pose_pos   = workaround::pointAt(mline, -(.5 * cfg_mps_width_));
+		pose_ori   = input_ori;
+	}
 
-  // Problem: range of first value is only [0..pi], which might result
-  // in "funny" and unexpected angles. If we want only yaw, we can work
-  // around this using rpy order... Better use utils.
-  // Eigen::Vector3f input_euler  = input_ori.toRotationMatrix().eulerAngles(0,
-  // 1, 2);
+	// Problem: range of first value is only [0..pi], which might result
+	// in "funny" and unexpected angles. If we want only yaw, we can work
+	// around this using rpy order... Better use utils.
+	// Eigen::Vector3f input_euler  = input_ori.toRotationMatrix().eulerAngles(0,
+	// 1, 2);
 
-  /*
+	/*
   logger->log_info(name(), "P(%f,%f,%f) Q(%f,%f,%f,%f)  D(%f,%f,%f)",
                    proj_pos[0], proj_pos[1], proj_pos[2],
                    proj_ori.x(), proj_ori.y(), proj_ori.z(), proj_ori.w(),
@@ -418,279 +425,287 @@ void NavGraphGeneratorMPSThread::update_station(std::string id, bool input,
   proj_pos).norm());
   */
 
-  // **** 4. (optional) calculate corner points
-  std::vector<Eigen::Vector2f> corners;
-  if (cfg_mps_corner_obst_) {
-    corners.resize(4);
+	// **** 4. (optional) calculate corner points
+	std::vector<Eigen::Vector2f> corners;
+	if (cfg_mps_corner_obst_) {
+		corners.resize(4);
 
-    const float mps_width_2 = cfg_mps_width_ / 2.;
-    const float mps_length_2 = cfg_mps_length_ / 2.;
+		const float mps_width_2  = cfg_mps_width_ / 2.;
+		const float mps_length_2 = cfg_mps_length_ / 2.;
 
-    Eigen::Rotation2Df rot(quat_yaw(pose_ori));
-    Eigen::Vector2f center;
-    center[0] = pose_pos[0];
-    center[1] = pose_pos[1];
-    corners[0] = (rot * Eigen::Vector2f(mps_width_2, -mps_length_2)) + center;
-    corners[1] = (rot * Eigen::Vector2f(-mps_width_2, -mps_length_2)) + center;
-    corners[2] = (rot * Eigen::Vector2f(-mps_width_2, mps_length_2)) + center;
-    corners[3] = (rot * Eigen::Vector2f(mps_width_2, mps_length_2)) + center;
-  }
+		Eigen::Rotation2Df rot(quat_yaw(pose_ori));
+		Eigen::Vector2f    center;
+		center[0]  = pose_pos[0];
+		center[1]  = pose_pos[1];
+		corners[0] = (rot * Eigen::Vector2f(mps_width_2, -mps_length_2)) + center;
+		corners[1] = (rot * Eigen::Vector2f(-mps_width_2, -mps_length_2)) + center;
+		corners[2] = (rot * Eigen::Vector2f(-mps_width_2, mps_length_2)) + center;
+		corners[3] = (rot * Eigen::Vector2f(mps_width_2, mps_length_2)) + center;
+	}
 
-  // **** 5. add to stations
-  MPSStation s;
-  s.tag_frame = frame;
-  s.tag_pose_pos = pose_pos;
-  s.tag_pose_ori = proj_ori;
-  s.pose_pos = pose_pos;
-  s.pose_ori = pose_ori;
-  s.pose_yaw = quat_yaw(pose_ori);
-  s.input_pos = input_pos;
-  s.input_ori = input_ori;
-  s.input_yaw = quat_yaw(input_ori);
-  s.output_pos = output_pos;
-  s.output_ori = output_ori;
-  s.output_yaw = quat_yaw(output_ori);
-  s.corners = corners;
-  s.zone = zone;
-  s.blocked_zones = blocked_zones(zone, quantize_yaw(quat_yaw(pose_ori)));
+	// **** 5. add to stations
+	MPSStation s;
+	s.tag_frame     = frame;
+	s.tag_pose_pos  = pose_pos;
+	s.tag_pose_ori  = proj_ori;
+	s.pose_pos      = pose_pos;
+	s.pose_ori      = pose_ori;
+	s.pose_yaw      = quat_yaw(pose_ori);
+	s.input_pos     = input_pos;
+	s.input_ori     = input_ori;
+	s.input_yaw     = quat_yaw(input_ori);
+	s.output_pos    = output_pos;
+	s.output_ori    = output_ori;
+	s.output_yaw    = quat_yaw(output_ori);
+	s.corners       = corners;
+	s.zone          = zone;
+	s.blocked_zones = blocked_zones(zone, quantize_yaw(quat_yaw(pose_ori)));
 
-  stations_[id] = s;
+	stations_[id] = s;
 }
 
 fawkes::NavGraphGeneratorInterface::ConnectionMode
-NavGraphGeneratorMPSThread::mps_node_insmode(std::string name) {
-  if (base_graph_ && base_graph_->node_exists(name)) {
-    NavGraphNode n(base_graph_->node(name));
-    if (n.has_property("generator-insert-mode")) {
-      std::string prop = n.property("generator-insert-mode");
-      if (prop == "closest-node") {
-        return NavGraphGeneratorInterface::CLOSEST_NODE;
-      } else if (prop == "closest-edge") {
-        return NavGraphGeneratorInterface::CLOSEST_EDGE;
-      } else if (prop == "closest-edge-or-node") {
-        return NavGraphGeneratorInterface::CLOSEST_EDGE_OR_NODE;
-      }
-    }
-  }
+NavGraphGeneratorMPSThread::mps_node_insmode(std::string name)
+{
+	if (base_graph_ && base_graph_->node_exists(name)) {
+		NavGraphNode n(base_graph_->node(name));
+		if (n.has_property("generator-insert-mode")) {
+			std::string prop = n.property("generator-insert-mode");
+			if (prop == "closest-node") {
+				return NavGraphGeneratorInterface::CLOSEST_NODE;
+			} else if (prop == "closest-edge") {
+				return NavGraphGeneratorInterface::CLOSEST_EDGE;
+			} else if (prop == "closest-edge-or-node") {
+				return NavGraphGeneratorInterface::CLOSEST_EDGE_OR_NODE;
+			}
+		}
+	}
 
-  return NavGraphGeneratorInterface::CLOSEST_EDGE;
+	return NavGraphGeneratorInterface::CLOSEST_EDGE;
 }
 
-void NavGraphGeneratorMPSThread::generate_navgraph() {
-  navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::ClearMessage());
+void
+NavGraphGeneratorMPSThread::generate_navgraph()
+{
+	navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::ClearMessage());
 
-  navgen_if_->msgq_enqueue(
-      new NavGraphGeneratorInterface::SetAlgorithmMessage(cfg_algorithm_));
-  for (const auto &p : cfg_algo_params_) {
-    navgen_if_->msgq_enqueue(
-        new NavGraphGeneratorInterface::SetAlgorithmParameterMessage(
-            p.first.c_str(), p.second.c_str()));
-  }
+	navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::SetAlgorithmMessage(cfg_algorithm_));
+	for (const auto &p : cfg_algo_params_) {
+		navgen_if_->msgq_enqueue(
+		  new NavGraphGeneratorInterface::SetAlgorithmParameterMessage(p.first.c_str(),
+		                                                               p.second.c_str()));
+	}
 
-  navgen_if_->msgq_enqueue(
-      new NavGraphGeneratorInterface::SetBoundingBoxMessage(
-          cfg_bounding_box_p1_[0], cfg_bounding_box_p1_[1],
-          cfg_bounding_box_p2_[0], cfg_bounding_box_p2_[1]));
+	navgen_if_->msgq_enqueue(
+	  new NavGraphGeneratorInterface::SetBoundingBoxMessage(cfg_bounding_box_p1_[0],
+	                                                        cfg_bounding_box_p1_[1],
+	                                                        cfg_bounding_box_p2_[0],
+	                                                        cfg_bounding_box_p2_[1]));
 
-  navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::SetFilterMessage(
-      NavGraphGeneratorInterface::FILTER_EDGES_BY_MAP, true));
+	navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::SetFilterMessage(
+	  NavGraphGeneratorInterface::FILTER_EDGES_BY_MAP, true));
 
-  navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::SetFilterMessage(
-      NavGraphGeneratorInterface::FILTER_ORPHAN_NODES, true));
+	navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::SetFilterMessage(
+	  NavGraphGeneratorInterface::FILTER_ORPHAN_NODES, true));
 
-  navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::SetFilterMessage(
-      NavGraphGeneratorInterface::FILTER_MULTI_GRAPH, true));
+	navgen_if_->msgq_enqueue(
+	  new NavGraphGeneratorInterface::SetFilterMessage(NavGraphGeneratorInterface::FILTER_MULTI_GRAPH,
+	                                                   true));
 
-  navgen_if_->msgq_enqueue(
-      new NavGraphGeneratorInterface::SetFilterParamFloatMessage(
-          NavGraphGeneratorInterface::FILTER_EDGES_BY_MAP, "distance",
-          cfg_map_min_dist_));
+	navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::SetFilterParamFloatMessage(
+	  NavGraphGeneratorInterface::FILTER_EDGES_BY_MAP, "distance", cfg_map_min_dist_));
 
-  navgen_if_->msgq_enqueue(
-      new NavGraphGeneratorInterface::AddMapObstaclesMessage(
-          cfg_map_point_max_dist_));
+	navgen_if_->msgq_enqueue(
+	  new NavGraphGeneratorInterface::AddMapObstaclesMessage(cfg_map_point_max_dist_));
 
-  navgen_if_->msgq_enqueue(
-      new NavGraphGeneratorInterface::SetCopyGraphDefaultPropertiesMessage(
-          true));
+	navgen_if_->msgq_enqueue(
+	  new NavGraphGeneratorInterface::SetCopyGraphDefaultPropertiesMessage(true));
 
-  for (const auto &s : stations_) {
-    navgen_if_->msgq_enqueue(
-        new NavGraphGeneratorInterface::AddPointOfInterestWithOriMessage(
-            (s.first + "-I").c_str(), s.second.input_pos[0],
-            s.second.input_pos[1], s.second.input_yaw,
-            mps_node_insmode(s.first + "-I")));
+	for (const auto &s : stations_) {
+		navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestWithOriMessage(
+		  (s.first + "-I").c_str(),
+		  s.second.input_pos[0],
+		  s.second.input_pos[1],
+		  s.second.input_yaw,
+		  mps_node_insmode(s.first + "-I")));
 
-    navgen_if_->msgq_enqueue(
-        new NavGraphGeneratorInterface::AddPointOfInterestWithOriMessage(
-            (s.first + "-O").c_str(), s.second.output_pos[0],
-            s.second.output_pos[1], s.second.output_yaw,
-            mps_node_insmode(s.first + "-O")));
+		navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestWithOriMessage(
+		  (s.first + "-O").c_str(),
+		  s.second.output_pos[0],
+		  s.second.output_pos[1],
+		  s.second.output_yaw,
+		  mps_node_insmode(s.first + "-O")));
 
-    navgen_if_->msgq_enqueue(
-        new NavGraphGeneratorInterface::AddPointOfInterestWithOriMessage(
-            s.first.c_str(), s.second.pose_pos[0], s.second.pose_pos[1],
-            s.second.output_yaw, NavGraphGeneratorInterface::UNCONNECTED));
-    navgen_if_->msgq_enqueue(
-        new NavGraphGeneratorInterface::SetPointOfInterestPropertyMessage(
-            s.first.c_str(), "mps", "true"));
+		navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestWithOriMessage(
+		  s.first.c_str(),
+		  s.second.pose_pos[0],
+		  s.second.pose_pos[1],
+		  s.second.output_yaw,
+		  NavGraphGeneratorInterface::UNCONNECTED));
+		navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::SetPointOfInterestPropertyMessage(
+		  s.first.c_str(), "mps", "true"));
 
-    if (cfg_mps_corner_obst_) {
-      for (size_t i = 0; i < s.second.corners.size(); ++i) {
-        const Eigen::Vector2f &c = s.second.corners[i];
-        navgen_if_->msgq_enqueue(
-            new NavGraphGeneratorInterface::AddObstacleMessage(
-                (s.first + "-C" + std::to_string(i)).c_str(), c[0], c[1]));
-      }
-    }
-    navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddObstacleMessage(
-        (s.first + "-C").c_str(), s.second.pose_pos[0], s.second.pose_pos[1]));
-  }
+		if (cfg_mps_corner_obst_) {
+			for (size_t i = 0; i < s.second.corners.size(); ++i) {
+				const Eigen::Vector2f &c = s.second.corners[i];
+				navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddObstacleMessage(
+				  (s.first + "-C" + std::to_string(i)).c_str(), c[0], c[1]));
+			}
+		}
+		navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddObstacleMessage(
+		  (s.first + "-C").c_str(), s.second.pose_pos[0], s.second.pose_pos[1]));
+	}
 
-  if (base_graph_) {
-    // add base graph nodes and edges
-    std::list<std::string> cn; // copied nodes
-    const std::vector<NavGraphNode> &nodes = base_graph_->nodes();
-    const std::vector<NavGraphEdge> &edges = base_graph_->edges();
-    for (const NavGraphNode &n : nodes) {
-      bool do_copy =
-          n.has_property("always-copy") && n.property_as_bool("always-copy");
-      if (!do_copy) {
-        // check for other reasons
-        for (size_t i = 0; i < exp_zones_.size(); ++i) {
-          if (exp_zones_[i]) {
-            std::string prop_name = "orientation_Z" + std::to_string(i + 1);
-            if (n.has_property(prop_name)) {
-              do_copy = true;
-              break;
-            }
-          }
-        }
-      }
-      if (do_copy) {
-        cn.push_back(n.name());
+	if (base_graph_) {
+		// add base graph nodes and edges
+		std::list<std::string>           cn; // copied nodes
+		const std::vector<NavGraphNode> &nodes = base_graph_->nodes();
+		const std::vector<NavGraphEdge> &edges = base_graph_->edges();
+		for (const NavGraphNode &n : nodes) {
+			bool do_copy = n.has_property("always-copy") && n.property_as_bool("always-copy");
+			if (!do_copy) {
+				// check for other reasons
+				for (size_t i = 0; i < exp_zones_.size(); ++i) {
+					if (exp_zones_[i]) {
+						std::string prop_name = "orientation_Z" + std::to_string(i + 1);
+						if (n.has_property(prop_name)) {
+							do_copy = true;
+							break;
+						}
+					}
+				}
+			}
+			if (do_copy) {
+				cn.push_back(n.name());
 
-        NavGraphGeneratorInterface::ConnectionMode conn_mode =
-            NavGraphGeneratorInterface::NOT_CONNECTED;
+				NavGraphGeneratorInterface::ConnectionMode conn_mode =
+				  NavGraphGeneratorInterface::NOT_CONNECTED;
 
-        if (n.unconnected()) {
-          conn_mode = NavGraphGeneratorInterface::UNCONNECTED;
-        }
+				if (n.unconnected()) {
+					conn_mode = NavGraphGeneratorInterface::UNCONNECTED;
+				}
 
-        // insert-mode may still override unconnected status, which it
-        // may only have to satisfy initial loading criteria
-        if (n.has_property("insert-mode")) {
-          std::string ins_mode = n.property("insert-mode");
-          if (ins_mode == "closest-node" || ins_mode == "CLOSEST_NODE") {
-            conn_mode = NavGraphGeneratorInterface::CLOSEST_NODE;
-          } else if (ins_mode == "closest-edge" || ins_mode == "CLOSEST_EDGE") {
-            conn_mode = NavGraphGeneratorInterface::CLOSEST_EDGE;
-          } else if (ins_mode == "closest-edge-or-node" ||
-                     ins_mode == "CLOSEST_EDGE_OR_NODE") {
-            conn_mode = NavGraphGeneratorInterface::CLOSEST_EDGE_OR_NODE;
-          } else if (ins_mode == "unconnected" || ins_mode == "UNCONNECTED") {
-            conn_mode = NavGraphGeneratorInterface::UNCONNECTED;
-          } else if (ins_mode == "not-connected" ||
-                     ins_mode == "NOT_CONNECTED") {
-            conn_mode = NavGraphGeneratorInterface::NOT_CONNECTED;
-          } else {
-            ins_mode = "NOT_CONNECTED";
-            logger->log_warn(name(),
-                             "Unknown insertion mode '%s' for node '%s', "
-                             "defaulting to NOT_CONNECTED",
-                             ins_mode.c_str(), n.name().c_str());
-          }
-        }
+				// insert-mode may still override unconnected status, which it
+				// may only have to satisfy initial loading criteria
+				if (n.has_property("insert-mode")) {
+					std::string ins_mode = n.property("insert-mode");
+					if (ins_mode == "closest-node" || ins_mode == "CLOSEST_NODE") {
+						conn_mode = NavGraphGeneratorInterface::CLOSEST_NODE;
+					} else if (ins_mode == "closest-edge" || ins_mode == "CLOSEST_EDGE") {
+						conn_mode = NavGraphGeneratorInterface::CLOSEST_EDGE;
+					} else if (ins_mode == "closest-edge-or-node" || ins_mode == "CLOSEST_EDGE_OR_NODE") {
+						conn_mode = NavGraphGeneratorInterface::CLOSEST_EDGE_OR_NODE;
+					} else if (ins_mode == "unconnected" || ins_mode == "UNCONNECTED") {
+						conn_mode = NavGraphGeneratorInterface::UNCONNECTED;
+					} else if (ins_mode == "not-connected" || ins_mode == "NOT_CONNECTED") {
+						conn_mode = NavGraphGeneratorInterface::NOT_CONNECTED;
+					} else {
+						ins_mode = "NOT_CONNECTED";
+						logger->log_warn(name(),
+						                 "Unknown insertion mode '%s' for node '%s', "
+						                 "defaulting to NOT_CONNECTED",
+						                 ins_mode.c_str(),
+						                 n.name().c_str());
+					}
+				}
 
-        logger->log_debug(name(), "Copying node %s (insertion mode %s)",
-                          n.name().c_str(),
-                          navgen_if_->tostring_ConnectionMode(conn_mode));
-        navgen_if_->msgq_enqueue(
-            new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-                n.name().c_str(), n.x(), n.y(), conn_mode));
-      } else {
-        logger->log_debug(name(), "Ignoring irrelevant node %s",
-                          n.name().c_str());
-      }
+				logger->log_debug(name(),
+				                  "Copying node %s (insertion mode %s)",
+				                  n.name().c_str(),
+				                  navgen_if_->tostring_ConnectionMode(conn_mode));
+				navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+				  n.name().c_str(), n.x(), n.y(), conn_mode));
+			} else {
+				logger->log_debug(name(), "Ignoring irrelevant node %s", n.name().c_str());
+			}
 
-      if (do_copy || (n.has_property("only-copy-properties") &&
-                      n.property_as_bool("only-copy-properties"))) {
-        // copy node properties
-        for (const auto &p : n.properties()) {
-          if (p.first != "only-copy-properties") {
-            logger->log_debug(name(), "    Copying property %s=%s",
-                              p.first.c_str(), p.second.c_str());
-            navgen_if_->msgq_enqueue(
-                new NavGraphGeneratorInterface::
-                    SetPointOfInterestPropertyMessage(
-                        n.name().c_str(), p.first.c_str(), p.second.c_str()));
-          }
-        }
-      }
-    }
-    for (const NavGraphEdge &e : edges) {
-      if (e.has_property("generated"))
-        continue;
+			if (do_copy
+			    || (n.has_property("only-copy-properties")
+			        && n.property_as_bool("only-copy-properties"))) {
+				// copy node properties
+				for (const auto &p : n.properties()) {
+					if (p.first != "only-copy-properties") {
+						logger->log_debug(name(),
+						                  "    Copying property %s=%s",
+						                  p.first.c_str(),
+						                  p.second.c_str());
+						navgen_if_->msgq_enqueue(
+						  new NavGraphGeneratorInterface::SetPointOfInterestPropertyMessage(n.name().c_str(),
+						                                                                    p.first.c_str(),
+						                                                                    p.second.c_str()));
+					}
+				}
+			}
+		}
+		for (const NavGraphEdge &e : edges) {
+			if (e.has_property("generated"))
+				continue;
 
-      std::list<std::string> en = {e.from(), e.to()};
-      if (std::all_of(en.begin(), en.end(), [&cn](const std::string &enn) {
-            return std::find(cn.begin(), cn.end(), enn) != cn.end();
-          })) {
-        logger->log_debug(name(), "Copying edge %s-%s%s", e.from().c_str(),
-                          e.is_directed() ? ">" : "-", e.to().c_str());
-        navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddEdgeMessage(
-            e.from().c_str(), e.to().c_str(), e.is_directed(),
-            NavGraphGeneratorInterface::SPLIT_INTERSECTION));
-      } else {
-        logger->log_debug(name(), "Ignoring irrelevant edge %s-%s%s",
-                          e.from().c_str(), e.is_directed() ? ">" : "-",
-                          e.to().c_str());
-      }
-    }
-  }
+			std::list<std::string> en = {e.from(), e.to()};
+			if (std::all_of(en.begin(), en.end(), [&cn](const std::string &enn) {
+				    return std::find(cn.begin(), cn.end(), enn) != cn.end();
+			    })) {
+				logger->log_debug(name(),
+				                  "Copying edge %s-%s%s",
+				                  e.from().c_str(),
+				                  e.is_directed() ? ">" : "-",
+				                  e.to().c_str());
+				navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddEdgeMessage(
+				  e.from().c_str(),
+				  e.to().c_str(),
+				  e.is_directed(),
+				  NavGraphGeneratorInterface::SPLIT_INTERSECTION));
+			} else {
+				logger->log_debug(name(),
+				                  "Ignoring irrelevant edge %s-%s%s",
+				                  e.from().c_str(),
+				                  e.is_directed() ? ">" : "-",
+				                  e.to().c_str());
+			}
+		}
+	}
 
-  for (const Eigen::Vector2i &zn : wait_zones_) {
-    std::string z_name = "WAIT-";
+	for (const Eigen::Vector2i &zn : wait_zones_) {
+		std::string z_name = "WAIT-";
 
-    float x = float(zn.x());
-    if (x < 0) {
-      x += 0.5f;
-      z_name += "M-Z";
-    } else {
-      x -= 0.5f;
-      z_name += "C-Z";
-    }
+		float x = float(zn.x());
+		if (x < 0) {
+			x += 0.5f;
+			z_name += "M-Z";
+		} else {
+			x -= 0.5f;
+			z_name += "C-Z";
+		}
 
-    float y = float(zn.y());
-    if (y < 0)
-      y += 0.5f;
-    else
-      y -= 0.5f;
+		float y = float(zn.y());
+		if (y < 0)
+			y += 0.5f;
+		else
+			y -= 0.5f;
 
-    z_name += std::to_string(std::abs(zn.x())) + std::to_string(zn.y());
+		z_name += std::to_string(std::abs(zn.x())) + std::to_string(zn.y());
 
-    logger->log_info(name(), "Adding wait zone %s.", z_name.c_str());
+		logger->log_info(name(), "Adding wait zone %s.", z_name.c_str());
 
-    navgen_if_->msgq_enqueue(
-        new NavGraphGeneratorInterface::AddPointOfInterestMessage(
-            z_name.c_str(), x, y,
-            NavGraphGeneratorInterface::CLOSEST_EDGE_OR_NODE));
-  }
+		navgen_if_->msgq_enqueue(new NavGraphGeneratorInterface::AddPointOfInterestMessage(
+		  z_name.c_str(), x, y, NavGraphGeneratorInterface::CLOSEST_EDGE_OR_NODE));
+	}
 
-  NavGraphGeneratorInterface::ComputeMessage *compute_msg =
-      new NavGraphGeneratorInterface::ComputeMessage();
-  compute_msg->ref();
-  navgen_if_->msgq_enqueue(compute_msg);
-  compute_msgid_ = compute_msg->id();
-  compute_msg->unref();
+	NavGraphGeneratorInterface::ComputeMessage *compute_msg =
+	  new NavGraphGeneratorInterface::ComputeMessage();
+	compute_msg->ref();
+	navgen_if_->msgq_enqueue(compute_msg);
+	compute_msgid_ = compute_msg->id();
+	compute_msg->unref();
 }
 
-void NavGraphGeneratorMPSThread::bb_interface_data_changed(
-    Interface *interface) throw() {
-  navgen_if_->read();
-  if (navgen_if_->msgid() == compute_msgid_ && navgen_if_->is_final()) {
-    logger->log_info(name(), "Computation finished");
-    navgen_mps_if_->set_final(true);
-    navgen_mps_if_->write();
-  }
+void
+NavGraphGeneratorMPSThread::bb_interface_data_changed(Interface *interface) throw()
+{
+	navgen_if_->read();
+	if (navgen_if_->msgid() == compute_msgid_ && navgen_if_->is_final()) {
+		logger->log_info(name(), "Computation finished");
+		navgen_mps_if_->set_final(true);
+		navgen_mps_if_->write();
+	}
 }

--- a/src/plugins/navgraph-generator-mps/navgraph_generator_mps_thread.h
+++ b/src/plugins/navgraph-generator-mps/navgraph_generator_mps_thread.h
@@ -29,11 +29,9 @@
 #include <blackboard/interface_listener.h>
 #include <core/threading/thread.h>
 #include <core/utils/lock_list.h>
-
 #include <interfaces/NavGraphGeneratorInterface.h>
 
 #include <Eigen/Geometry>
-
 #include <array>
 #include <map>
 #include <string>
@@ -50,92 +48,99 @@ class NavGraphGeneratorMPSThread : public fawkes::Thread,
                                    public fawkes::ConfigurableAspect,
                                    public fawkes::BlackBoardAspect,
                                    public fawkes::TransformAspect,
-                                   public fawkes::BlackBoardInterfaceListener {
+                                   public fawkes::BlackBoardInterfaceListener
+{
 public:
-  NavGraphGeneratorMPSThread();
-  virtual ~NavGraphGeneratorMPSThread();
+	NavGraphGeneratorMPSThread();
+	virtual ~NavGraphGeneratorMPSThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  void generate_navgraph();
-  fawkes::NavGraphGeneratorInterface::ConnectionMode
-  mps_node_insmode(std::string name);
+	void                                               generate_navgraph();
+	fawkes::NavGraphGeneratorInterface::ConnectionMode mps_node_insmode(std::string name);
 
-  virtual void bb_interface_data_changed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_changed(fawkes::Interface *interface) throw();
 
 private:
-  std::string cfg_global_frame_;
-  float cfg_mps_width_;
-  float cfg_mps_length_;
-  float cfg_mps_approach_dist_;
-  bool cfg_mps_corner_obst_;
-  float cfg_map_min_dist_;
-  float cfg_map_point_max_dist_;
-  fawkes::NavGraphGeneratorInterface::Algorithm cfg_algorithm_;
-  std::map<std::string, std::string> cfg_algo_params_;
-  Eigen::Vector2f cfg_bounding_box_p1_;
-  Eigen::Vector2f cfg_bounding_box_p2_;
-  size_t cfg_num_wait_zones_;
+	std::string                                   cfg_global_frame_;
+	float                                         cfg_mps_width_;
+	float                                         cfg_mps_length_;
+	float                                         cfg_mps_approach_dist_;
+	bool                                          cfg_mps_corner_obst_;
+	float                                         cfg_map_min_dist_;
+	float                                         cfg_map_point_max_dist_;
+	fawkes::NavGraphGeneratorInterface::Algorithm cfg_algorithm_;
+	std::map<std::string, std::string>            cfg_algo_params_;
+	Eigen::Vector2f                               cfg_bounding_box_p1_;
+	Eigen::Vector2f                               cfg_bounding_box_p2_;
+	size_t                                        cfg_num_wait_zones_;
 
-  unsigned int last_id_;
-  fawkes::NavGraphGeneratorInterface *navgen_if_;
-  fawkes::NavGraphWithMPSGeneratorInterface *navgen_mps_if_;
+	unsigned int                               last_id_;
+	fawkes::NavGraphGeneratorInterface *       navgen_if_;
+	fawkes::NavGraphWithMPSGeneratorInterface *navgen_mps_if_;
 
-  fawkes::BlackBoardOnMessageWaker *msg_waker_;
+	fawkes::BlackBoardOnMessageWaker *msg_waker_;
 
-  fawkes::NavGraph *base_graph_;
+	fawkes::NavGraph *base_graph_;
 
-  std::vector<unsigned int> exp_zones_;
+	std::vector<unsigned int> exp_zones_;
 
-  unsigned int compute_msgid_;
-  std::vector<Eigen::Vector2i> wait_zones_;
+	unsigned int                 compute_msgid_;
+	std::vector<Eigen::Vector2i> wait_zones_;
 
-  typedef struct {
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+	typedef struct
+	{
+		EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    std::string tag_frame;
-    Eigen::Vector3f tag_pose_pos;
-    Eigen::Quaternionf tag_pose_ori;
-    bool tag_is_input;
+		std::string        tag_frame;
+		Eigen::Vector3f    tag_pose_pos;
+		Eigen::Quaternionf tag_pose_ori;
+		bool               tag_is_input;
 
-    Eigen::Vector3f pose_pos;
-    Eigen::Quaternionf pose_ori;
-    float pose_yaw;
+		Eigen::Vector3f    pose_pos;
+		Eigen::Quaternionf pose_ori;
+		float              pose_yaw;
 
-    bool transformed;
+		bool transformed;
 
-    Eigen::Vector3f input_pos;
-    Eigen::Quaternionf input_ori;
-    float input_yaw;
+		Eigen::Vector3f    input_pos;
+		Eigen::Quaternionf input_ori;
+		float              input_yaw;
 
-    Eigen::Vector3f output_pos;
-    Eigen::Quaternionf output_ori;
-    float output_yaw;
-    Eigen::Vector2i zone;
-    std::vector<Eigen::Vector2i> blocked_zones;
+		Eigen::Vector3f              output_pos;
+		Eigen::Quaternionf           output_ori;
+		float                        output_yaw;
+		Eigen::Vector2i              zone;
+		std::vector<Eigen::Vector2i> blocked_zones;
 
-    std::vector<Eigen::Vector2f> corners;
+		std::vector<Eigen::Vector2f> corners;
 
-  } MPSStation;
-  std::map<std::string, MPSStation> stations_;
+	} MPSStation;
+	std::map<std::string, MPSStation> stations_;
 
-  static std::map<uint16_t, std::vector<Eigen::Vector2i>> zone_blocking_;
-  static std::vector<Eigen::Vector2i> reserved_zones_;
+	static std::map<uint16_t, std::vector<Eigen::Vector2i>> zone_blocking_;
+	static std::vector<Eigen::Vector2i>                     reserved_zones_;
 
-  void update_station(std::string id, bool input, std::string frame,
-                      double tag_pos[3], double tag_ori[4],
-                      Eigen::Vector2i zone);
-  static inline std::vector<Eigen::Vector2i>
-  blocked_zones(Eigen::Vector2i zone, uint16_t discrete_ori);
-  void generate_wait_zones(size_t count,
-                           std::vector<Eigen::Vector2i> &free_zones);
+	void                                       update_station(std::string     id,
+	                                                          bool            input,
+	                                                          std::string     frame,
+	                                                          double          tag_pos[3],
+	                                                          double          tag_ori[4],
+	                                                          Eigen::Vector2i zone);
+	static inline std::vector<Eigen::Vector2i> blocked_zones(Eigen::Vector2i zone,
+	                                                         uint16_t        discrete_ori);
+	void generate_wait_zones(size_t count, std::vector<Eigen::Vector2i> &free_zones);
 };
 
 #endif

--- a/src/plugins/navgraph-prefer-exploration/navgraph_prefer_exploration_plugin.cpp
+++ b/src/plugins/navgraph-prefer-exploration/navgraph_prefer_exploration_plugin.cpp
@@ -19,23 +19,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "navgraph_prefer_exploration_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Automatically generate navgraph for MPS
  * @author Tim Niemueller
  */
-class NavGraphPreferExplorationPlugin : public fawkes::Plugin {
+class NavGraphPreferExplorationPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  NavGraphPreferExplorationPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new NavGraphPreferExplorationThread());
-  }
+	NavGraphPreferExplorationPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new NavGraphPreferExplorationThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Increase cost of non-exploration graph parts")

--- a/src/plugins/navgraph-prefer-exploration/navgraph_prefer_exploration_thread.cpp
+++ b/src/plugins/navgraph-prefer-exploration/navgraph_prefer_exploration_thread.cpp
@@ -37,68 +37,78 @@ using namespace fawkes;
 
 /** Constructor. */
 NavGraphPreferExplorationThread::NavGraphPreferExplorationThread()
-    : Thread("NavGraphPreferExplorationThread", Thread::OPMODE_WAITFORWAKEUP) {
-  set_coalesce_wakeups(true);
+: Thread("NavGraphPreferExplorationThread", Thread::OPMODE_WAITFORWAKEUP)
+{
+	set_coalesce_wakeups(true);
 }
 
 /** Destructor. */
-NavGraphPreferExplorationThread::~NavGraphPreferExplorationThread() {}
-
-void NavGraphPreferExplorationThread::init() {
-  cfg_cost_factor_ =
-      config->get_float("/navgraph-prefer-exploration/cost-factor");
-
-  edge_cost_constraint_ =
-      new NavGraphStaticListEdgeCostConstraint("prefer-expl");
-  navgraph->constraint_repo()->register_constraint(edge_cost_constraint_);
-
-  navgraph->add_change_listener(this);
-
-  // wakeup();
+NavGraphPreferExplorationThread::~NavGraphPreferExplorationThread()
+{
 }
 
-void NavGraphPreferExplorationThread::finalize() {
-  navgraph->remove_change_listener(this);
-  navgraph->constraint_repo()->unregister_constraint(
-      edge_cost_constraint_->name());
-  delete edge_cost_constraint_;
+void
+NavGraphPreferExplorationThread::init()
+{
+	cfg_cost_factor_ = config->get_float("/navgraph-prefer-exploration/cost-factor");
+
+	edge_cost_constraint_ = new NavGraphStaticListEdgeCostConstraint("prefer-expl");
+	navgraph->constraint_repo()->register_constraint(edge_cost_constraint_);
+
+	navgraph->add_change_listener(this);
+
+	// wakeup();
 }
 
-void NavGraphPreferExplorationThread::loop() {
-  MutexLocker lock(navgraph.objmutex_ptr());
-
-  bool has_exploration_nodes = false;
-
-  std::vector<std::pair<fawkes::NavGraphEdge, float>> cedges;
-
-  const std::vector<NavGraphEdge> &edges = navgraph->edges();
-  for (const NavGraphEdge &e : edges) {
-    if (!e.has_property("created-for")) {
-      cedges.push_back(std::make_pair(e, cfg_cost_factor_));
-    } else {
-      std::string created_for = e.property("created-for");
-      std::string n1, n2;
-      std::string::size_type pos;
-      if ((pos = created_for.find("--")) != std::string::npos) {
-        n1 = created_for.substr(0, pos);
-        n2 = created_for.substr(pos + 2);
-      }
-
-      if (!n1.empty() && !n2.empty()) {
-        if (n1.find("Exp-") == 0 || n2.find("Exp-") == 0) {
-          has_exploration_nodes = true;
-        } else {
-          cedges.push_back(std::make_pair(e, cfg_cost_factor_));
-        }
-      }
-    }
-  }
-
-  if (has_exploration_nodes) {
-    edge_cost_constraint_->add_edges(cedges);
-  } else {
-    edge_cost_constraint_->clear_edges();
-  }
+void
+NavGraphPreferExplorationThread::finalize()
+{
+	navgraph->remove_change_listener(this);
+	navgraph->constraint_repo()->unregister_constraint(edge_cost_constraint_->name());
+	delete edge_cost_constraint_;
 }
 
-void NavGraphPreferExplorationThread::graph_changed() throw() { wakeup(); }
+void
+NavGraphPreferExplorationThread::loop()
+{
+	MutexLocker lock(navgraph.objmutex_ptr());
+
+	bool has_exploration_nodes = false;
+
+	std::vector<std::pair<fawkes::NavGraphEdge, float>> cedges;
+
+	const std::vector<NavGraphEdge> &edges = navgraph->edges();
+	for (const NavGraphEdge &e : edges) {
+		if (!e.has_property("created-for")) {
+			cedges.push_back(std::make_pair(e, cfg_cost_factor_));
+		} else {
+			std::string            created_for = e.property("created-for");
+			std::string            n1, n2;
+			std::string::size_type pos;
+			if ((pos = created_for.find("--")) != std::string::npos) {
+				n1 = created_for.substr(0, pos);
+				n2 = created_for.substr(pos + 2);
+			}
+
+			if (!n1.empty() && !n2.empty()) {
+				if (n1.find("Exp-") == 0 || n2.find("Exp-") == 0) {
+					has_exploration_nodes = true;
+				} else {
+					cedges.push_back(std::make_pair(e, cfg_cost_factor_));
+				}
+			}
+		}
+	}
+
+	if (has_exploration_nodes) {
+		edge_cost_constraint_->add_edges(cedges);
+	} else {
+		edge_cost_constraint_->clear_edges();
+	}
+}
+
+void
+NavGraphPreferExplorationThread::graph_changed() throw()
+{
+	wakeup();
+}

--- a/src/plugins/navgraph-prefer-exploration/navgraph_prefer_exploration_thread.h
+++ b/src/plugins/navgraph-prefer-exploration/navgraph_prefer_exploration_thread.h
@@ -37,31 +37,35 @@ namespace fawkes {
 class NavGraphStaticListEdgeCostConstraint;
 }
 
-class NavGraphPreferExplorationThread
-    : public fawkes::Thread,
-      public fawkes::ClockAspect,
-      public fawkes::LoggingAspect,
-      public fawkes::ConfigurableAspect,
-      public fawkes::BlackBoardAspect,
-      public fawkes::NavGraphAspect,
-      public fawkes::NavGraph::ChangeListener {
+class NavGraphPreferExplorationThread : public fawkes::Thread,
+                                        public fawkes::ClockAspect,
+                                        public fawkes::LoggingAspect,
+                                        public fawkes::ConfigurableAspect,
+                                        public fawkes::BlackBoardAspect,
+                                        public fawkes::NavGraphAspect,
+                                        public fawkes::NavGraph::ChangeListener
+{
 public:
-  NavGraphPreferExplorationThread();
-  virtual ~NavGraphPreferExplorationThread();
+	NavGraphPreferExplorationThread();
+	virtual ~NavGraphPreferExplorationThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  virtual void graph_changed() throw();
+	virtual void graph_changed() throw();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
-  float cfg_cost_factor_;
-  fawkes::NavGraphStaticListEdgeCostConstraint *edge_cost_constraint_;
+	float                                         cfg_cost_factor_;
+	fawkes::NavGraphStaticListEdgeCostConstraint *edge_cost_constraint_;
 };
 
 #endif

--- a/src/plugins/navgraph_broker/navgraph_broker_plugin.cpp
+++ b/src/plugins/navgraph_broker/navgraph_broker_plugin.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "navgraph_broker_thread.h"
+
 #include <core/plugin.h>
 
 using namespace fawkes;
@@ -28,14 +29,16 @@ using namespace fawkes;
 /** NavGraph Broker plugin.
  * @author Sebastian Reuter
  */
-class NavGraphBrokerPlugin : public fawkes::Plugin {
+class NavGraphBrokerPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  NavGraphBrokerPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new NavgraphBrokerThread());
-  }
+	NavGraphBrokerPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new NavgraphBrokerThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("NavGraph Broker")

--- a/src/plugins/navgraph_broker/navgraph_broker_thread.cpp
+++ b/src/plugins/navgraph_broker/navgraph_broker_thread.cpp
@@ -20,8 +20,10 @@
  */
 
 #include "navgraph_broker_thread.h"
-#include <boost/algorithm/string.hpp>
+
 #include <core/threading/mutex_locker.h>
+
+#include <boost/algorithm/string.hpp>
 
 using namespace fawkes;
 
@@ -32,331 +34,334 @@ using namespace fawkes;
 
 /** Constructor. */
 NavgraphBrokerThread::NavgraphBrokerThread()
-    : Thread("NavgraphBrokerThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT),
-      BlackBoardInterfaceListener("NavPathInterface"), GossipAspect("example") {
+: Thread("NavgraphBrokerThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT),
+  BlackBoardInterfaceListener("NavPathInterface"),
+  GossipAspect("example")
+{
 }
 
 /** Destructor. */
-NavgraphBrokerThread::~NavgraphBrokerThread() {}
+NavgraphBrokerThread::~NavgraphBrokerThread()
+{
+}
 
-void NavgraphBrokerThread::init() {
+void
+NavgraphBrokerThread::init()
+{
+	// initialize interfaces
+	path_if_ = blackboard->open_for_reading<NavPathInterface>("NavPath");
+	bbil_add_data_interface(path_if_);
+	blackboard->register_listener(this);
 
-  // initialize interfaces
-  path_if_ = blackboard->open_for_reading<NavPathInterface>("NavPath");
-  bbil_add_data_interface(path_if_);
-  blackboard->register_listener(this);
+	robotname_ = config->get_string("/plugins/navgraph-broker/robotname");
+	// get robot-name from host.yaml
+	try {
+		robotname_ = config->get_string("/robotname");
+	} catch (Exception &e) {
+		logger->log_error(name(),
+		                  "Can't read the robot name. Is 'robot-name' "
+		                  "specified in cfg/host.yaml ?");
+	}
+	repeat_send_duration_ =
+	  (double)config->get_float("/plugins/navgraph-broker/repeat-send-duration");
+	max_reservation_duration_ =
+	  (double)config->get_float("/plugins/navgraph-broker/max-reservation-duration");
+	use_node_constraints_ = config->get_bool("/plugins/navgraph-broker/use-node-constraint");
 
-  robotname_ = config->get_string("/plugins/navgraph-broker/robotname");
-  // get robot-name from host.yaml
-  try {
-    robotname_ = config->get_string("/robotname");
-  } catch (Exception &e) {
-    logger->log_error(name(), "Can't read the robot name. Is 'robot-name' "
-                              "specified in cfg/host.yaml ?");
-  }
-  repeat_send_duration_ = (double)config->get_float(
-      "/plugins/navgraph-broker/repeat-send-duration");
-  max_reservation_duration_ = (double)config->get_float(
-      "/plugins/navgraph-broker/max-reservation-duration");
-  use_node_constraints_ =
-      config->get_bool("/plugins/navgraph-broker/use-node-constraint");
+	m_mutex_ = new Mutex();
+	m_       = new navgraph_broker::NavigationMessage();
+	m_->set_robotname(robotname_.c_str());
+	last_message_time_sec_  = 0;
+	last_message_time_nsec_ = 0;
 
-  m_mutex_ = new Mutex();
-  m_ = new navgraph_broker::NavigationMessage();
-  m_->set_robotname(robotname_.c_str());
-  last_message_time_sec_ = 0;
-  last_message_time_nsec_ = 0;
-
-  /******************************************************************************************
+	/******************************************************************************************
    * ***************************************************************************************
    * ***************************************************************************************
    * **************************** Test Nodes for reservation
    *****************************************
    * ***************************************************************************************
    ****************************************************************************************/
-  // load reserved_nodes from config for testing issues
+	// load reserved_nodes from config for testing issues
 
-  if (use_node_constraints_) {
-    try {
-      std::string snodes =
-          config->get_string("/plugins/navgraph-broker/reserved_nodes");
+	if (use_node_constraints_) {
+		try {
+			std::string snodes = config->get_string("/plugins/navgraph-broker/reserved_nodes");
 
-      std::vector<fawkes::NavGraphNode> nodes = get_nodes_from_string(snodes);
+			std::vector<fawkes::NavGraphNode> nodes = get_nodes_from_string(snodes);
 
-      if (nodes.size() > 0) {
-        std::string txt = "{";
-        for (uint16_t i = 0; i < nodes.size(); i++) {
-          txt += nodes[i].name();
-          txt += ",";
-        }
-        txt.erase(txt.length() - 1, 1);
-        txt += "}";
-        logger->log_info(name(), "Reserving test nodes  %s", txt.c_str());
-      }
+			if (nodes.size() > 0) {
+				std::string txt = "{";
+				for (uint16_t i = 0; i < nodes.size(); i++) {
+					txt += nodes[i].name();
+					txt += ",";
+				}
+				txt.erase(txt.length() - 1, 1);
+				txt += "}";
+				logger->log_info(name(), "Reserving test nodes  %s", txt.c_str());
+			}
 
-      fawkes::Time now(clock);
-      std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_nodes;
-      double max_reservation_duration = (double)max_reservation_duration_;
-      fawkes::Time valid_duration = now + max_reservation_duration;
-      for (fawkes::NavGraphNode &node : nodes) {
-        timed_nodes.push_back(std::pair<fawkes::NavGraphNode, fawkes::Time>(
-            node, valid_duration));
-      }
+			fawkes::Time                                               now(clock);
+			std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_nodes;
+			double       max_reservation_duration = (double)max_reservation_duration_;
+			fawkes::Time valid_duration           = now + max_reservation_duration;
+			for (fawkes::NavGraphNode &node : nodes) {
+				timed_nodes.push_back(std::pair<fawkes::NavGraphNode, fawkes::Time>(node, valid_duration));
+			}
 
-      reserve_nodes("test", timed_nodes);
+			reserve_nodes("test", timed_nodes);
 
-    } catch (Exception &e) {
-      logger->log_error(name(),
-                        "No static nodes reserved. Did you miss to specify "
-                        "'reserved_nodes' in navgraph.broker.yaml ?");
-    }
-  }
+		} catch (Exception &e) {
+			logger->log_error(name(),
+			                  "No static nodes reserved. Did you miss to specify "
+			                  "'reserved_nodes' in navgraph.broker.yaml ?");
+		}
+	}
 
-  /******************************************************************************************
+	/******************************************************************************************
    * ***************************************************************************************
    * ***************************************************************************************
    * ***************************************************************************************
    * ***************************************************************************************
    ****************************************************************************************/
 
-  // init gossip receiver
-  try {
-    gossip_group->message_register()
-        .add_message_type<navgraph_broker::NavigationMessage>();
-  } catch (std::runtime_error &e) {
-  } // ignore, probably already added
+	// init gossip receiver
+	try {
+		gossip_group->message_register().add_message_type<navgraph_broker::NavigationMessage>();
+	} catch (std::runtime_error &e) {
+	} // ignore, probably already added
 
-  sig_rcvd_conn_ = gossip_group->signal_received().connect(boost::bind(
-      &NavgraphBrokerThread::handle_peer_msg, this, _1, _2, _3, _4));
+	sig_rcvd_conn_ = gossip_group->signal_received().connect(
+	  boost::bind(&NavgraphBrokerThread::handle_peer_msg, this, _1, _2, _3, _4));
 
-  sig_recv_error_conn_ = gossip_group->signal_recv_error().connect(
-      boost::bind(&NavgraphBrokerThread::handle_peer_recv_error, this, _1, _2));
+	sig_recv_error_conn_ = gossip_group->signal_recv_error().connect(
+	  boost::bind(&NavgraphBrokerThread::handle_peer_recv_error, this, _1, _2));
 
-  sig_send_error_conn_ = gossip_group->signal_send_error().connect(
-      boost::bind(&NavgraphBrokerThread::handle_peer_send_error, this, _1));
+	sig_send_error_conn_ = gossip_group->signal_send_error().connect(
+	  boost::bind(&NavgraphBrokerThread::handle_peer_send_error, this, _1));
 }
 
-void NavgraphBrokerThread::finalize() {
-
-  /*
+void
+NavgraphBrokerThread::finalize()
+{
+	/*
    * ToDo: Keep registered constraints in mind and unregister them on finalize
    */
-  // constraint_repo.lock();
-  // constraint_repo->unregister_constraint(robotname_.c_str());
-  // constraint_repo.unlock();
+	// constraint_repo.lock();
+	// constraint_repo->unregister_constraint(robotname_.c_str());
+	// constraint_repo.unlock();
 
-  blackboard->unregister_listener(this);
-  blackboard->close(path_if_);
+	blackboard->unregister_listener(this);
+	blackboard->close(path_if_);
 
-  sig_rcvd_conn_.disconnect();
-  sig_recv_error_conn_.disconnect();
-  sig_send_error_conn_.disconnect();
+	sig_rcvd_conn_.disconnect();
+	sig_recv_error_conn_.disconnect();
+	sig_send_error_conn_.disconnect();
 
-  delete m_mutex_;
-  delete m_;
+	delete m_mutex_;
+	delete m_;
 }
 
-void NavgraphBrokerThread::loop() {
+void
+NavgraphBrokerThread::loop()
+{
+	if (!reservation_messages_.empty()) {
+		std::shared_ptr<navgraph_broker::NavigationMessage> msg = reservation_messages_.front();
+		reservation_messages_.pop();
 
-  if (!reservation_messages_.empty()) {
+		if (true /*msg->robotname() != robotname_*/) {
+			std::vector<fawkes::NavGraphNode> nodes;
 
-    std::shared_ptr<navgraph_broker::NavigationMessage> msg =
-        reservation_messages_.front();
-    reservation_messages_.pop();
+			// get nodes out of message
+			for (int i = 0; i < (msg->nodelist_size()); i++) {
+				nodes.push_back(navgraph->node(msg->nodelist(i)));
+			}
 
-    if (true /*msg->robotname() != robotname_*/) {
+			// put nodes pairwise with time into vector
+			fawkes::Time now(clock);
+			double       max_reservation_duration = (double)max_reservation_duration_;
+			fawkes::Time valid_duration           = now + max_reservation_duration;
+			std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_nodes;
+			for (fawkes::NavGraphNode &node : nodes) {
+				timed_nodes.push_back(std::pair<fawkes::NavGraphNode, fawkes::Time>(node, valid_duration));
+			}
 
-      std::vector<fawkes::NavGraphNode> nodes;
+			std::string constraint_name;
 
-      // get nodes out of message
-      for (int i = 0; i < (msg->nodelist_size()); i++) {
-        nodes.push_back(navgraph->node(msg->nodelist(i)));
-      }
+			// reserve node / edge
+			if (use_node_constraints_) {
+				constraint_name = msg->robotname() + "_Reserved_Nodes";
+				reserve_nodes(constraint_name, timed_nodes);
+			} else {
+				constraint_name = msg->robotname() + "_Reserved_Edges";
+				reserve_edges(constraint_name, timed_nodes);
+			}
+		} else {
+			logger->log_warn(name(),
+			                 "Message with proper component_id and msg_type, but no conversion. "
+			                 " Wrong component ID/message type to C++ type mapping?");
+		}
+	}
 
-      // put nodes pairwise with time into vector
-      fawkes::Time now(clock);
-      double max_reservation_duration = (double)max_reservation_duration_;
-      fawkes::Time valid_duration = now + max_reservation_duration;
-      std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_nodes;
-      for (fawkes::NavGraphNode &node : nodes) {
-        timed_nodes.push_back(std::pair<fawkes::NavGraphNode, fawkes::Time>(
-            node, valid_duration));
-      }
-
-      std::string constraint_name;
-
-      // reserve node / edge
-      if (use_node_constraints_) {
-        constraint_name = msg->robotname() + "_Reserved_Nodes";
-        reserve_nodes(constraint_name, timed_nodes);
-      } else {
-        constraint_name = msg->robotname() + "_Reserved_Edges";
-        reserve_edges(constraint_name, timed_nodes);
-      }
-    } else {
-      logger->log_warn(
-          name(),
-          "Message with proper component_id and msg_type, but no conversion. "
-          " Wrong component ID/message type to C++ type mapping?");
-    }
-  }
-
-  fawkes::Time now(clock);
-  if ((now.in_sec() - time_of_plan_chg.in_sec()) <= repeat_send_duration_) {
-    send_msg();
-  }
+	fawkes::Time now(clock);
+	if ((now.in_sec() - time_of_plan_chg.in_sec()) <= repeat_send_duration_) {
+		send_msg();
+	}
 }
 
 std::vector<fawkes::NavGraphNode>
-NavgraphBrokerThread::get_nodes_from_string(std::string path) {
+NavgraphBrokerThread::get_nodes_from_string(std::string path)
+{
+	std::vector<fawkes::NavGraphNode> nodes;
+	std::vector<std::string>          string_node_time_list;
+	boost::split(string_node_time_list, path, boost::is_any_of(","));
 
-  std::vector<fawkes::NavGraphNode> nodes;
-  std::vector<std::string> string_node_time_list;
-  boost::split(string_node_time_list, path, boost::is_any_of(","));
-
-  for (unsigned int i = 0; i < string_node_time_list.size(); i++) {
-    nodes.push_back(navgraph->node(string_node_time_list[i]));
-  }
-  return nodes;
+	for (unsigned int i = 0; i < string_node_time_list.size(); i++) {
+		nodes.push_back(navgraph->node(string_node_time_list[i]));
+	}
+	return nodes;
 }
 
 std::vector<std::string>
-NavgraphBrokerThread::get_path_from_interface_as_vector() {
+NavgraphBrokerThread::get_path_from_interface_as_vector()
+{
+	std::vector<std::string> path;
+	std::string              vpath[40];
 
-  std::vector<std::string> path;
-  std::string vpath[40];
+	unsigned int path_length = path_if_->path_length();
 
-  unsigned int path_length = path_if_->path_length();
+	vpath[0]  = path_if_->path_node_1();
+	vpath[1]  = path_if_->path_node_2();
+	vpath[2]  = path_if_->path_node_3();
+	vpath[3]  = path_if_->path_node_4();
+	vpath[4]  = path_if_->path_node_5();
+	vpath[5]  = path_if_->path_node_6();
+	vpath[6]  = path_if_->path_node_7();
+	vpath[7]  = path_if_->path_node_8();
+	vpath[8]  = path_if_->path_node_9();
+	vpath[9]  = path_if_->path_node_10();
+	vpath[10] = path_if_->path_node_11();
+	vpath[11] = path_if_->path_node_12();
+	vpath[12] = path_if_->path_node_13();
+	vpath[13] = path_if_->path_node_14();
+	vpath[14] = path_if_->path_node_15();
+	vpath[15] = path_if_->path_node_16();
+	vpath[16] = path_if_->path_node_17();
+	vpath[17] = path_if_->path_node_18();
+	vpath[18] = path_if_->path_node_19();
+	vpath[29] = path_if_->path_node_20();
+	vpath[20] = path_if_->path_node_21();
+	vpath[21] = path_if_->path_node_22();
+	vpath[22] = path_if_->path_node_23();
+	vpath[23] = path_if_->path_node_24();
+	vpath[24] = path_if_->path_node_25();
+	vpath[25] = path_if_->path_node_26();
+	vpath[26] = path_if_->path_node_27();
+	vpath[27] = path_if_->path_node_28();
+	vpath[28] = path_if_->path_node_29();
+	vpath[29] = path_if_->path_node_30();
+	vpath[30] = path_if_->path_node_31();
+	vpath[31] = path_if_->path_node_32();
+	vpath[32] = path_if_->path_node_33();
+	vpath[33] = path_if_->path_node_34();
+	vpath[34] = path_if_->path_node_35();
+	vpath[35] = path_if_->path_node_36();
+	vpath[36] = path_if_->path_node_37();
+	vpath[37] = path_if_->path_node_38();
+	vpath[38] = path_if_->path_node_39();
+	vpath[39] = path_if_->path_node_40();
 
-  vpath[0] = path_if_->path_node_1();
-  vpath[1] = path_if_->path_node_2();
-  vpath[2] = path_if_->path_node_3();
-  vpath[3] = path_if_->path_node_4();
-  vpath[4] = path_if_->path_node_5();
-  vpath[5] = path_if_->path_node_6();
-  vpath[6] = path_if_->path_node_7();
-  vpath[7] = path_if_->path_node_8();
-  vpath[8] = path_if_->path_node_9();
-  vpath[9] = path_if_->path_node_10();
-  vpath[10] = path_if_->path_node_11();
-  vpath[11] = path_if_->path_node_12();
-  vpath[12] = path_if_->path_node_13();
-  vpath[13] = path_if_->path_node_14();
-  vpath[14] = path_if_->path_node_15();
-  vpath[15] = path_if_->path_node_16();
-  vpath[16] = path_if_->path_node_17();
-  vpath[17] = path_if_->path_node_18();
-  vpath[18] = path_if_->path_node_19();
-  vpath[29] = path_if_->path_node_20();
-  vpath[20] = path_if_->path_node_21();
-  vpath[21] = path_if_->path_node_22();
-  vpath[22] = path_if_->path_node_23();
-  vpath[23] = path_if_->path_node_24();
-  vpath[24] = path_if_->path_node_25();
-  vpath[25] = path_if_->path_node_26();
-  vpath[26] = path_if_->path_node_27();
-  vpath[27] = path_if_->path_node_28();
-  vpath[28] = path_if_->path_node_29();
-  vpath[29] = path_if_->path_node_30();
-  vpath[30] = path_if_->path_node_31();
-  vpath[31] = path_if_->path_node_32();
-  vpath[32] = path_if_->path_node_33();
-  vpath[33] = path_if_->path_node_34();
-  vpath[34] = path_if_->path_node_35();
-  vpath[35] = path_if_->path_node_36();
-  vpath[36] = path_if_->path_node_37();
-  vpath[37] = path_if_->path_node_38();
-  vpath[38] = path_if_->path_node_39();
-  vpath[39] = path_if_->path_node_40();
+	path_.clear();
 
-  path_.clear();
+	for (unsigned int i = 0; i < path_length && i < 39; i++) {
+		path.push_back(vpath[i]);
+	}
 
-  for (unsigned int i = 0; i < path_length && i < 39; i++) {
-    path.push_back(vpath[i]);
-  }
-
-  return path;
+	return path;
 }
 
-void NavgraphBrokerThread::reserve_nodes(
-    std::string constraint_name,
-    std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_path) {
-  LockPtr<NavGraphConstraintRepo> constraint_repo = navgraph->constraint_repo();
+void
+NavgraphBrokerThread::reserve_nodes(
+  std::string                                                constraint_name,
+  std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_path)
+{
+	LockPtr<NavGraphConstraintRepo> constraint_repo = navgraph->constraint_repo();
 
-  constraint_repo.lock();
+	constraint_repo.lock();
 
-  fawkes::NavGraphTimedReservationListNodeConstraint *timed_node_constraint;
+	fawkes::NavGraphTimedReservationListNodeConstraint *timed_node_constraint;
 
-  if (constraint_repo->has_constraint(constraint_name)) {
-    timed_node_constraint =
-        (NavGraphTimedReservationListNodeConstraint *)
-            constraint_repo->get_node_constraint(constraint_name);
-    timed_node_constraint->clear_nodes();
-    timed_node_constraint->add_nodes(timed_path);
-  } else {
-    timed_node_constraint = new NavGraphTimedReservationListNodeConstraint(
-        logger, constraint_name, clock);
-    timed_node_constraint->add_nodes(timed_path);
-    constraint_repo->register_constraint(
-        (NavGraphNodeConstraint *)timed_node_constraint);
-  }
+	if (constraint_repo->has_constraint(constraint_name)) {
+		timed_node_constraint =
+		  (NavGraphTimedReservationListNodeConstraint *)constraint_repo->get_node_constraint(
+		    constraint_name);
+		timed_node_constraint->clear_nodes();
+		timed_node_constraint->add_nodes(timed_path);
+	} else {
+		timed_node_constraint =
+		  new NavGraphTimedReservationListNodeConstraint(logger, constraint_name, clock);
+		timed_node_constraint->add_nodes(timed_path);
+		constraint_repo->register_constraint((NavGraphNodeConstraint *)timed_node_constraint);
+	}
 
-  constraint_repo.unlock();
+	constraint_repo.unlock();
 }
 
-void NavgraphBrokerThread::reserve_edges(
-    std::string constraint_name,
-    std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_path) {
-  LockPtr<NavGraphConstraintRepo> constraint_repo = navgraph->constraint_repo();
+void
+NavgraphBrokerThread::reserve_edges(
+  std::string                                                constraint_name,
+  std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_path)
+{
+	LockPtr<NavGraphConstraintRepo> constraint_repo = navgraph->constraint_repo();
 
-  constraint_repo.lock();
+	constraint_repo.lock();
 
-  fawkes::NavGraphTimedReservationListEdgeConstraint *timed_edge_constraint;
-  const std::vector<fawkes::NavGraphEdge> &graph_edges = navgraph->edges();
+	fawkes::NavGraphTimedReservationListEdgeConstraint *timed_edge_constraint;
+	const std::vector<fawkes::NavGraphEdge> &           graph_edges = navgraph->edges();
 
-  if (constraint_repo->has_constraint(constraint_name)) {
-    timed_edge_constraint =
-        (NavGraphTimedReservationListEdgeConstraint *)
-            constraint_repo->get_edge_constraint(constraint_name);
-    timed_edge_constraint->clear_edges();
+	if (constraint_repo->has_constraint(constraint_name)) {
+		timed_edge_constraint =
+		  (NavGraphTimedReservationListEdgeConstraint *)constraint_repo->get_edge_constraint(
+		    constraint_name);
+		timed_edge_constraint->clear_edges();
 
-    for (uint16_t i = 1; i < timed_path.size(); i++) {
-      for (const NavGraphEdge &gedge : graph_edges) {
-        if ((timed_path[i - 1].first.name() == gedge.from() &&
-             timed_path[i].first.name() == gedge.to()) ||
-            (timed_path[i - 1].first.name() == gedge.to() &&
-             timed_path[i].first.name() == gedge.from())) {
-          timed_edge_constraint->add_edge(gedge, timed_path[i].second);
-          break;
-        }
-      }
-    }
-  } else {
-    timed_edge_constraint = new NavGraphTimedReservationListEdgeConstraint(
-        logger, constraint_name, clock);
+		for (uint16_t i = 1; i < timed_path.size(); i++) {
+			for (const NavGraphEdge &gedge : graph_edges) {
+				if ((timed_path[i - 1].first.name() == gedge.from()
+				     && timed_path[i].first.name() == gedge.to())
+				    || (timed_path[i - 1].first.name() == gedge.to()
+				        && timed_path[i].first.name() == gedge.from())) {
+					timed_edge_constraint->add_edge(gedge, timed_path[i].second);
+					break;
+				}
+			}
+		}
+	} else {
+		timed_edge_constraint =
+		  new NavGraphTimedReservationListEdgeConstraint(logger, constraint_name, clock);
 
-    for (uint16_t i = 1; i < timed_path.size(); i++) {
-      for (const NavGraphEdge &gedge : graph_edges) {
-        if ((timed_path[i - 1].first.name() == gedge.from() &&
-             timed_path[i].first.name() == gedge.to()) ||
-            (timed_path[i - 1].first.name() == gedge.to() &&
-             timed_path[i].first.name() == gedge.from())) {
-          timed_edge_constraint->add_edge(gedge, timed_path[i].second);
-          break;
-        }
-      }
-    }
+		for (uint16_t i = 1; i < timed_path.size(); i++) {
+			for (const NavGraphEdge &gedge : graph_edges) {
+				if ((timed_path[i - 1].first.name() == gedge.from()
+				     && timed_path[i].first.name() == gedge.to())
+				    || (timed_path[i - 1].first.name() == gedge.to()
+				        && timed_path[i].first.name() == gedge.from())) {
+					timed_edge_constraint->add_edge(gedge, timed_path[i].second);
+					break;
+				}
+			}
+		}
 
-    constraint_repo->register_constraint(timed_edge_constraint);
-  }
+		constraint_repo->register_constraint(timed_edge_constraint);
+	}
 
-  constraint_repo.unlock();
+	constraint_repo.unlock();
 }
 
-void NavgraphBrokerThread::send_msg() {
-
-  /*
+void
+NavgraphBrokerThread::send_msg()
+{
+	/*
   std::string txt ="{";
   for(int i=0; i < (m_->nodelist_size()); i++ ){
           txt += m_->nodelist(i);
@@ -364,83 +369,90 @@ void NavgraphBrokerThread::send_msg() {
   }
   */
 
-  MutexLocker lock(m_mutex_);
-  try {
-    gossip_group->broadcast(*m_);
-  } catch (std::exception &e) {
-    logger->log_warn(name(), "Failed to send message: %s", e.what());
-  }
+	MutexLocker lock(m_mutex_);
+	try {
+		gossip_group->broadcast(*m_);
+	} catch (std::exception &e) {
+		logger->log_warn(name(), "Failed to send message: %s", e.what());
+	}
 }
 
-void NavgraphBrokerThread::bb_interface_data_changed(
-    fawkes::Interface *interface) throw() {
+void
+NavgraphBrokerThread::bb_interface_data_changed(fawkes::Interface *interface) throw()
+{
+	path_if_->read();
+	std::vector<std::string> path = get_path_from_interface_as_vector();
 
-  path_if_->read();
-  std::vector<std::string> path = get_path_from_interface_as_vector();
+	fawkes::Time now(clock);
+	time_of_plan_chg = now;
 
-  fawkes::Time now(clock);
-  time_of_plan_chg = now;
+	MutexLocker lock(m_mutex_);
+	m_->set_sec(now.get_sec());
+	m_->set_nsec(now.get_nsec());
+	m_->clear_nodelist();
 
-  MutexLocker lock(m_mutex_);
-  m_->set_sec(now.get_sec());
-  m_->set_nsec(now.get_nsec());
-  m_->clear_nodelist();
-
-  for (unsigned i = 0; i < path.size(); i++) {
-    m_->add_nodelist(path[i].c_str());
-  }
+	for (unsigned i = 0; i < path.size(); i++) {
+		m_->add_nodelist(path[i].c_str());
+	}
 }
 
-void NavgraphBrokerThread::handle_peer_msg(
-    boost::asio::ip::udp::endpoint &endpoint, uint16_t component_id,
-    uint16_t msg_type, std::shared_ptr<google::protobuf::Message> msg) {
+void
+NavgraphBrokerThread::handle_peer_msg(boost::asio::ip::udp::endpoint &           endpoint,
+                                      uint16_t                                   component_id,
+                                      uint16_t                                   msg_type,
+                                      std::shared_ptr<google::protobuf::Message> msg)
+{
+	MutexLocker lock(loop_mutex);
 
-  MutexLocker lock(loop_mutex);
+	if (component_id == navgraph_broker::NavigationMessage::COMP_ID
+	    && msg_type == navgraph_broker::NavigationMessage::MSG_TYPE) {
+		std::shared_ptr<navgraph_broker::NavigationMessage> tm =
+		  std::dynamic_pointer_cast<navgraph_broker::NavigationMessage>(msg);
 
-  if (component_id == navgraph_broker::NavigationMessage::COMP_ID &&
-      msg_type == navgraph_broker::NavigationMessage::MSG_TYPE) {
-    std::shared_ptr<navgraph_broker::NavigationMessage> tm =
-        std::dynamic_pointer_cast<navgraph_broker::NavigationMessage>(msg);
+		int msg_sec  = tm->sec();
+		int msg_nsec = tm->nsec();
+		if ((msg_sec != last_message_time_sec_) || (msg_nsec != last_message_time_nsec_)) {
+			reservation_messages_.push(tm);
+			last_message_time_sec_  = tm->sec();
+			last_message_time_nsec_ = tm->nsec();
 
-    int msg_sec = tm->sec();
-    int msg_nsec = tm->nsec();
-    if ((msg_sec != last_message_time_sec_) ||
-        (msg_nsec != last_message_time_nsec_)) {
-
-      reservation_messages_.push(tm);
-      last_message_time_sec_ = tm->sec();
-      last_message_time_nsec_ = tm->nsec();
-
-      // print
-      std::string txt = "{";
-      for (int i = 0; i < (tm->nodelist_size()); i++) {
-        txt += tm->nodelist(i);
-        txt += ",";
-      }
-      txt.erase(txt.length() - 1, 1);
-      txt += "}";
-      logger->log_info(
-          name(),
-          "Received reservation msg from '%s'time: { sec=%ld nsec=%ld }",
-          tm->robotname().c_str(), tm->sec(), tm->nsec());
-    }
-  }
+			// print
+			std::string txt = "{";
+			for (int i = 0; i < (tm->nodelist_size()); i++) {
+				txt += tm->nodelist(i);
+				txt += ",";
+			}
+			txt.erase(txt.length() - 1, 1);
+			txt += "}";
+			logger->log_info(name(),
+			                 "Received reservation msg from '%s'time: { sec=%ld nsec=%ld }",
+			                 tm->robotname().c_str(),
+			                 tm->sec(),
+			                 tm->nsec());
+		}
+	}
 }
 
 /** Handle error during peer message processing.
  * @param endpoint endpoint of incoming message
  * @param msg error message
  */
-void NavgraphBrokerThread::handle_peer_recv_error(
-    boost::asio::ip::udp::endpoint &endpoint, std::string msg) {
-  logger->log_warn(name(), "Failed to receive peer message from %s:%u: %s",
-                   endpoint.address().to_string().c_str(), endpoint.port(),
-                   msg.c_str());
+void
+NavgraphBrokerThread::handle_peer_recv_error(boost::asio::ip::udp::endpoint &endpoint,
+                                             std::string                     msg)
+{
+	logger->log_warn(name(),
+	                 "Failed to receive peer message from %s:%u: %s",
+	                 endpoint.address().to_string().c_str(),
+	                 endpoint.port(),
+	                 msg.c_str());
 }
 
 /** Handle error during peer message processing.
  * @param msg error message
  */
-void NavgraphBrokerThread::handle_peer_send_error(std::string msg) {
-  logger->log_warn(name(), "Failed to send peer message: %s", msg.c_str());
+void
+NavgraphBrokerThread::handle_peer_send_error(std::string msg)
+{
+	logger->log_warn(name(), "Failed to send peer message: %s", msg.c_str());
 }

--- a/src/plugins/navgraph_broker/navgraph_broker_thread.h
+++ b/src/plugins/navgraph_broker/navgraph_broker_thread.h
@@ -23,27 +23,23 @@
 #ifndef __PLUGINS_NAVGRAPH_BROKER_THREAD_H_
 #define __PLUGINS_NAVGRAPH_BROKER_THREAD_H_
 
+#include "NavigationMessage.pb.h"
+
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/clock.h>
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
+#include <blackboard/interface_listener.h>
 #include <core/threading/thread.h>
-
-#include <plugins/gossip/aspect/gossip.h>
-#include <plugins/gossip/gossip/gossip_group.h>
-
+#include <interfaces/NavPathInterface.h>
 #include <navgraph/aspect/navgraph.h>
 #include <navgraph/constraints/constraint_repo.h>
-
 #include <navgraph/constraints/timed_reservation_list_edge_constraint.h>
 #include <navgraph/constraints/timed_reservation_list_node_constraint.h>
 #include <navgraph/navgraph.h>
-
-#include <blackboard/interface_listener.h>
-#include <interfaces/NavPathInterface.h>
-
-#include "NavigationMessage.pb.h"
+#include <plugins/gossip/aspect/gossip.h>
+#include <plugins/gossip/gossip/gossip_group.h>
 
 #include <queue>
 #include <string>
@@ -67,70 +63,70 @@ class NavgraphBrokerThread : public fawkes::Thread,
                              public fawkes::ConfigurableAspect,
                              public fawkes::BlockedTimingAspect,
                              public fawkes::BlackBoardInterfaceListener,
-                             public fawkes::GossipAspect {
+                             public fawkes::GossipAspect
+{
 public:
-  NavgraphBrokerThread();
-  virtual ~NavgraphBrokerThread();
+	NavgraphBrokerThread();
+	virtual ~NavgraphBrokerThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
-  // For BlackBoardInterfaceListener
-  virtual void bb_interface_data_changed(fawkes::Interface *interface) throw();
+	// For BlackBoardInterfaceListener
+	virtual void bb_interface_data_changed(fawkes::Interface *interface) throw();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private: // methods
-  void reserve_nodes(
-      std::string constraint_name,
-      std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_path);
-  void reserve_edges(
-      std::string constraint_name,
-      std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_path);
-  void add_edges_to_edge_constraint(
-      fawkes::NavGraphTimedReservationListEdgeConstraint *edge_constraint,
-      std::vector<fawkes::NavGraphNode> path);
-  std::vector<fawkes::NavGraphNode> get_nodes_from_string(std::string path);
-  std::vector<std::string> get_path_from_interface_as_vector();
-  void send_msg();
+	void reserve_nodes(std::string                                                constraint_name,
+	                   std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_path);
+	void reserve_edges(std::string                                                constraint_name,
+	                   std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> timed_path);
+	void
+	                                  add_edges_to_edge_constraint(fawkes::NavGraphTimedReservationListEdgeConstraint *edge_constraint,
+	                                                               std::vector<fawkes::NavGraphNode>                   path);
+	std::vector<fawkes::NavGraphNode> get_nodes_from_string(std::string path);
+	std::vector<std::string>          get_path_from_interface_as_vector();
+	void                              send_msg();
 
-  void handle_peer_msg(boost::asio::ip::udp::endpoint &endpoint,
-                       uint16_t component_id, uint16_t msg_type,
-                       std::shared_ptr<google::protobuf::Message> msg);
-  void handle_peer_recv_error(boost::asio::ip::udp::endpoint &endpoint,
-                              std::string msg);
-  void handle_peer_send_error(std::string msg);
+	void handle_peer_msg(boost::asio::ip::udp::endpoint &           endpoint,
+	                     uint16_t                                   component_id,
+	                     uint16_t                                   msg_type,
+	                     std::shared_ptr<google::protobuf::Message> msg);
+	void handle_peer_recv_error(boost::asio::ip::udp::endpoint &endpoint, std::string msg);
+	void handle_peer_send_error(std::string msg);
 
-  void log_node_constraint(
-      fawkes::NavGraphTimedReservationListNodeConstraint *node_constraint);
-  void log_edge_constraint(
-      fawkes::NavGraphTimedReservationListEdgeConstraint *edge_constraint);
+	void log_node_constraint(fawkes::NavGraphTimedReservationListNodeConstraint *node_constraint);
+	void log_edge_constraint(fawkes::NavGraphTimedReservationListEdgeConstraint *edge_constraint);
 
 private:
-  boost::signals2::connection sig_rcvd_conn_;
-  boost::signals2::connection sig_recv_error_conn_;
-  boost::signals2::connection sig_send_error_conn_;
+	boost::signals2::connection sig_rcvd_conn_;
+	boost::signals2::connection sig_recv_error_conn_;
+	boost::signals2::connection sig_send_error_conn_;
 
 private:
-  fawkes::NavPathInterface *path_if_;
-  std::vector<std::string> path_;
-  std::queue<std::shared_ptr<navgraph_broker::NavigationMessage>>
-      reservation_messages_;
-  std::string robotname_;
+	fawkes::NavPathInterface *                                      path_if_;
+	std::vector<std::string>                                        path_;
+	std::queue<std::shared_ptr<navgraph_broker::NavigationMessage>> reservation_messages_;
+	std::string                                                     robotname_;
 
-  navgraph_broker::NavigationMessage *m_;
-  fawkes::Mutex *m_mutex_;
-  int last_message_time_sec_;
-  int last_message_time_nsec_;
+	navgraph_broker::NavigationMessage *m_;
+	fawkes::Mutex *                     m_mutex_;
+	int                                 last_message_time_sec_;
+	int                                 last_message_time_nsec_;
 
-  fawkes::Time time_of_plan_chg;
-  fawkes::Time *time_;
-  double repeat_send_duration_;
-  bool use_node_constraints_;
-  long int max_reservation_duration_;
+	fawkes::Time  time_of_plan_chg;
+	fawkes::Time *time_;
+	double        repeat_send_duration_;
+	bool          use_node_constraints_;
+	long int      max_reservation_duration_;
 };
 
 #endif

--- a/src/plugins/tag_vision/tag_position_interface_helper.h
+++ b/src/plugins/tag_vision/tag_position_interface_helper.h
@@ -23,113 +23,127 @@
 #ifndef TAG_POSITION_INTREFACE_H
 #define TAG_POSITION_INTREFACE_H
 
-#include <string>
-
 #include <interfaces/Position3DInterface.h>
 #include <tf/transform_publisher.h>
 #include <tf/types.h>
 #include <utils/math/angle.h>
 
+#include <string>
+
 #ifdef HAVE_AR_TRACK_ALVAR
-#include <ar_track_alvar/Pose.h>
+#	include <ar_track_alvar/Pose.h>
 #else
-#include <alvar/Pose.h>
+#	include <alvar/Pose.h>
 #endif
 
 #define EMPTY_INTERFACE_MARKER_ID 0
 #define CHILD_FRAME "/tag_"
 #define INTERFACE_UNSEEN_BOUND -1000
 
-class TagPositionInterfaceHelper {
-  enum ROT { X = 0, Y = 1, Z = 2, W = 3 };
+class TagPositionInterfaceHelper
+{
+	enum ROT { X = 0, Y = 1, Z = 2, W = 3 };
 
-  enum ALVAR_ROT {
-    A_W = 0,
-    A_X = 1,
-    A_Y = 2,
-    A_Z = 3,
-  };
+	enum ALVAR_ROT {
+		A_W = 0,
+		A_X = 1,
+		A_Y = 2,
+		A_Z = 3,
+	};
 
-  enum TRANS {
-    T_X = 0,
-    T_Y = 1,
-    T_Z = 2,
-  };
+	enum TRANS {
+		T_X = 0,
+		T_Y = 1,
+		T_Z = 2,
+	};
 
-  enum ALVAR_TRANS {
-    A_T_X = 2,
-    A_T_Y = 0,
-    A_T_Z = 1,
-  };
+	enum ALVAR_TRANS {
+		A_T_X = 2,
+		A_T_Y = 0,
+		A_T_Z = 1,
+	};
 
 public:
-  /// Constructor
-  TagPositionInterfaceHelper(fawkes::Position3DInterface *position_interface,
-                             u_int32_t vector_position_, fawkes::Clock *clock,
-                             fawkes::tf::TransformPublisher *tf_publisher,
-                             std::string frame);
-  /// Destructor
-  ~TagPositionInterfaceHelper();
+	/// Constructor
+	TagPositionInterfaceHelper(fawkes::Position3DInterface *   position_interface,
+	                           u_int32_t                       vector_position_,
+	                           fawkes::Clock *                 clock,
+	                           fawkes::tf::TransformPublisher *tf_publisher,
+	                           std::string                     frame);
+	/// Destructor
+	~TagPositionInterfaceHelper();
 
-  /// Update the position of the interface
-  void set_pose(alvar::Pose new_pose);
+	/// Update the position of the interface
+	void set_pose(alvar::Pose new_pose);
 
-  /// Write the interface on the blackboard
-  void write();
+	/// Write the interface on the blackboard
+	void write();
 
-  /**
+	/**
    * @brief Returns the id of the marker this interface belongs to
    *
    * @return The marker-id of the interface
    */
-  u_int32_t marker_id() { return this->marker_id_; }
+	u_int32_t
+	marker_id()
+	{
+		return this->marker_id_;
+	}
 
-  /// Set the marker id
-  void set_marker_id(u_int32_t new_id);
+	/// Set the marker id
+	void set_marker_id(u_int32_t new_id);
 
-  /**
+	/**
    * @brief Returns the Position3D interface of this plugin
    *
    * @return The interface
    */
-  fawkes::Position3DInterface *interface() { return this->interface_; }
+	fawkes::Position3DInterface *
+	interface()
+	{
+		return this->interface_;
+	}
 
-  /**
+	/**
    * @brief Returns the position of this interface in the TagPositionList, or
    * any other enumeration
    *
    * @return The position of this interface of the list
    */
-  u_int32_t vector_position() { return this->vector_position_; }
+	u_int32_t
+	vector_position()
+	{
+		return this->vector_position_;
+	}
 
 private:
-  /// The interface to handle
-  fawkes::Position3DInterface *interface_;
+	/// The interface to handle
+	fawkes::Position3DInterface *interface_;
 
-  /// The visibility history for the interface to handle
-  int32_t visibility_history_;
+	/// The visibility history for the interface to handle
+	int32_t visibility_history_;
 
-  /// Marker, whether the interface was updated since last write
-  bool touched_;
+	/// Marker, whether the interface was updated since last write
+	bool touched_;
 
-  /// The id of the marker the interface represents
-  u_int32_t marker_id_;
+	/// The id of the marker the interface represents
+	u_int32_t marker_id_;
 
-  /// The position of the interface in the vector
-  u_int32_t vector_position_;
+	/// The position of the interface in the vector
+	u_int32_t vector_position_;
 
-  /// The frame of reference for this tag
-  std::string frame_;
+	/// The frame of reference for this tag
+	std::string frame_;
 
-  /// The child frame / name of the transform
-  std::string child_frame_;
+	/// The child frame / name of the transform
+	std::string child_frame_;
 
-  /// The clock to get the time stamps for StampedTransform nad Transform
-  /// publishing
-  fawkes::Clock *clock_;
+	/// The clock to get the time stamps for StampedTransform nad Transform
+	/// publishing
+	fawkes::Clock *clock_;
 
-  /// The transform publisher
-  fawkes::tf::TransformPublisher *tf_publisher_;
+	/// The transform publisher
+	fawkes::tf::TransformPublisher *tf_publisher_;
 };
 
 #endif // TAG_POSITION_INTREFACE_H

--- a/src/plugins/tag_vision/tag_position_list.cpp
+++ b/src/plugins/tag_vision/tag_position_list.cpp
@@ -20,10 +20,10 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
+#include "tag_position_list.h"
+
 #include <tf/types.h>
 #include <utils/math/angle.h>
-
-#include "tag_position_list.h"
 
 /** @class TagPositionList "tag_position_list.h"
  * This class handles the Tag Positions and the Blackboard communication for the
@@ -47,173 +47,171 @@
  * @param tf_publisher The fawes transform publisher, used to publish the
  * transforms of the tags
  */
-TagPositionList::TagPositionList(fawkes::BlackBoard *blackboard,
-                                 fawkes::tf::Transformer *tf_listener,
-                                 u_int32_t max_markers, std::string frame,
-                                 std::string thread_name,
-                                 fawkes::Logger *logger, fawkes::Clock *clock,
-                                 fawkes::tf::TransformPublisher *tf_publisher) {
-  // store parameters
-  this->blackboard_ = blackboard;
-  this->max_markers_ = max_markers;
-  this->thread_name_ = thread_name;
-  this->logger_ = logger;
-  this->clock_ = clock;
-  this->tf_publisher_ = tf_publisher;
-  frame_ = frame;
-  this->tf_listener = tf_listener;
+TagPositionList::TagPositionList(fawkes::BlackBoard *            blackboard,
+                                 fawkes::tf::Transformer *       tf_listener,
+                                 u_int32_t                       max_markers,
+                                 std::string                     frame,
+                                 std::string                     thread_name,
+                                 fawkes::Logger *                logger,
+                                 fawkes::Clock *                 clock,
+                                 fawkes::tf::TransformPublisher *tf_publisher)
+{
+	// store parameters
+	this->blackboard_   = blackboard;
+	this->max_markers_  = max_markers;
+	this->thread_name_  = thread_name;
+	this->logger_       = logger;
+	this->clock_        = clock;
+	this->tf_publisher_ = tf_publisher;
+	frame_              = frame;
+	this->tf_listener   = tf_listener;
 
-  // create blackboard interfaces
-  for (size_t i = 0; i < this->max_markers_; i++) {
-    // create a name for the new interface
-    std::string interface_name =
-        std::string("/tag-vision/") + std::to_string(i);
-    // create the interface and store
-    try {
-      // get an interface from the blackboard
-      auto interface =
-          this->blackboard_->open_for_writing<fawkes::Position3DInterface>(
-              interface_name.c_str());
-      // set the frame of the interface
-      interface->set_frame(frame.c_str());
-      // generate a helper class and push it into this vector
-      this->push_back(new TagPositionInterfaceHelper(
-          interface, i, this->clock_, this->tf_publisher_, frame));
-    } catch (std::exception &e) {
-      this->logger_->log_error(thread_name.c_str(),
-                               (std::string("Could not open the blackboard: ") +
-                                std::string(e.what()))
-                                   .c_str());
-      throw(e);
-    }
-  }
+	// create blackboard interfaces
+	for (size_t i = 0; i < this->max_markers_; i++) {
+		// create a name for the new interface
+		std::string interface_name = std::string("/tag-vision/") + std::to_string(i);
+		// create the interface and store
+		try {
+			// get an interface from the blackboard
+			auto interface =
+			  this->blackboard_->open_for_writing<fawkes::Position3DInterface>(interface_name.c_str());
+			// set the frame of the interface
+			interface->set_frame(frame.c_str());
+			// generate a helper class and push it into this vector
+			this->push_back(
+			  new TagPositionInterfaceHelper(interface, i, this->clock_, this->tf_publisher_, frame));
+		} catch (std::exception &e) {
+			this->logger_->log_error(
+			  thread_name.c_str(),
+			  (std::string("Could not open the blackboard: ") + std::string(e.what())).c_str());
+			throw(e);
+		}
+	}
 
-  // initialize tag info interface
-  try {
-    this->tag_vision_interface_ =
-        blackboard->open_for_writing<fawkes::TagVisionInterface>(
-            "/tag-vision/info");
-  } catch (std::exception &e) {
-    this->logger_->log_error(
-        thread_name.c_str(),
-        (std::string("Could not open the blackboard: ") + std::string(e.what()))
-            .c_str());
-    throw(e);
-  }
+	// initialize tag info interface
+	try {
+		this->tag_vision_interface_ =
+		  blackboard->open_for_writing<fawkes::TagVisionInterface>("/tag-vision/info");
+	} catch (std::exception &e) {
+		this->logger_->log_error(
+		  thread_name.c_str(),
+		  (std::string("Could not open the blackboard: ") + std::string(e.what())).c_str());
+		throw(e);
+	}
 }
 
 /**
  * The destructor closes all interfaces and frees allocated memory
  */
-TagPositionList::~TagPositionList() {
-  // close tag vision interface
-  this->blackboard_->close(this->tag_vision_interface_);
+TagPositionList::~TagPositionList()
+{
+	// close tag vision interface
+	this->blackboard_->close(this->tag_vision_interface_);
 
-  // delete this interfaces
-  for (auto &&interface : *this) {
-    this->blackboard_->close(interface->interface());
-    delete interface;
-  }
+	// delete this interfaces
+	for (auto &&interface : *this) {
+		this->blackboard_->close(interface->interface());
+		delete interface;
+	}
 }
 
-alvar::Pose TagPositionList::get_laser_line_pose(
-    fawkes::LaserLineInterface *laser_line_if) {
-  alvar::Pose pose;
+alvar::Pose
+TagPositionList::get_laser_line_pose(fawkes::LaserLineInterface *laser_line_if)
+{
+	alvar::Pose pose;
 
-  double x =
-      laser_line_if->end_point_1(0) +
-      (laser_line_if->end_point_2(0) - laser_line_if->end_point_1(0)) / 2;
-  double y =
-      laser_line_if->end_point_1(1) +
-      (laser_line_if->end_point_2(1) - laser_line_if->end_point_1(1)) / 2;
-  double ori = fawkes::normalize_mirror_rad(laser_line_if->bearing());
+	double x = laser_line_if->end_point_1(0)
+	           + (laser_line_if->end_point_2(0) - laser_line_if->end_point_1(0)) / 2;
+	double y = laser_line_if->end_point_1(1)
+	           + (laser_line_if->end_point_2(1) - laser_line_if->end_point_1(1)) / 2;
+	double ori = fawkes::normalize_mirror_rad(laser_line_if->bearing());
 
-  fawkes::tf::Quaternion f_q = fawkes::tf::create_quaternion_from_yaw(ori);
-  double q[4];
-  fawkes::tf::Point f_p(x, y, 0.);
+	fawkes::tf::Quaternion f_q = fawkes::tf::create_quaternion_from_yaw(ori);
+	double                 q[4];
+	fawkes::tf::Point      f_p(x, y, 0.);
 
-  fawkes::tf::Pose f_p_in(f_q, f_p);
+	fawkes::tf::Pose f_p_in(f_q, f_p);
 
-  fawkes::tf::Stamped<fawkes::tf::Pose> f_sp_in(
-      f_p_in, laser_line_if->timestamp(), laser_line_if->frame_id());
+	fawkes::tf::Stamped<fawkes::tf::Pose> f_sp_in(f_p_in,
+	                                              laser_line_if->timestamp(),
+	                                              laser_line_if->frame_id());
 
-  fawkes::tf::Stamped<fawkes::tf::Pose> f_sp_out;
+	fawkes::tf::Stamped<fawkes::tf::Pose> f_sp_out;
 
-  try {
-    //    logger_->log_info("tag_vision", "Transform from %s to %s",
-    //    laser_line_if->frame_id(), frame_.c_str());
-    tf_listener->transform_pose(frame_, f_sp_in, f_sp_out);
-  } catch (fawkes::Exception &e) {
-    f_sp_in.stamp = fawkes::Time(0, 0);
-    tf_listener->transform_pose(frame_, f_sp_in, f_sp_out);
-    //    logger_->log_warn("tag_vision", "Can't transform laser-line; error
-    //    %s\nuse newest", e.what());
-  }
+	try {
+		//    logger_->log_info("tag_vision", "Transform from %s to %s",
+		//    laser_line_if->frame_id(), frame_.c_str());
+		tf_listener->transform_pose(frame_, f_sp_in, f_sp_out);
+	} catch (fawkes::Exception &e) {
+		f_sp_in.stamp = fawkes::Time(0, 0);
+		tf_listener->transform_pose(frame_, f_sp_in, f_sp_out);
+		//    logger_->log_warn("tag_vision", "Can't transform laser-line; error
+		//    %s\nuse newest", e.what());
+	}
 
-  pose.translation[0] = f_sp_out.getOrigin().getX() * 1000;
-  pose.translation[1] = f_sp_out.getOrigin().getY() * 1000;
-  pose.translation[2] = f_sp_out.getOrigin().getZ() * 1000;
+	pose.translation[0] = f_sp_out.getOrigin().getX() * 1000;
+	pose.translation[1] = f_sp_out.getOrigin().getY() * 1000;
+	pose.translation[2] = f_sp_out.getOrigin().getZ() * 1000;
 
-  fawkes::tf::Quaternion q_out = f_sp_out.getRotation();
-  fawkes::tf::Quaternion q_rot_for_cam =
-      fawkes::tf::create_quaternion_from_rpy(M_PI_2, 0, -M_PI_2);
-  q_out = q_out * q_rot_for_cam;
-  q[0] = q_out.getW();
-  q[1] = q_out.getX();
-  q[2] = q_out.getY();
-  q[3] = q_out.getZ();
+	fawkes::tf::Quaternion q_out         = f_sp_out.getRotation();
+	fawkes::tf::Quaternion q_rot_for_cam = fawkes::tf::create_quaternion_from_rpy(M_PI_2, 0, -M_PI_2);
+	q_out                                = q_out * q_rot_for_cam;
+	q[0]                                 = q_out.getW();
+	q[1]                                 = q_out.getX();
+	q[2]                                 = q_out.getY();
+	q[3]                                 = q_out.getZ();
 
-  pose.SetQuaternion(q);
+	pose.SetQuaternion(q);
 
-  return pose;
+	return pose;
 }
 
-alvar::Pose TagPositionList::get_nearest_laser_line_pose(
-    alvar::Pose tag_pose,
-    std::vector<fawkes::LaserLineInterface *> *laser_line_ifs) {
-  double dist_closest = 10000000000000000.;
+alvar::Pose
+TagPositionList::get_nearest_laser_line_pose(
+  alvar::Pose                                tag_pose,
+  std::vector<fawkes::LaserLineInterface *> *laser_line_ifs)
+{
+	double dist_closest = 10000000000000000.;
 
-  alvar::Pose
-      ll_pose_clostest; // = get_laser_line_pose( laser_line_ifs->at(0) );
-  ll_pose_clostest.translation[0] = 10000000.;
-  ll_pose_clostest.translation[1] = 10000000.;
-  ll_pose_clostest.translation[2] = 10000000.;
-  // for each laser_line
-  for (unsigned int i = 0; i < laser_line_ifs->size(); ++i) {
-    laser_line_ifs->at(i)->read();
-    if (laser_line_ifs->at(i)->visibility_history() > 0) {
-      // get centeroid
-      // transform to what we need ;)
-      alvar::Pose ll_pose_current;
-      try {
-        ll_pose_current = get_laser_line_pose(laser_line_ifs->at(i));
-      } catch (fawkes::Exception &e) {
-        continue;
-      }
-      // check if clostest (translation)
-      double dist_current =
-          sqrt((ll_pose_current.translation[0] - tag_pose.translation[0]) *
-                   (ll_pose_current.translation[0] - tag_pose.translation[0]) +
-               (ll_pose_current.translation[1] - tag_pose.translation[1]) *
-                   (ll_pose_current.translation[1] - tag_pose.translation[1]) +
-               (ll_pose_current.translation[2] - tag_pose.translation[2]) *
-                   (ll_pose_current.translation[2] - tag_pose.translation[2]));
-      // save closest
-      if (dist_current < dist_closest) {
-        ll_pose_clostest = ll_pose_current;
-        dist_closest = dist_current;
-      }
-    }
-  }
+	alvar::Pose ll_pose_clostest; // = get_laser_line_pose( laser_line_ifs->at(0) );
+	ll_pose_clostest.translation[0] = 10000000.;
+	ll_pose_clostest.translation[1] = 10000000.;
+	ll_pose_clostest.translation[2] = 10000000.;
+	// for each laser_line
+	for (unsigned int i = 0; i < laser_line_ifs->size(); ++i) {
+		laser_line_ifs->at(i)->read();
+		if (laser_line_ifs->at(i)->visibility_history() > 0) {
+			// get centeroid
+			// transform to what we need ;)
+			alvar::Pose ll_pose_current;
+			try {
+				ll_pose_current = get_laser_line_pose(laser_line_ifs->at(i));
+			} catch (fawkes::Exception &e) {
+				continue;
+			}
+			// check if clostest (translation)
+			double dist_current = sqrt((ll_pose_current.translation[0] - tag_pose.translation[0])
+			                             * (ll_pose_current.translation[0] - tag_pose.translation[0])
+			                           + (ll_pose_current.translation[1] - tag_pose.translation[1])
+			                               * (ll_pose_current.translation[1] - tag_pose.translation[1])
+			                           + (ll_pose_current.translation[2] - tag_pose.translation[2])
+			                               * (ll_pose_current.translation[2] - tag_pose.translation[2]));
+			// save closest
+			if (dist_current < dist_closest) {
+				ll_pose_clostest = ll_pose_current;
+				dist_closest     = dist_current;
+			}
+		}
+	}
 
-  // check if the choosen laser-line is ok, to use (don't use anything far away
-  if (dist_closest <= 150) {
-    return ll_pose_clostest;
-  } else {
-    //    logger_->log_info("tag_vision", "can't find sutable laser-line, use
-    //    tag; dist is: %lf", dist_closest);
-    return tag_pose;
-  }
+	// check if the choosen laser-line is ok, to use (don't use anything far away
+	if (dist_closest <= 150) {
+		return ll_pose_clostest;
+	} else {
+		//    logger_->log_info("tag_vision", "can't find sutable laser-line, use
+		//    tag; dist is: %lf", dist_closest);
+		return tag_pose;
+	}
 }
 
 /**
@@ -223,73 +221,69 @@ alvar::Pose TagPositionList::get_nearest_laser_line_pose(
  *
  * @param marker_list The detected markers.
  */
-void TagPositionList::update_blackboard(
-    std::vector<alvar::MarkerData> *marker_list,
-    std::vector<fawkes::LaserLineInterface *> *laser_line_ifs) {
-  int i = 0;
-  for (alvar::MarkerData &marker : *marker_list) {
-    // skip the marker, if the pose is directly on the camera (error)
-    alvar::Pose tmp_pose = marker.pose;
-    if (tmp_pose.translation[0] < 1 && tmp_pose.translation[1] < 1 &&
-        tmp_pose.translation[2] < 1) {
-      logger_->log_info("tag_vision", "don't use tag");
-      continue;
-    }
-    try {
-      alvar::Pose ll_pose =
-          get_nearest_laser_line_pose(tmp_pose, laser_line_ifs);
-      //      logger_->log_info("tag_vision", "%i before: %f\t%f\t%f", i,
-      //      tmp_pose.translation[0], tmp_pose.translation[1],
-      //      tmp_pose.translation[2]);
-      tmp_pose = ll_pose;
-      //      logger_->log_info("tag_vision", "%i after:  %f\t%f\t%f", i,
-      //      tmp_pose.translation[0], tmp_pose.translation[1],
-      //      tmp_pose.translation[2]);
-    } catch (std::exception &e) {
-      logger_->log_error("tag_vision",
-                         "some strange exception that where not expected");
-    }
-    ++i;
-    // get the id of the marker
-    u_int32_t marker_id = marker.GetId();
+void
+TagPositionList::update_blackboard(std::vector<alvar::MarkerData> *           marker_list,
+                                   std::vector<fawkes::LaserLineInterface *> *laser_line_ifs)
+{
+	int i = 0;
+	for (alvar::MarkerData &marker : *marker_list) {
+		// skip the marker, if the pose is directly on the camera (error)
+		alvar::Pose tmp_pose = marker.pose;
+		if (tmp_pose.translation[0] < 1 && tmp_pose.translation[1] < 1 && tmp_pose.translation[2] < 1) {
+			logger_->log_info("tag_vision", "don't use tag");
+			continue;
+		}
+		try {
+			alvar::Pose ll_pose = get_nearest_laser_line_pose(tmp_pose, laser_line_ifs);
+			//      logger_->log_info("tag_vision", "%i before: %f\t%f\t%f", i,
+			//      tmp_pose.translation[0], tmp_pose.translation[1],
+			//      tmp_pose.translation[2]);
+			tmp_pose = ll_pose;
+			//      logger_->log_info("tag_vision", "%i after:  %f\t%f\t%f", i,
+			//      tmp_pose.translation[0], tmp_pose.translation[1],
+			//      tmp_pose.translation[2]);
+		} catch (std::exception &e) {
+			logger_->log_error("tag_vision", "some strange exception that where not expected");
+		}
+		++i;
+		// get the id of the marker
+		u_int32_t marker_id = marker.GetId();
 
-    // find an interface with this marker assigned or an empty interface
-    TagPositionInterfaceHelper *marker_interface = NULL;
-    TagPositionInterfaceHelper *empty_interface = NULL;
-    for (TagPositionInterfaceHelper *interface : *this) {
-      // assign marker_interface
-      if (interface->marker_id() == marker_id) {
-        marker_interface = interface;
-      }
-      // assign empty interface
-      if (empty_interface == NULL &&
-          interface->marker_id() == EMPTY_INTERFACE_MARKER_ID) {
-        empty_interface = interface;
-      }
-    }
-    // if no marker interface is found, assign the empty interface and assign
-    // the marker id
-    if (marker_interface == NULL) {
-      // no empty interface found, cannot find any suitable interface,
-      if (empty_interface == NULL) {
-        continue;
-      }
-      marker_interface = empty_interface;
-      marker_interface->set_marker_id(marker_id);
-    }
-    // continue with the marker interface
-    marker_interface->set_pose(tmp_pose);
-  }
-  // update blackboard with interfaces
-  u_int32_t visible_markers = 0;
-  for (TagPositionInterfaceHelper *interface : *this) {
-    this->tag_vision_interface_->set_tag_id(interface->vector_position(),
-                                            interface->marker_id());
-    if (interface->marker_id() != EMPTY_INTERFACE_MARKER_ID) {
-      visible_markers++;
-    }
-    interface->write();
-  }
-  this->tag_vision_interface_->set_tags_visible(visible_markers);
-  this->tag_vision_interface_->write();
+		// find an interface with this marker assigned or an empty interface
+		TagPositionInterfaceHelper *marker_interface = NULL;
+		TagPositionInterfaceHelper *empty_interface  = NULL;
+		for (TagPositionInterfaceHelper *interface : *this) {
+			// assign marker_interface
+			if (interface->marker_id() == marker_id) {
+				marker_interface = interface;
+			}
+			// assign empty interface
+			if (empty_interface == NULL && interface->marker_id() == EMPTY_INTERFACE_MARKER_ID) {
+				empty_interface = interface;
+			}
+		}
+		// if no marker interface is found, assign the empty interface and assign
+		// the marker id
+		if (marker_interface == NULL) {
+			// no empty interface found, cannot find any suitable interface,
+			if (empty_interface == NULL) {
+				continue;
+			}
+			marker_interface = empty_interface;
+			marker_interface->set_marker_id(marker_id);
+		}
+		// continue with the marker interface
+		marker_interface->set_pose(tmp_pose);
+	}
+	// update blackboard with interfaces
+	u_int32_t visible_markers = 0;
+	for (TagPositionInterfaceHelper *interface : *this) {
+		this->tag_vision_interface_->set_tag_id(interface->vector_position(), interface->marker_id());
+		if (interface->marker_id() != EMPTY_INTERFACE_MARKER_ID) {
+			visible_markers++;
+		}
+		interface->write();
+	}
+	this->tag_vision_interface_->set_tags_visible(visible_markers);
+	this->tag_vision_interface_->write();
 }

--- a/src/plugins/tag_vision/tag_position_list.h
+++ b/src/plugins/tag_vision/tag_position_list.h
@@ -26,31 +26,35 @@
 #include <blackboard/blackboard.h>
 #include <blackboard/exceptions.h>
 #include <interfaces/TagVisionInterface.h>
+
 #include <string>
 #include <vector>
 #ifdef HAVE_AR_TRACK_ALVAR
-#include <ar_track_alvar/Marker.h>
+#	include <ar_track_alvar/Marker.h>
 #else
-#include <alvar/Marker.h>
+#	include <alvar/Marker.h>
 #endif
-#include <aspect/tf.h>
-#include <logging/logger.h>
-
-#include <interfaces/LaserLineInterface.h>
-
 #include "tag_position_interface_helper.h"
 
-class TagPositionList : public std::vector<TagPositionInterfaceHelper *> {
-public:
-  TagPositionList(fawkes::BlackBoard *blackboard,
-                  fawkes::tf::Transformer *tf_listener, u_int32_t max_markers,
-                  std::string frame, std::string thread_name,
-                  fawkes::Logger *logger, fawkes::Clock *clock,
-                  fawkes::tf::TransformPublisher *tf_publisher);
-  /// Destructor
-  ~TagPositionList();
+#include <aspect/tf.h>
+#include <interfaces/LaserLineInterface.h>
+#include <logging/logger.h>
 
-  /**
+class TagPositionList : public std::vector<TagPositionInterfaceHelper *>
+{
+public:
+	TagPositionList(fawkes::BlackBoard *            blackboard,
+	                fawkes::tf::Transformer *       tf_listener,
+	                u_int32_t                       max_markers,
+	                std::string                     frame,
+	                std::string                     thread_name,
+	                fawkes::Logger *                logger,
+	                fawkes::Clock *                 clock,
+	                fawkes::tf::TransformPublisher *tf_publisher);
+	/// Destructor
+	~TagPositionList();
+
+	/**
    * @brief Assigns every marker found to an interface. The interface will stay
    * the same for a marker as long as the marker is considered seen (visibility
    * history > 0). It also updates the Marker IDs on the TagVision interface.
@@ -58,33 +62,32 @@ public:
    * @param marker_list List of marker data
    * @param laser_line_ifs List of laser_line interfaces
    */
-  void
-  update_blackboard(std::vector<alvar::MarkerData> *marker_list,
-                    std::vector<fawkes::LaserLineInterface *> *laser_line_ifs);
+	void update_blackboard(std::vector<alvar::MarkerData> *           marker_list,
+	                       std::vector<fawkes::LaserLineInterface *> *laser_line_ifs);
 
 private:
-  /// How many markers can be detected at the same time
-  u_int32_t max_markers_;
-  /// The blackboard to publish on
-  fawkes::BlackBoard *blackboard_;
-  /// Tag vision inforamtion interface
-  fawkes::TagVisionInterface *tag_vision_interface_;
-  /// Name of the calling thread
-  std::string thread_name_;
-  /// Logger for logging
-  fawkes::Logger *logger_;
-  /// The clock for the StampedTransforms
-  fawkes::Clock *clock_;
-  /// Publisher for the transforms
-  fawkes::tf::TransformPublisher *tf_publisher_;
+	/// How many markers can be detected at the same time
+	u_int32_t max_markers_;
+	/// The blackboard to publish on
+	fawkes::BlackBoard *blackboard_;
+	/// Tag vision inforamtion interface
+	fawkes::TagVisionInterface *tag_vision_interface_;
+	/// Name of the calling thread
+	std::string thread_name_;
+	/// Logger for logging
+	fawkes::Logger *logger_;
+	/// The clock for the StampedTransforms
+	fawkes::Clock *clock_;
+	/// Publisher for the transforms
+	fawkes::tf::TransformPublisher *tf_publisher_;
 
-  std::string frame_;
-  fawkes::tf::Transformer *tf_listener;
+	std::string              frame_;
+	fawkes::tf::Transformer *tf_listener;
 
-  alvar::Pose get_laser_line_pose(fawkes::LaserLineInterface *laser_line_if);
-  alvar::Pose get_nearest_laser_line_pose(
-      alvar::Pose tag_pose,
-      std::vector<fawkes::LaserLineInterface *> *laser_line_ifs);
+	alvar::Pose get_laser_line_pose(fawkes::LaserLineInterface *laser_line_if);
+	alvar::Pose
+	get_nearest_laser_line_pose(alvar::Pose                                tag_pose,
+	                            std::vector<fawkes::LaserLineInterface *> *laser_line_ifs);
 };
 
 #endif // TAG_POSITION_LIST_H

--- a/src/plugins/tag_vision/tag_vision_plugin.cpp
+++ b/src/plugins/tag_vision/tag_vision_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "tag_vision_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /**
  * @author Nicolas Limpert & Randolph Maaßen
  */
-class TagVision : public fawkes::Plugin {
+class TagVision : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  TagVision(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new TagVisionThread());
-  }
+	TagVision(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new TagVisionThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("AR Tracking plugin")

--- a/src/plugins/tag_vision/tag_vision_thread.cpp
+++ b/src/plugins/tag_vision/tag_vision_thread.cpp
@@ -21,10 +21,10 @@
 #include "tag_vision_thread.h"
 
 #include <interfaces/Position3DInterface.h>
+#include <opencv/cv.h>
 #include <tf/types.h>
 
 #include <math.h>
-#include <opencv/cv.h>
 #include <string>
 
 #define CFG_PREFIX "/plugins/tag_vision/"
@@ -41,200 +41,213 @@ using namespace std;
 
 /** Constructor. */
 TagVisionThread::TagVisionThread()
-    : Thread("TagVisionThread", Thread::OPMODE_WAITFORWAKEUP),
-      VisionAspect(VisionAspect::CYCLIC),
-      ConfigurationChangeHandler(CFG_PREFIX), fawkes::TransformAspect(
-                                                  fawkes::TransformAspect::BOTH,
-                                                  "tags") {
-  fv_cam = NULL;
-  shm_buffer = NULL;
-  image_buffer = NULL;
-  ipl = NULL;
-  this->markers_ = NULL;
+: Thread("TagVisionThread", Thread::OPMODE_WAITFORWAKEUP),
+  VisionAspect(VisionAspect::CYCLIC),
+  ConfigurationChangeHandler(CFG_PREFIX),
+  fawkes::TransformAspect(fawkes::TransformAspect::BOTH, "tags")
+{
+	fv_cam         = NULL;
+	shm_buffer     = NULL;
+	image_buffer   = NULL;
+	ipl            = NULL;
+	this->markers_ = NULL;
 }
 
-void TagVisionThread::init() {
-  config->add_change_handler(this);
-  // load config
-  // config prefix in string for concatinating
-  std::string prefix = CFG_PREFIX;
-  // log, that we open load the config
-  logger->log_info(name(), "loading config");
-  // load alvar camera calibration
-  if (!alvar_cam.SetCalib(
-          config->get_string((prefix + "alvar_camera_calib_file").c_str())
-              .c_str(),
-          0, 0, FILE_FORMAT_DEFAULT)) {
-    this->logger->log_warn(this->name(), "Faild to load calibration file");
-  }
-  // load marker size and apply it
-  marker_size = config->get_uint((prefix + "marker_size").c_str());
-  detector.SetMarkerSize(marker_size);
+void
+TagVisionThread::init()
+{
+	config->add_change_handler(this);
+	// load config
+	// config prefix in string for concatinating
+	std::string prefix = CFG_PREFIX;
+	// log, that we open load the config
+	logger->log_info(name(), "loading config");
+	// load alvar camera calibration
+	if (!alvar_cam.SetCalib(config->get_string((prefix + "alvar_camera_calib_file").c_str()).c_str(),
+	                        0,
+	                        0,
+	                        FILE_FORMAT_DEFAULT)) {
+		this->logger->log_warn(this->name(), "Faild to load calibration file");
+	}
+	// load marker size and apply it
+	marker_size = config->get_uint((prefix + "marker_size").c_str());
+	detector.SetMarkerSize(marker_size);
 
-  // Image Buffer ID
-  shm_id = config->get_string((prefix + "shm_image_id").c_str());
+	// Image Buffer ID
+	shm_id = config->get_string((prefix + "shm_image_id").c_str());
 
-  // init firevision camera
-  // CAM swapping not working (??)
-  if (fv_cam != NULL) {
-    // free the camera
-    fv_cam->stop();
-    fv_cam->flush();
-    fv_cam->dispose_buffer();
-    fv_cam->close();
-    delete fv_cam;
-    fv_cam = NULL;
-  }
-  if (fv_cam == NULL) {
-    std::string connection =
-        this->config->get_string((prefix + "camera").c_str());
-    fv_cam = vision_master->register_for_camera(connection.c_str(), this);
-    fv_cam->start();
-    fv_cam->open();
-    this->img_width = fv_cam->pixel_width();
-    this->img_height = fv_cam->pixel_height();
-  }
+	// init firevision camera
+	// CAM swapping not working (??)
+	if (fv_cam != NULL) {
+		// free the camera
+		fv_cam->stop();
+		fv_cam->flush();
+		fv_cam->dispose_buffer();
+		fv_cam->close();
+		delete fv_cam;
+		fv_cam = NULL;
+	}
+	if (fv_cam == NULL) {
+		std::string connection = this->config->get_string((prefix + "camera").c_str());
+		fv_cam                 = vision_master->register_for_camera(connection.c_str(), this);
+		fv_cam->start();
+		fv_cam->open();
+		this->img_width  = fv_cam->pixel_width();
+		this->img_height = fv_cam->pixel_height();
+	}
 
-  // set camera resolution
-  alvar_cam.SetRes(this->img_width, this->img_height);
+	// set camera resolution
+	alvar_cam.SetRes(this->img_width, this->img_height);
 
-  // SHM image buffer
-  if (shm_buffer != NULL) {
-    delete shm_buffer;
-    shm_buffer = NULL;
-    image_buffer = NULL;
-  }
+	// SHM image buffer
+	if (shm_buffer != NULL) {
+		delete shm_buffer;
+		shm_buffer   = NULL;
+		image_buffer = NULL;
+	}
 
-  shm_buffer = new firevision::SharedMemoryImageBuffer(
-      shm_id.c_str(), firevision::YUV422_PLANAR, this->img_width,
-      this->img_height);
-  if (!shm_buffer->is_valid()) {
-    delete shm_buffer;
-    delete fv_cam;
-    shm_buffer = NULL;
-    fv_cam = NULL;
-    throw fawkes::Exception("Shared memory segment not valid");
-  }
-  std::string frame = this->config->get_string((prefix + "frame").c_str());
-  shm_buffer->set_frame_id(frame.c_str());
+	shm_buffer = new firevision::SharedMemoryImageBuffer(shm_id.c_str(),
+	                                                     firevision::YUV422_PLANAR,
+	                                                     this->img_width,
+	                                                     this->img_height);
+	if (!shm_buffer->is_valid()) {
+		delete shm_buffer;
+		delete fv_cam;
+		shm_buffer = NULL;
+		fv_cam     = NULL;
+		throw fawkes::Exception("Shared memory segment not valid");
+	}
+	std::string frame = this->config->get_string((prefix + "frame").c_str());
+	shm_buffer->set_frame_id(frame.c_str());
 
-  image_buffer = shm_buffer->buffer();
-  ipl = cvCreateImage(cvSize(this->img_width, this->img_height), IPL_DEPTH_8U,
-                      IMAGE_CAHNNELS);
+	image_buffer = shm_buffer->buffer();
+	ipl = cvCreateImage(cvSize(this->img_width, this->img_height), IPL_DEPTH_8U, IMAGE_CAHNNELS);
 
-  // set up marker
-  max_marker = 16;
-  this->markers_ = new std::vector<alvar::MarkerData>();
+	// set up marker
+	max_marker     = 16;
+	this->markers_ = new std::vector<alvar::MarkerData>();
 
-  this->tag_interfaces = new TagPositionList(
-      this->blackboard, tf_listener, this->max_marker, frame, this->name(),
-      this->logger, this->clock, this->tf_publisher);
-  // get laser-line interfaces
-  laser_line_ifs_ = new std::vector<fawkes::LaserLineInterface *>();
-  for (int i = 1; i <= 8; i++) {
-    // std::string if_name = "/laser-lines/" + i;
-    std::string if_name = "/laser-lines/" + std::to_string(i);
+	this->tag_interfaces = new TagPositionList(this->blackboard,
+	                                           tf_listener,
+	                                           this->max_marker,
+	                                           frame,
+	                                           this->name(),
+	                                           this->logger,
+	                                           this->clock,
+	                                           this->tf_publisher);
+	// get laser-line interfaces
+	laser_line_ifs_ = new std::vector<fawkes::LaserLineInterface *>();
+	for (int i = 1; i <= 8; i++) {
+		// std::string if_name = "/laser-lines/" + i;
+		std::string if_name = "/laser-lines/" + std::to_string(i);
 
-    fawkes::LaserLineInterface *ll_if =
-        blackboard->open_for_reading<fawkes::LaserLineInterface>(
-            if_name.c_str());
-    laser_line_ifs_->push_back(ll_if);
-  }
+		fawkes::LaserLineInterface *ll_if =
+		  blackboard->open_for_reading<fawkes::LaserLineInterface>(if_name.c_str());
+		laser_line_ifs_->push_back(ll_if);
+	}
 }
 
-void TagVisionThread::finalize() {
-  vision_master->unregister_thread(this);
-  config->rem_change_handler(this);
-  // free the markers
-  this->markers_->clear();
-  delete this->markers_;
-  delete fv_cam;
-  fv_cam = NULL;
-  delete shm_buffer;
-  shm_buffer = NULL;
-  image_buffer = NULL;
-  cvReleaseImage(&ipl);
-  ipl = NULL;
-  delete this->tag_interfaces;
+void
+TagVisionThread::finalize()
+{
+	vision_master->unregister_thread(this);
+	config->rem_change_handler(this);
+	// free the markers
+	this->markers_->clear();
+	delete this->markers_;
+	delete fv_cam;
+	fv_cam = NULL;
+	delete shm_buffer;
+	shm_buffer   = NULL;
+	image_buffer = NULL;
+	cvReleaseImage(&ipl);
+	ipl = NULL;
+	delete this->tag_interfaces;
 
-  while (!laser_line_ifs_->empty()) {
-    blackboard->close(laser_line_ifs_->back());
-    laser_line_ifs_->pop_back();
-  }
-  delete laser_line_ifs_;
+	while (!laser_line_ifs_->empty()) {
+		blackboard->close(laser_line_ifs_->back());
+		laser_line_ifs_->pop_back();
+	}
+	delete laser_line_ifs_;
 }
 
-void TagVisionThread::loop() {
-  if (!cfg_mutex.try_lock()) {
-    // logger->log_info(name(),"Skipping loop");
-    return;
-  }
-  if (fv_cam == NULL || !fv_cam->ready()) {
-    logger->log_info(name(), "Camera not ready");
-    init();
-    return;
-  }
-  // logger->log_info(name(),"entering loop");
-  // get img form fv
-  fv_cam->capture();
-  firevision::convert(fv_cam->colorspace(), firevision::YUV422_PLANAR,
-                      fv_cam->buffer(), image_buffer, this->img_width,
-                      this->img_height);
-  fv_cam->dispose_buffer();
-  // convert img
-  firevision::IplImageAdapter::convert_image_bgr(image_buffer, ipl);
-  // get marker from img
-  get_marker();
+void
+TagVisionThread::loop()
+{
+	if (!cfg_mutex.try_lock()) {
+		// logger->log_info(name(),"Skipping loop");
+		return;
+	}
+	if (fv_cam == NULL || !fv_cam->ready()) {
+		logger->log_info(name(), "Camera not ready");
+		init();
+		return;
+	}
+	// logger->log_info(name(),"entering loop");
+	// get img form fv
+	fv_cam->capture();
+	firevision::convert(fv_cam->colorspace(),
+	                    firevision::YUV422_PLANAR,
+	                    fv_cam->buffer(),
+	                    image_buffer,
+	                    this->img_width,
+	                    this->img_height);
+	fv_cam->dispose_buffer();
+	// convert img
+	firevision::IplImageAdapter::convert_image_bgr(image_buffer, ipl);
+	// get marker from img
+	get_marker();
 
-  this->tag_interfaces->update_blackboard(this->markers_, laser_line_ifs_);
+	this->tag_interfaces->update_blackboard(this->markers_, laser_line_ifs_);
 
-  cfg_mutex.unlock();
+	cfg_mutex.unlock();
 }
 
-void TagVisionThread::get_marker() {
-  // detect makres on image
-  detector.Detect(ipl, &alvar_cam);
-  // reset currently saved markers
-  this->markers_->clear();
-  // fill output array
-  for (alvar::MarkerData &tmp_marker : *(this->detector.markers)) {
-    Pose tmp_pose = tmp_marker.pose;
-    // skip the marker, if the pose is directly on the camera (error)
-    if (tmp_pose.translation[0] < 1 && tmp_pose.translation[1] < 1 &&
-        tmp_pose.translation[2] < 1) {
-      continue;
-    }
-    this->markers_->push_back(tmp_marker);
-    // add up to markers
-    tmp_marker.Visualize(ipl, &alvar_cam);
-  }
-  firevision::IplImageAdapter::convert_image_yuv422_planar(ipl, image_buffer);
+void
+TagVisionThread::get_marker()
+{
+	// detect makres on image
+	detector.Detect(ipl, &alvar_cam);
+	// reset currently saved markers
+	this->markers_->clear();
+	// fill output array
+	for (alvar::MarkerData &tmp_marker : *(this->detector.markers)) {
+		Pose tmp_pose = tmp_marker.pose;
+		// skip the marker, if the pose is directly on the camera (error)
+		if (tmp_pose.translation[0] < 1 && tmp_pose.translation[1] < 1 && tmp_pose.translation[2] < 1) {
+			continue;
+		}
+		this->markers_->push_back(tmp_marker);
+		// add up to markers
+		tmp_marker.Visualize(ipl, &alvar_cam);
+	}
+	firevision::IplImageAdapter::convert_image_yuv422_planar(ipl, image_buffer);
 }
 
 // config handling
 void TagVisionThread::config_value_erased(const char *path){};
 void TagVisionThread::config_tag_changed(const char *new_tag){};
-void TagVisionThread::config_comment_changed(
-    const fawkes::Configuration::ValueIterator *v){};
-void TagVisionThread::config_value_changed(
-    const fawkes::Configuration::ValueIterator *v) {
-  if (cfg_mutex.try_lock()) {
-    try {
-      std::string prefix = CFG_PREFIX;
-      // log, that we open load the config
-      logger->log_info(name(), "loading config");
-      // load alvar camera calibration
-      alvar_cam.SetCalib(
-          config->get_string((prefix + "alvar_camera_calib_file").c_str())
-              .c_str(),
-          0, 0, FILE_FORMAT_DEFAULT);
-      // load marker size and apply it
-      marker_size = config->get_uint((prefix + "marker_size").c_str());
-      detector.SetMarkerSize(marker_size);
-    } catch (fawkes::Exception &e) {
-      logger->log_error(name(), e);
-    }
-  }
-  // gets called for every changed entry... so init is called once per change.
-  cfg_mutex.unlock();
+void TagVisionThread::config_comment_changed(const fawkes::Configuration::ValueIterator *v){};
+void
+TagVisionThread::config_value_changed(const fawkes::Configuration::ValueIterator *v)
+{
+	if (cfg_mutex.try_lock()) {
+		try {
+			std::string prefix = CFG_PREFIX;
+			// log, that we open load the config
+			logger->log_info(name(), "loading config");
+			// load alvar camera calibration
+			alvar_cam.SetCalib(config->get_string((prefix + "alvar_camera_calib_file").c_str()).c_str(),
+			                   0,
+			                   0,
+			                   FILE_FORMAT_DEFAULT);
+			// load marker size and apply it
+			marker_size = config->get_uint((prefix + "marker_size").c_str());
+			detector.SetMarkerSize(marker_size);
+		} catch (fawkes::Exception &e) {
+			logger->log_error(name(), e);
+		}
+	}
+	// gets called for every changed entry... so init is called once per change.
+	cfg_mutex.unlock();
 }

--- a/src/plugins/tag_vision/tag_vision_thread.h
+++ b/src/plugins/tag_vision/tag_vision_thread.h
@@ -40,25 +40,24 @@
 #include <cv.h>
 // alvar marker detection to get poses
 #ifdef HAVE_AR_TRACK_ALVAR
-#include <ar_track_alvar/MarkerDetector.h>
+#	include <ar_track_alvar/MarkerDetector.h>
 #else
-#include <alvar/MarkerDetector.h>
+#	include <alvar/MarkerDetector.h>
 #endif
 
 // firevision camera
 #include <fvcams/camera.h>
 #include <fvclassifiers/simple.h>
+#include <fvutils/adapters/iplimage.h>
 #include <fvutils/base/roi.h>
 #include <fvutils/color/conversions.h>
 #include <fvutils/ipc/shm_image.h>
 
-#include <fvutils/adapters/iplimage.h>
-
 // interface
+#include "tag_position_list.h"
+
 #include <interfaces/LaserLineInterface.h>
 #include <interfaces/TagVisionInterface.h>
-
-#include "tag_position_list.h"
 
 #define MAX_MARKERS 16
 
@@ -78,61 +77,60 @@ class TagVisionThread : public fawkes::Thread,
                         public fawkes::VisionAspect,
                         public fawkes::ConfigurationChangeHandler,
                         public fawkes::ClockAspect,
-                        public fawkes::TransformAspect {
+                        public fawkes::TransformAspect
+{
 public:
-  TagVisionThread();
-  // marker size accasors
-  // thread functions
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	TagVisionThread();
+	// marker size accasors
+	// thread functions
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  /// load config from file
-  void loadConfig();
-  /// the marker detector in alvar
-  alvar::MarkerDetector<alvar::MarkerData> detector;
-  /// the camera the detector uses
-  alvar::Camera alvar_cam;
-  /// the size of a marker in millimeter
-  uint marker_size;
-  /// function to get the markers from an image
-  void get_marker();
-  /// store the alvar markers, containing the poses
-  std::vector<alvar::MarkerData> *markers_;
-  /// maximum markers to detect, size for the markers array
-  size_t max_marker;
+	/// load config from file
+	void loadConfig();
+	/// the marker detector in alvar
+	alvar::MarkerDetector<alvar::MarkerData> detector;
+	/// the camera the detector uses
+	alvar::Camera alvar_cam;
+	/// the size of a marker in millimeter
+	uint marker_size;
+	/// function to get the markers from an image
+	void get_marker();
+	/// store the alvar markers, containing the poses
+	std::vector<alvar::MarkerData> *markers_;
+	/// maximum markers to detect, size for the markers array
+	size_t max_marker;
 
-  /// mutex for config access
-  fawkes::Mutex cfg_mutex;
+	/// mutex for config access
+	fawkes::Mutex cfg_mutex;
 
-  /// firevision camera
-  firevision::Camera *fv_cam;
-  /// firevision image buffer
-  firevision::SharedMemoryImageBuffer *shm_buffer;
-  unsigned char *image_buffer;
-  /// Image Buffer Id
-  std::string shm_id;
+	/// firevision camera
+	firevision::Camera *fv_cam;
+	/// firevision image buffer
+	firevision::SharedMemoryImageBuffer *shm_buffer;
+	unsigned char *                      image_buffer;
+	/// Image Buffer Id
+	std::string shm_id;
 
-  // config handling
-  virtual void config_value_erased(const char *path);
-  virtual void config_tag_changed(const char *new_tag);
-  virtual void
-  config_comment_changed(const fawkes::Configuration::ValueIterator *v);
-  virtual void
-  config_value_changed(const fawkes::Configuration::ValueIterator *v);
+	// config handling
+	virtual void config_value_erased(const char *path);
+	virtual void config_tag_changed(const char *new_tag);
+	virtual void config_comment_changed(const fawkes::Configuration::ValueIterator *v);
+	virtual void config_value_changed(const fawkes::Configuration::ValueIterator *v);
 
-  /// cv image
-  IplImage *ipl;
+	/// cv image
+	IplImage *ipl;
 
-  /// blackboard communication
-  TagPositionList *tag_interfaces;
-  std::vector<fawkes::LaserLineInterface *> *laser_line_ifs_;
+	/// blackboard communication
+	TagPositionList *                          tag_interfaces;
+	std::vector<fawkes::LaserLineInterface *> *laser_line_ifs_;
 
-  /// Width of the image
-  unsigned int img_width;
-  /// Height of the image
-  unsigned int img_height;
+	/// Width of the image
+	unsigned int img_width;
+	/// Height of the image
+	unsigned int img_height;
 };
 
 #endif

--- a/src/plugins/voltagelogger/voltagelogger_plugin.cpp
+++ b/src/plugins/voltagelogger/voltagelogger_plugin.cpp
@@ -20,23 +20,25 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "voltagelogger_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
 /** Template! Makes the robotino move forward for 3 seconds
  * @author Daniel Ewert
  */
-class VoltageLoggerPlugin : public fawkes::Plugin {
+class VoltageLoggerPlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  VoltageLoggerPlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new VoltageLoggerThread());
-  }
+	VoltageLoggerPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new VoltageLoggerThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("Write Battery Voltage to file")

--- a/src/plugins/voltagelogger/voltagelogger_thread.cpp
+++ b/src/plugins/voltagelogger/voltagelogger_thread.cpp
@@ -37,29 +37,39 @@ using namespace fawkes;
 
 /** Constructor. */
 VoltageLoggerThread::VoltageLoggerThread()
-    : Thread("PluginTemplateThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL) {
-  flogger_ = new FileLogger(FILENAME, Logger::LL_DEBUG);
+: Thread("PluginTemplateThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
+	flogger_ = new FileLogger(FILENAME, Logger::LL_DEBUG);
 }
 
-void VoltageLoggerThread::init() {
-
-  logger->log_info(name(), "Plugin Template starts up");
-  bat_if_ = blackboard->open_for_reading<BatteryInterface>("Robotino");
-  last_measure_ = clock->now();
+void
+VoltageLoggerThread::init()
+{
+	logger->log_info(name(), "Plugin Template starts up");
+	bat_if_       = blackboard->open_for_reading<BatteryInterface>("Robotino");
+	last_measure_ = clock->now();
 }
 
-bool VoltageLoggerThread::prepare_finalize_user() { return true; }
-
-void VoltageLoggerThread::finalize() {
-  blackboard->close(bat_if_);
-  delete flogger_;
+bool
+VoltageLoggerThread::prepare_finalize_user()
+{
+	return true;
 }
 
-void VoltageLoggerThread::loop() {
-  if (clock->elapsed(&last_measure_) > INTERVAL) {
-    last_measure_ = clock->now();
-    bat_if_->read();
-    flogger_->log_info(name(), "voltage[V]: %f", (bat_if_->voltage() / 1000.f));
-  }
+void
+VoltageLoggerThread::finalize()
+{
+	blackboard->close(bat_if_);
+	delete flogger_;
+}
+
+void
+VoltageLoggerThread::loop()
+{
+	if (clock->elapsed(&last_measure_) > INTERVAL) {
+		last_measure_ = clock->now();
+		bat_if_->read();
+		flogger_->log_info(name(), "voltage[V]: %f", (bat_if_->voltage() / 1000.f));
+	}
 }

--- a/src/plugins/voltagelogger/voltagelogger_thread.h
+++ b/src/plugins/voltagelogger/voltagelogger_thread.h
@@ -42,25 +42,29 @@ class VoltageLoggerThread : public fawkes::Thread,
                             public fawkes::LoggingAspect,
                             public fawkes::ConfigurableAspect,
                             public fawkes::BlackBoardAspect,
-                            public fawkes::ClockAspect {
-
+                            public fawkes::ClockAspect
+{
 public:
-  VoltageLoggerThread();
+	VoltageLoggerThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual bool prepare_finalize_user();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual bool prepare_finalize_user();
+	virtual void finalize();
 
-  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
-  virtual void run() { Thread::run(); }
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
 private:
 private:
-  fawkes::BatteryInterface *bat_if_;
-  fawkes::FileLogger *flogger_;
-  fawkes::Time last_measure_;
+	fawkes::BatteryInterface *bat_if_;
+	fawkes::FileLogger *      flogger_;
+	fawkes::Time              last_measure_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/advertisment_capability.cpp
+++ b/src/plugins/webtools-bridge/advertisment_capability.cpp
@@ -17,17 +17,18 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <list>
-#include <map>
-#include <memory>
+#include "advertisment_capability.h"
+
+#include "web_session.h"
 
 #include <core/exceptions/software.h>
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
 #include <utils/time/time.h>
 
-#include "advertisment_capability.h"
-#include "web_session.h"
+#include <list>
+#include <map>
+#include <memory>
 
 using namespace fawkes;
 
@@ -46,43 +47,43 @@ using namespace fawkes;
  * @param prefix the prefix that identifies the BridgeProcessor
  */
 Advertisment::Advertisment(std::string topic_name, std::string prefix)
-    : active_status_(DORMANT), topic_name_(topic_name),
-      processor_prefix_(prefix), finalized(false) {
-  __mutex = new fawkes::Mutex();
+: active_status_(DORMANT), topic_name_(topic_name), processor_prefix_(prefix), finalized(false)
+{
+	__mutex = new fawkes::Mutex();
 }
 
 /** Disstructor. */
-Advertisment::~Advertisment() {
-  advertisments_.clear();
-  delete __mutex;
+Advertisment::~Advertisment()
+{
+	advertisments_.clear();
+	delete __mutex;
 }
 
 /** Finalize an advertisment before terminating the instance. */
-void Advertisment::finalize() {
-  MutexLocker ml(__mutex);
+void
+Advertisment::finalize()
+{
+	MutexLocker ml(__mutex);
 
-  if (!finalized) {
-    // If still active deactivate
-    if (is_active()) {
-      deactivate();
-    }
-    // call the extended version
-    finalize_impl();
+	if (!finalized) {
+		// If still active deactivate
+		if (is_active()) {
+			deactivate();
+		}
+		// call the extended version
+		finalize_impl();
 
-    // Deregister from sessions and remove them
-    if (!empty()) {
+		// Deregister from sessions and remove them
+		if (!empty()) {
+			for (it_advertisments_ = advertisments_.begin(); it_advertisments_ != advertisments_.end();) {
+				it_advertisments_->first->unregister_callback(EventType::TERMINATE, shared_from_this());
+				it_advertisments_->second.clear();
+				advertisments_.erase(it_advertisments_++);
+			}
+		}
 
-      for (it_advertisments_ = advertisments_.begin();
-           it_advertisments_ != advertisments_.end();) {
-        it_advertisments_->first->unregister_callback(EventType::TERMINATE,
-                                                      shared_from_this());
-        it_advertisments_->second.clear();
-        advertisments_.erase(it_advertisments_++);
-      }
-    }
-
-    finalized = true;
-  }
+		finalized = true;
+	}
 }
 
 /** Activate the Advertisement instance
@@ -90,11 +91,13 @@ void Advertisment::finalize() {
  * called. When an advertisement is created, it is initially DORMANT. The method
  * will call Activate_impl() by default to execute any extended behaviours.
  */
-void Advertisment::activate() {
-  if (!is_active()) {
-    activate_impl();
-    active_status_ = ACTIVE;
-  }
+void
+Advertisment::activate()
+{
+	if (!is_active()) {
+		activate_impl();
+		active_status_ = ACTIVE;
+	}
 }
 
 /** Change Status into DORMANT
@@ -103,33 +106,53 @@ void Advertisment::activate() {
  * The method will call deactivate_impl() by default to execute any extended
  * behaviours.
  */
-void Advertisment::deactivate() {
-  if (is_active()) {
-    deactivate_impl();
-    active_status_ = DORMANT;
-  }
+void
+Advertisment::deactivate()
+{
+	if (is_active()) {
+		deactivate_impl();
+		active_status_ = DORMANT;
+	}
 }
 
 /** @return True when its an ACTIVE instance */
-bool Advertisment::is_active() { return (active_status_ == ACTIVE); }
+bool
+Advertisment::is_active()
+{
+	return (active_status_ == ACTIVE);
+}
 
 /** @return True when this instance has no session registered for topic
  * advertisement*/
-bool Advertisment::empty() { return advertisments_.empty(); }
+bool
+Advertisment::empty()
+{
+	return advertisments_.empty();
+}
 
 /** @return topic name maintained by this advertisement instance */
-std::string Advertisment::get_topic_name() { return topic_name_; }
+std::string
+Advertisment::get_topic_name()
+{
+	return topic_name_;
+}
 
 /** @return the processor prefix of that topic */
-std::string Advertisment::get_processor_prefix() { return processor_prefix_; }
+std::string
+Advertisment::get_processor_prefix()
+{
+	return processor_prefix_;
+}
 
 /** Finalize extended behaviour
  * This method will be called by default by Finalize()
  * Extend this if you wish to add any operations upon finalizing of the your
  * Subscription. After this the your instance should be ready to be terminated.
  */
-void Advertisment::finalize_impl() {
-  // Override to extend behaviour
+void
+Advertisment::finalize_impl()
+{
+	// Override to extend behaviour
 }
 
 /** Activate extended behaviour
@@ -139,16 +162,20 @@ void Advertisment::finalize_impl() {
  * events listener relevant to topics changes, Or prescribing when the publish
  * should be triggered.
  */
-void Advertisment::activate_impl() {
-  // Override to extend behaviour
+void
+Advertisment::activate_impl()
+{
+	// Override to extend behaviour
 }
 
 /** Deactivate extended behaviour
  * This method will be called by default from dectivate()
  * any operation done to make the instance active "could be" undone here.
  */
-void Advertisment::deactivate_impl() {
-  // Override to extend behaviour
+void
+Advertisment::deactivate_impl()
+{
+	// Override to extend behaviour
 }
 
 /** Subsumes a DORMANT Advertisement instance into an ACTIVE one.
@@ -158,39 +185,38 @@ void Advertisment::deactivate_impl() {
  * After the call, the dormant instance could be safly deleted.
  * @param dormant_advertisment instance to be subsumed
  */
-void Advertisment::subsume(std::shared_ptr<Advertisment> dormant_advertisment) {
+void
+Advertisment::subsume(std::shared_ptr<Advertisment> dormant_advertisment)
+{
+	if (topic_name_ != dormant_advertisment->get_topic_name()) {
+		// throw exception that they dont belong to the same topic and cant be
+		// merged
+		return;
+	}
 
-  if (topic_name_ != dormant_advertisment->get_topic_name()) {
-    // throw exception that they dont belong to the same topic and cant be
-    // merged
-    return;
-  }
+	if (!is_active()) {
+		// throw exceptoin that they dont belong to the same topic and cant be
+		// merged
+		return;
+	}
 
-  if (!is_active()) {
-    // throw exceptoin that they dont belong to the same topic and cant be
-    // merged
-    return;
-  }
+	if (dormant_advertisment->is_active()) {
+		// throw exception that they dont belong to the same topic and cant be
+		// merged
+		return;
+	}
 
-  if (dormant_advertisment->is_active()) {
-    // throw exception that they dont belong to the same topic and cant be
-    // merged
-    return;
-  }
-
-  for (std::map<std::shared_ptr<WebSession>, std::list<Request>>::iterator
-           it_advertisments = dormant_advertisment->advertisments_.begin();
-       it_advertisments != dormant_advertisment->advertisments_.end();
-       it_advertisments++) {
-
-    for (std::list<Request>::iterator it_requests =
-             it_advertisments->second.begin();
-         it_requests != it_advertisments->second.end(); it_requests++) {
-
-      add_request(it_requests->id, it_advertisments->first);
-    }
-  }
-  dormant_advertisment->finalize();
+	for (std::map<std::shared_ptr<WebSession>, std::list<Request>>::iterator it_advertisments =
+	       dormant_advertisment->advertisments_.begin();
+	     it_advertisments != dormant_advertisment->advertisments_.end();
+	     it_advertisments++) {
+		for (std::list<Request>::iterator it_requests = it_advertisments->second.begin();
+		     it_requests != it_advertisments->second.end();
+		     it_requests++) {
+			add_request(it_requests->id, it_advertisments->first);
+		}
+	}
+	dormant_advertisment->finalize();
 }
 
 /** Process a request by add an entry for the request mapped to it's session.
@@ -199,35 +225,35 @@ void Advertisment::subsume(std::shared_ptr<Advertisment> dormant_advertisment) {
  * @param session the session requesting to advertise the topic maintained by
  * this instance.
  */
-void Advertisment::add_request(std::string id,
-                               std::shared_ptr<WebSession> session) {
+void
+Advertisment::add_request(std::string id, std::shared_ptr<WebSession> session)
+{
+	Request request;
+	// CHANGE:this matches for the pointer not the object
+	MutexLocker ml(__mutex);
 
-  Request request;
-  // CHANGE:this matches for the pointer not the object
-  MutexLocker ml(__mutex);
+	it_advertisments_ = advertisments_.find(session);
 
-  it_advertisments_ = advertisments_.find(session);
+	// if it is a new session, register my terminate_handler for the session's
+	// callbacks
+	if (it_advertisments_ == advertisments_.end()) {
+		session->register_callback(EventType::TERMINATE, shared_from_this());
+	}
 
-  // if it is a new session, register my terminate_handler for the session's
-  // callbacks
-  if (it_advertisments_ == advertisments_.end()) {
-    session->register_callback(EventType::TERMINATE, shared_from_this());
-  }
+	// //if there was older requests for this session,  point to the same
+	// last_published_time if ( it_advertisments_ != advertisments_.end() &&
+	// !(advertisments_[session].empty()) )
+	// {
+	// 	if(advertisments_[session].find(id) != advertisments_[session].end())
+	// 	{
+	// 		//throw exception..That id already exists for that client on
+	// that topic
+	// 	}
+	// }
 
-  // //if there was older requests for this session,  point to the same
-  // last_published_time if ( it_advertisments_ != advertisments_.end() &&
-  // !(advertisments_[session].empty()) )
-  // {
-  // 	if(advertisments_[session].find(id) != advertisments_[session].end())
-  // 	{
-  // 		//throw exception..That id already exists for that client on
-  // that topic
-  // 	}
-  // }
+	request.id = id;
 
-  request.id = id;
-
-  advertisments_[session].push_back(request);
+	advertisments_[session].push_back(request);
 }
 
 /** Remove a request upon an unadvertise operation
@@ -237,39 +263,43 @@ void Advertisment::add_request(std::string id,
  * @param session responsible for the request.
  *
  */
-void Advertisment::remove_request(std::string advertisment_id,
-                                  std::shared_ptr<WebSession> session) {
-  MutexLocker ml(__mutex);
+void
+Advertisment::remove_request(std::string advertisment_id, std::shared_ptr<WebSession> session)
+{
+	MutexLocker ml(__mutex);
 
-  it_advertisments_ = advertisments_.find(session);
+	it_advertisments_ = advertisments_.find(session);
 
-  if (it_advertisments_ == advertisments_.end()) {
-    // there is no such session. Maybe session was closed before the request is
-    // processed
-    return;
-  }
+	if (it_advertisments_ == advertisments_.end()) {
+		// there is no such session. Maybe session was closed before the request is
+		// processed
+		return;
+	}
 
-  for (it_requests_ = advertisments_[session].begin();
-       it_requests_ != advertisments_[session].end(); it_requests_++) {
+	for (it_requests_ = advertisments_[session].begin();
+	     it_requests_ != advertisments_[session].end();
+	     it_requests_++) {
+		if ((*it_requests_).id == advertisment_id) {
+			advertisments_[session].erase(it_requests_);
+			break;
+		}
+	}
 
-    if ((*it_requests_).id == advertisment_id) {
-      advertisments_[session].erase(it_requests_);
-      break;
-    }
-  }
-
-  // sub_list_mutex_->lock();
-  if (advertisments_[session].empty()) {
-    session->unregister_callback(EventType::TERMINATE, shared_from_this());
-    advertisments_.erase(session);
-  }
+	// sub_list_mutex_->lock();
+	if (advertisments_[session].empty()) {
+		session->unregister_callback(EventType::TERMINATE, shared_from_this());
+		advertisments_.erase(session);
+	}
 }
 
-void Advertisment::emitt_event(EventType event_type) {
-  for (it_callables_ = callbacks_[event_type].begin();
-       it_callables_ != callbacks_[event_type].end(); it_callables_++) {
-    (*it_callables_)->callback(event_type, shared_from_this());
-  }
+void
+Advertisment::emitt_event(EventType event_type)
+{
+	for (it_callables_ = callbacks_[event_type].begin();
+	     it_callables_ != callbacks_[event_type].end();
+	     it_callables_++) {
+		(*it_callables_)->callback(event_type, shared_from_this());
+	}
 }
 
 /** Callback To Be Called On Events This Instance Is Registered To
@@ -279,47 +309,48 @@ void Advertisment::emitt_event(EventType event_type) {
  * @param event_type of event responsible for this call
  * @param event_emitter is a ptr to the instance that emitted that event
  */
-void Advertisment::callback(EventType event_type,
-                            std::shared_ptr<EventEmitter> event_emitter) {
-  // sub_list_mutex_->lock();
-  MutexLocker ml(__mutex);
+void
+Advertisment::callback(EventType event_type, std::shared_ptr<EventEmitter> event_emitter)
+{
+	// sub_list_mutex_->lock();
+	MutexLocker ml(__mutex);
 
-  try {
-    // check if the event emitter was a session
-    std::shared_ptr<WebSession> session;
-    session = std::dynamic_pointer_cast<WebSession>(event_emitter);
-    if (session != NULL) {
-      if (event_type == EventType::TERMINATE) {
-        // make sure the session is still there and was not deleted while
-        // waiting for the mutex
-        if (advertisments_.find(session) != advertisments_.end())
-          advertisments_.erase(session);
+	try {
+		// check if the event emitter was a session
+		std::shared_ptr<WebSession> session;
+		session = std::dynamic_pointer_cast<WebSession>(event_emitter);
+		if (session != NULL) {
+			if (event_type == EventType::TERMINATE) {
+				// make sure the session is still there and was not deleted while
+				// waiting for the mutex
+				if (advertisments_.find(session) != advertisments_.end())
+					advertisments_.erase(session);
 
-        // std::cout<< "Session terminated NICELY :D" << std::endl;
+				// std::cout<< "Session terminated NICELY :D" << std::endl;
 
-        // was it the last session? if yes, Advertisment emit TERMINATTION event
-        // to the Advertisment_Manager.
-        if (advertisments_.empty()) {
-          std::shared_ptr<Advertisment> my_self =
-              shared_from_this(); // Just to keep object alive till after its
-                                  // deleted from manager
-          ml.unlock();
+				// was it the last session? if yes, Advertisment emit TERMINATTION event
+				// to the Advertisment_Manager.
+				if (advertisments_.empty()) {
+					std::shared_ptr<Advertisment> my_self =
+					  shared_from_this(); // Just to keep object alive till after its
+					                      // deleted from manager
+					ml.unlock();
 
-          emitt_event(EventType::TERMINATE);
+					emitt_event(EventType::TERMINATE);
 
-          // ml.unlock();
-          // my_self->finalize();
-          // std::cout<< "Advertisment topic terminated!" << std::endl;
+					// ml.unlock();
+					// my_self->finalize();
+					// std::cout<< "Advertisment topic terminated!" << std::endl;
 
-          // finalize will need the mutex
-        }
-        // TODO:check if advertisment became empty and trigger the delete from
-        // the owning class if that was the case
-      }
-    }
+					// finalize will need the mutex
+				}
+				// TODO:check if advertisment became empty and trigger the delete from
+				// the owning class if that was the case
+			}
+		}
 
-  } catch (Exception &e) {
-    // if exception was fired it only means that the casting failed becasue the
-    // emitter is not a session
-  }
+	} catch (Exception &e) {
+		// if exception was fired it only means that the casting failed becasue the
+		// emitter is not a session
+	}
 }

--- a/src/plugins/webtools-bridge/advertisment_capability.h
+++ b/src/plugins/webtools-bridge/advertisment_capability.h
@@ -20,13 +20,13 @@
 #ifndef __PLUGINS_ADVERTIS_CAPABILITY_H_
 #define __PLUGINS_ADVERTIS_CAPABILITY_H_
 
-#include <list>
-#include <map>
-#include <memory>
-
 #include "callable.h"
 #include "event_emitter.h"
 #include "event_type.h"
+
+#include <list>
+#include <map>
+#include <memory>
 
 namespace fawkes {
 class Mutex;
@@ -44,104 +44,109 @@ class EventEmitter;
  *
  * @author Mostafa Gomaa
  */
-class AdvertismentCapability {
+class AdvertismentCapability
+{
 public:
-  /** To be implemented by the bridge processor for domain specific semantics
+	/** To be implemented by the bridge processor for domain specific semantics
    * @param topic_name the session wishes to advertise
    * @param id specified in the JSON message
    * @param type  specified in the  JSON message
    * @param session the session requesting the advertise
    * @return ptr to a newly created dormant advertisement instance
    */
-  virtual std::shared_ptr<Advertisment>
-  advertise(std::string topic_name, std::string id, std::string type,
-            std::shared_ptr<WebSession> session) = 0;
+	virtual std::shared_ptr<Advertisment> advertise(std::string                 topic_name,
+	                                                std::string                 id,
+	                                                std::string                 type,
+	                                                std::shared_ptr<WebSession> session) = 0;
 
-  /** To be implemented by the bridge processor for domain specific semantics
+	/** To be implemented by the bridge processor for domain specific semantics
    * @param id included in the JSON message
    * @param advertisment ptr to the instance that we need to unadvertised
    * @param session the session initiating requesting
    */
-  virtual void unadvertise(std::string id,
-                           std::shared_ptr<Advertisment> advertisment,
-                           std::shared_ptr<WebSession> session) = 0;
+	virtual void unadvertise(std::string                   id,
+	                         std::shared_ptr<Advertisment> advertisment,
+	                         std::shared_ptr<WebSession>   session) = 0;
 
-  /** To be implemented by the bridge processor for domain specific semantics
+	/** To be implemented by the bridge processor for domain specific semantics
    * @param id included in the JSON message
    * @param latch included in the JSON message
    * @param msg_in_json to be published for that topic
    * @param advertisment ptr to the instance that we need to publish on
    * @param session the session initiating requesting
    */
-  virtual void
-  publish(std::string id, bool latch,
-          std::string msg_in_json // TODO:: figure out a clever way to keep
-                                  // track of msgs types and content without the
-                                  // need to have the info before hands
-          ,
-          std::shared_ptr<Advertisment> advertisment,
-          std::shared_ptr<WebSession> session) = 0;
+	virtual void publish(std::string id,
+	                     bool        latch,
+	                     std::string msg_in_json // TODO:: figure out a clever way to keep
+	                                             // track of msgs types and content without the
+	                                             // need to have the info before hands
+	                     ,
+	                     std::shared_ptr<Advertisment> advertisment,
+	                     std::shared_ptr<WebSession>   session) = 0;
 };
 
 class Advertisment : public Callable,
                      public EventEmitter,
-                     public std::enable_shared_from_this<Advertisment> {
+                     public std::enable_shared_from_this<Advertisment>
+{
 public:
-  Advertisment(std::string topic_name, std::string processor_prefix);
+	Advertisment(std::string topic_name, std::string processor_prefix);
 
-  virtual ~Advertisment();
+	virtual ~Advertisment();
 
-  void finalize();
-  void activate();
-  void deactivate();
-  bool is_active();
-  bool empty();
-  std::string get_topic_name();
-  std::string get_processor_prefix();
-  void subsume(std::shared_ptr<Advertisment> another_advertisment);
+	void        finalize();
+	void        activate();
+	void        deactivate();
+	bool        is_active();
+	bool        empty();
+	std::string get_topic_name();
+	std::string get_processor_prefix();
+	void        subsume(std::shared_ptr<Advertisment> another_advertisment);
 
-  void add_request(std::string id, std::shared_ptr<WebSession> session);
-  void remove_request(std::string id, std::shared_ptr<WebSession> session);
+	void add_request(std::string id, std::shared_ptr<WebSession> session);
+	void remove_request(std::string id, std::shared_ptr<WebSession> session);
 
-  void callback(EventType event_type, std::shared_ptr<EventEmitter> handler);
+	void callback(EventType event_type, std::shared_ptr<EventEmitter> handler);
 
-  void emitt_event(EventType event_type);
-
-protected:
-  virtual void finalize_impl();   /**< Implicitly called from finalize() */
-  virtual void activate_impl();   /**< Implicitly called from activate() */
-  virtual void deactivate_impl(); /**< implicitly called from deactivate() */
-
-  fawkes::Mutex *__mutex; /**< needed to lock the eternal registry */
+	void emitt_event(EventType event_type);
 
 protected:
-  /** @brief the possible status of an instance. A DORMANT instance only keeps
+	virtual void finalize_impl();   /**< Implicitly called from finalize() */
+	virtual void activate_impl();   /**< Implicitly called from activate() */
+	virtual void deactivate_impl(); /**< implicitly called from deactivate() */
+
+	fawkes::Mutex *__mutex; /**< needed to lock the eternal registry */
+
+protected:
+	/** @brief the possible status of an instance. A DORMANT instance only keeps
    * the data.*/
-  enum Status { ACTIVE, DORMANT };
+	enum Status { ACTIVE, DORMANT };
 
-  /** @brief a single Request mad by a session for advertisement. A session
+	/** @brief a single Request mad by a session for advertisement. A session
    * can make multiple requests with different request parameters. */
-  struct Request {
-    Request() : id("") {}
-    ~Request(){};
-    std::string id; /**< id given to request. Unique across a single
+	struct Request
+	{
+		Request() : id("")
+		{
+		}
+		~Request(){};
+		std::string id; /**< id given to request. Unique across a single
                        advertisement instance*/
-  };
+	};
 
-  Status active_status_;         /**< Tracks the status of the instance */
-  std::string topic_name_;       /**< Topic name this instance is maintaining*/
-  std::string processor_prefix_; /**< processor specific prefix included in that
+	Status      active_status_;    /**< Tracks the status of the instance */
+	std::string topic_name_;       /**< Topic name this instance is maintaining*/
+	std::string processor_prefix_; /**< processor specific prefix included in that
                                     topic name*/
 
-  bool finalized; /**< set to true if it was Object was finilazed berfore */
+	bool finalized; /**< set to true if it was Object was finilazed berfore */
 
-  /// Contains mapping of session to request it made
-  std::map<std::shared_ptr<WebSession>, std::list<Request>> advertisments_;
-  /// Iterator for advertisement_ map
-  std::map<std::shared_ptr<WebSession>, std::list<Request>>::iterator
-      it_advertisments_;
-  /// Iterator for requests list
-  std::list<Request>::iterator it_requests_;
+	/// Contains mapping of session to request it made
+	std::map<std::shared_ptr<WebSession>, std::list<Request>> advertisments_;
+	/// Iterator for advertisement_ map
+	std::map<std::shared_ptr<WebSession>, std::list<Request>>::iterator it_advertisments_;
+	/// Iterator for requests list
+	std::list<Request>::iterator it_requests_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/advertisment_capability_manager.cpp
+++ b/src/plugins/webtools-bridge/advertisment_capability_manager.cpp
@@ -18,15 +18,15 @@
  */
 
 #include "advertisment_capability_manager.h"
-#include "advertisment_capability.h"
 
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
+#include "advertisment_capability.h"
 
 #include <core/exceptions/software.h>
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 
 using namespace fawkes;
 using namespace rapidjson;
@@ -36,146 +36,152 @@ using namespace rapidjson;
  * , "publish"] and dispatches them to the targeted BridgeProcessor (ex,
  * BlackBoard, clips, Ros) p
  */
-AdvertismentCapabilityManager::AdvertismentCapabilityManager()
-    : CapabilityManager("Advertisment") {
-  __mutex = new fawkes::Mutex();
+AdvertismentCapabilityManager::AdvertismentCapabilityManager() : CapabilityManager("Advertisment")
+{
+	__mutex = new fawkes::Mutex();
 }
 
-AdvertismentCapabilityManager::~AdvertismentCapabilityManager() {
-  topic_Advertisment_.clear();
+AdvertismentCapabilityManager::~AdvertismentCapabilityManager()
+{
+	topic_Advertisment_.clear();
 }
 
 /** Initialize the Capability Manager */
-void AdvertismentCapabilityManager::init() { initialized_ = true; }
-
-/** Finalize the Capability Manager */
-void AdvertismentCapabilityManager::finalize() {
-  MutexLocker ml(__mutex);
-
-  if (!finalized_) {
-    for (std::map<std::string, std::shared_ptr<Advertisment>>::iterator it =
-             topic_Advertisment_.begin();
-         it != topic_Advertisment_.end(); it++) {
-      it->second->finalize();
-    }
-
-    CapabilityManager::finalize();
-  }
+void
+AdvertismentCapabilityManager::init()
+{
+	initialized_ = true;
 }
 
-bool AdvertismentCapabilityManager::register_processor(
-    std::shared_ptr<BridgeProcessor> processor) {
-  std::shared_ptr<AdvertismentCapability> Advertisment_processor;
-  Advertisment_processor =
-      std::dynamic_pointer_cast<AdvertismentCapability>(processor);
-  if (Advertisment_processor == NULL) {
-    return false;
-  }
-  // find if it was used before
-  std::string processor_prefix = processor->get_prefix();
+/** Finalize the Capability Manager */
+void
+AdvertismentCapabilityManager::finalize()
+{
+	MutexLocker ml(__mutex);
 
-  if (processores_.find(processor_prefix) == processores_.end()) {
-    // throw exception this prefix name is invalide coz it was used before
-  }
+	if (!finalized_) {
+		for (std::map<std::string, std::shared_ptr<Advertisment>>::iterator it =
+		       topic_Advertisment_.begin();
+		     it != topic_Advertisment_.end();
+		     it++) {
+			it->second->finalize();
+		}
 
-  processores_[processor_prefix] = processor;
+		CapabilityManager::finalize();
+	}
+}
 
-  return true;
+bool
+AdvertismentCapabilityManager::register_processor(std::shared_ptr<BridgeProcessor> processor)
+{
+	std::shared_ptr<AdvertismentCapability> Advertisment_processor;
+	Advertisment_processor = std::dynamic_pointer_cast<AdvertismentCapability>(processor);
+	if (Advertisment_processor == NULL) {
+		return false;
+	}
+	// find if it was used before
+	std::string processor_prefix = processor->get_prefix();
+
+	if (processores_.find(processor_prefix) == processores_.end()) {
+		// throw exception this prefix name is invalide coz it was used before
+	}
+
+	processores_[processor_prefix] = processor;
+
+	return true;
 }
 
 void
 // TODO::remnam it (DispatchtoCapability)
-AdvertismentCapabilityManager::handle_message(
-    Document &d, std::shared_ptr<WebSession> session) {
+AdvertismentCapabilityManager::handle_message(Document &d, std::shared_ptr<WebSession> session)
+{
+	// TODO::MOVE ALL THE TYPE RELATED STUFF TO a proper protocol Class
+	if (!d.HasMember("topic") || !d.HasMember("id")) {
+		throw fawkes::MissingParameterException(
+		  "AdvertismentCPM: Wrong Json Msg, topic name or id missing!");
+	}
 
-  // TODO::MOVE ALL THE TYPE RELATED STUFF TO a proper protocol Class
-  if (!d.HasMember("topic") || !d.HasMember("id")) {
-    throw fawkes::MissingParameterException(
-        "AdvertismentCPM: Wrong Json Msg, topic name or id missing!");
-  }
+	// TODO::Pass the Dom the a Protocol Class that will have the deserialized
+	// types
+	std::string msg_op = std::string(d["op"].GetString());
 
-  // TODO::Pass the Dom the a Protocol Class that will have the deserialized
-  // types
-  std::string msg_op = std::string(d["op"].GetString());
+	std::string msg_topic    = std::string(d["topic"].GetString());
+	std::string match_prefix = "";
 
-  std::string msg_topic = std::string(d["topic"].GetString());
-  std::string match_prefix = "";
+	// Find longest matching processor presfix within topic_name
+	// TODO:Check the logic..might be wrong
+	// TODO:posible Optimization. if the same topic name exists in the
+	// topic_advertisment just get the prefix from there
+	for (ProcessorMap::iterator it = processores_.begin(); it != processores_.end(); it++) {
+		std::string processor_prefix = it->first;
+		std::size_t found_at         = msg_topic.find(processor_prefix, 0);
 
-  // Find longest matching processor presfix within topic_name
-  // TODO:Check the logic..might be wrong
-  // TODO:posible Optimization. if the same topic name exists in the
-  // topic_advertisment just get the prefix from there
-  for (ProcessorMap::iterator it = processores_.begin();
-       it != processores_.end(); it++) {
-    std::string processor_prefix = it->first;
-    std::size_t found_at = msg_topic.find(processor_prefix, 0);
+		if (found_at != std::string::npos) {
+			// allows freedom of 2 characters before the match to account
+			// for leading "/" ot "//" or and other startting charachters
+			if (found_at <= 1) {
+				if (processor_prefix.length() == match_prefix.length()) {
+					// Throw an exception. That there are 2 names with confusion prefixs
+					// a conflict like "/bl" and  "bl1" when looking for "bl".
+					// this cozed by the fliexibility
+					throw fawkes::IllegalArgumentException(
+					  "AdvertismentCPM: Could not select processor, 2 conflicting "
+					  "names!");
 
-    if (found_at != std::string::npos) {
-      // allows freedom of 2 characters before the match to account
-      // for leading "/" ot "//" or and other startting charachters
-      if (found_at <= 1) {
-        if (processor_prefix.length() == match_prefix.length()) {
-          // Throw an exception. That there are 2 names with confusion prefixs
-          // a conflict like "/bl" and  "bl1" when looking for "bl".
-          // this cozed by the fliexibility
-          throw fawkes::IllegalArgumentException(
-              "AdvertismentCPM: Could not select processor, 2 conflicting "
-              "names!");
+				} else if (processor_prefix.length() > match_prefix.length()) {
+					match_prefix = processor_prefix;
+				}
+			}
+		}
+	}
 
-        } else if (processor_prefix.length() > match_prefix.length()) {
-          match_prefix = processor_prefix;
-        }
-      }
-    }
-  }
+	if (match_prefix.length() == 0) {
+		throw fawkes::IllegalArgumentException(
+		  "AdvertismentCPM: No processor recognized for this topic!");
+	}
 
-  if (match_prefix.length() == 0) {
-    throw fawkes::IllegalArgumentException(
-        "AdvertismentCPM: No processor recognized for this topic!");
-  }
+	// Go with To the proper operation with the bridge_prefix and the request
+	// Paramters
+	if (msg_op == "advertise") {
+		std::string topic_name = "";
+		std::string id         = "";
+		std::string type       = "";
+		// bool 		 latch			=	false;
+		// int 		 queue_size 	=	100;
 
-  // Go with To the proper operation with the bridge_prefix and the request
-  // Paramters
-  if (msg_op == "advertise") {
-    std::string topic_name = "";
-    std::string id = "";
-    std::string type = "";
-    // bool 		 latch			=	false;
-    // int 		 queue_size 	=	100;
+		if (d.HasMember("topic"))
+			topic_name = std::string(d["topic"].GetString());
+		if (d.HasMember("id"))
+			id = std::string(d["id"].GetString());
+		if (d.HasMember("type"))
+			type = std::string(d["type"].GetString());
+		// if(d.HasMember("latch")) 		 latch			=
+		// d["latch"].GetBool();
+		// if(d.HasMember("queue_size")) 	 queue_size		=
+		// d["type"].GetInt();
 
-    if (d.HasMember("topic"))
-      topic_name = std::string(d["topic"].GetString());
-    if (d.HasMember("id"))
-      id = std::string(d["id"].GetString());
-    if (d.HasMember("type"))
-      type = std::string(d["type"].GetString());
-    // if(d.HasMember("latch")) 		 latch			=
-    // d["latch"].GetBool();
-    // if(d.HasMember("queue_size")) 	 queue_size		=
-    // d["type"].GetInt();
+		advertise(match_prefix, topic_name, id, type, session);
+	} else
 
-    advertise(match_prefix, topic_name, id, type, session);
-  } else
+	  if (msg_op == "unadvertise") {
+		std::string topic_name = std::string(d["topic"].GetString());
+		std::string id         = std::string(d["id"].GetString());
 
-      if (msg_op == "unadvertise") {
-    std::string topic_name = std::string(d["topic"].GetString());
-    std::string id = std::string(d["id"].GetString());
+		unadvertise(match_prefix, topic_name, id, session);
+	} else
 
-    unadvertise(match_prefix, topic_name, id, session);
-  } else
+	  if (msg_op == "publish") {
+		std::string topic_name = std::string(d["topic"].GetString());
+		std::string id         = std::string(d["id"].GetString());
+		bool        latch      = d["latch"].GetBool();
+		// TEMP: for now keep the msg as a json and just forward it to ros
+		StringBuffer         buffer;
+		Writer<StringBuffer> writer(buffer);
+		d["msg"].Accept(writer);
+		std::string msg_jsonStr = buffer.GetString();
 
-      if (msg_op == "publish") {
-    std::string topic_name = std::string(d["topic"].GetString());
-    std::string id = std::string(d["id"].GetString());
-    bool latch = d["latch"].GetBool();
-    // TEMP: for now keep the msg as a json and just forward it to ros
-    StringBuffer buffer;
-    Writer<StringBuffer> writer(buffer);
-    d["msg"].Accept(writer);
-    std::string msg_jsonStr = buffer.GetString();
-
-    publish(match_prefix, topic_name, id, latch, msg_jsonStr, session);
-  }
+		publish(match_prefix, topic_name, id, latch, msg_jsonStr, session);
+	}
 }
 
 /** Callback To Be Called On Events This Instance Is Registered To
@@ -185,140 +191,147 @@ AdvertismentCapabilityManager::handle_message(
  * @param event_type of event responsible for this call
  * @param event_emitter is a ptr to the instance that emitted that event
  */
-void AdvertismentCapabilityManager::callback(
-    EventType event_type, std::shared_ptr<EventEmitter> event_emitter) {
+void
+AdvertismentCapabilityManager::callback(EventType                     event_type,
+                                        std::shared_ptr<EventEmitter> event_emitter)
+{
+	MutexLocker ml(__mutex);
 
-  MutexLocker ml(__mutex);
+	try {
+		// check if the event emitter was a Advertisment
+		std::shared_ptr<Advertisment> advertisment;
+		advertisment = std::dynamic_pointer_cast<Advertisment>(event_emitter);
+		if (advertisment != NULL) {
+			if (event_type == EventType::TERMINATE) {
+				// construct the prefixed_name from info in the advertisment
+				// std::string
+				// prefixed_topic_name="/"+advertisment->get_processor_prefix()+"/"+advertisment->get_topic_name();
+				std::string prefixed_topic_name = advertisment->get_topic_name();
 
-  try {
-    // check if the event emitter was a Advertisment
-    std::shared_ptr<Advertisment> advertisment;
-    advertisment = std::dynamic_pointer_cast<Advertisment>(event_emitter);
-    if (advertisment != NULL) {
-      if (event_type == EventType::TERMINATE) {
-        // construct the prefixed_name from info in the advertisment
-        // std::string
-        // prefixed_topic_name="/"+advertisment->get_processor_prefix()+"/"+advertisment->get_topic_name();
-        std::string prefixed_topic_name = advertisment->get_topic_name();
-
-        // does the advertisment exist (unique per topic_name)
-        if (topic_Advertisment_.find(prefixed_topic_name) !=
-            topic_Advertisment_.end()) {
-          topic_Advertisment_[prefixed_topic_name]->finalize();
-          topic_Advertisment_.erase(prefixed_topic_name);
-        }
-      }
-    }
-  } catch (Exception &e) {
-    // if exception was fired it only means that the casting failed becasue the
-    // emitter is not a advertisment
-  }
+				// does the advertisment exist (unique per topic_name)
+				if (topic_Advertisment_.find(prefixed_topic_name) != topic_Advertisment_.end()) {
+					topic_Advertisment_[prefixed_topic_name]->finalize();
+					topic_Advertisment_.erase(prefixed_topic_name);
+				}
+			}
+		}
+	} catch (Exception &e) {
+		// if exception was fired it only means that the casting failed becasue the
+		// emitter is not a advertisment
+	}
 }
 
-void AdvertismentCapabilityManager::advertise(
-    std::string bridge_prefix, std::string topic_name, std::string id,
-    std::string type, std::shared_ptr<WebSession> session) {
-  MutexLocker ml(__mutex);
+void
+AdvertismentCapabilityManager::advertise(std::string                 bridge_prefix,
+                                         std::string                 topic_name,
+                                         std::string                 id,
+                                         std::string                 type,
+                                         std::shared_ptr<WebSession> session)
+{
+	MutexLocker ml(__mutex);
 
-  std::shared_ptr<AdvertismentCapability> processor;
-  processor = std::dynamic_pointer_cast<AdvertismentCapability>(
-      processores_[bridge_prefix]);
-  // should be garanteed to work
+	std::shared_ptr<AdvertismentCapability> processor;
+	processor = std::dynamic_pointer_cast<AdvertismentCapability>(processores_[bridge_prefix]);
+	// should be garanteed to work
 
-  std::shared_ptr<Advertisment> advertisment;
+	std::shared_ptr<Advertisment> advertisment;
 
-  try {
-    // always creates a new advertisment for that topic with the given Session
-    // and parameters
-    // TODO:: pass the pure string arguments or a "protocol" type
-    advertisment = processor->advertise(topic_name, id, type, session);
+	try {
+		// always creates a new advertisment for that topic with the given Session
+		// and parameters
+		// TODO:: pass the pure string arguments or a "protocol" type
+		advertisment = processor->advertise(topic_name, id, type, session);
 
-  } catch (Exception &e) {
-    throw e;
-  }
+	} catch (Exception &e) {
+		throw e;
+	}
 
-  /*push it to the topic_advertisment_map maintain only ONE Advertisement
+	/*push it to the topic_advertisment_map maintain only ONE Advertisement
    *instance per topic. ps.Advertisement contains all the clients mapped to
    *their individual requests*/
 
-  // Is it a new topic? Just push it to the map and activate the Advertisement
+	// Is it a new topic? Just push it to the map and activate the Advertisement
 
-  // Mutex.lock()
-  if (topic_Advertisment_.find(topic_name) == topic_Advertisment_.end()) {
-    topic_Advertisment_[topic_name] = advertisment;
-    // Activate the listeners or whatever that publishs
-    // advertisment->register_callback( TERMINATE , shared_from_this() );
-    advertisment->activate();
-    // Advertisments should norify me if it was terminated (by calling my
-    // callback)
-    advertisment->register_callback(EventType::TERMINATE, shared_from_this());
-  } else {
-    topic_Advertisment_[topic_name]->subsume(advertisment);
-    // advertisment->finalize();
-  }
+	// Mutex.lock()
+	if (topic_Advertisment_.find(topic_name) == topic_Advertisment_.end()) {
+		topic_Advertisment_[topic_name] = advertisment;
+		// Activate the listeners or whatever that publishs
+		// advertisment->register_callback( TERMINATE , shared_from_this() );
+		advertisment->activate();
+		// Advertisments should norify me if it was terminated (by calling my
+		// callback)
+		advertisment->register_callback(EventType::TERMINATE, shared_from_this());
+	} else {
+		topic_Advertisment_[topic_name]->subsume(advertisment);
+		// advertisment->finalize();
+	}
 
-  // Mutex.unlock();
+	// Mutex.unlock();
 }
 
-void AdvertismentCapabilityManager::unadvertise(
-    std::string bridge_prefix, std::string topic_name, std::string id,
-    std::shared_ptr<WebSession> session) {
-  MutexLocker ml(__mutex);
+void
+AdvertismentCapabilityManager::unadvertise(std::string                 bridge_prefix,
+                                           std::string                 topic_name,
+                                           std::string                 id,
+                                           std::shared_ptr<WebSession> session)
+{
+	MutexLocker ml(__mutex);
 
-  // select thre right processor
-  std::shared_ptr<AdvertismentCapability> processor;
-  processor = std::dynamic_pointer_cast<AdvertismentCapability>(
-      processores_[bridge_prefix]);
+	// select thre right processor
+	std::shared_ptr<AdvertismentCapability> processor;
+	processor = std::dynamic_pointer_cast<AdvertismentCapability>(processores_[bridge_prefix]);
 
-  std::shared_ptr<Advertisment> advertisment;
+	std::shared_ptr<Advertisment> advertisment;
 
-  if (topic_Advertisment_.find(topic_name) != topic_Advertisment_.end()) {
+	if (topic_Advertisment_.find(topic_name) != topic_Advertisment_.end()) {
+		advertisment = topic_Advertisment_[topic_name];
 
-    advertisment = topic_Advertisment_[topic_name];
+		try {
+			processor->unadvertise(id, advertisment, session);
+		} catch (Exception &e) {
+			throw e;
+		}
 
-    try {
-      processor->unadvertise(id, advertisment, session);
-    } catch (Exception &e) {
-      throw e;
-    }
+		if (advertisment->empty()) {
+			topic_Advertisment_[topic_name]->finalize();
+			topic_Advertisment_.erase(topic_name);
+		}
 
-    if (advertisment->empty()) {
-      topic_Advertisment_[topic_name]->finalize();
-      topic_Advertisment_.erase(topic_name);
-    }
-
-    return;
-  }
-  // throw exception that topic was not found
+		return;
+	}
+	// throw exception that topic was not found
 }
 
-void AdvertismentCapabilityManager::publish(
-    std::string bridge_prefix, std::string topic_name, std::string id,
-    bool latch, std::string msg_jsonStr, std::shared_ptr<WebSession> session) {
-  MutexLocker ml(__mutex);
+void
+AdvertismentCapabilityManager::publish(std::string                 bridge_prefix,
+                                       std::string                 topic_name,
+                                       std::string                 id,
+                                       bool                        latch,
+                                       std::string                 msg_jsonStr,
+                                       std::shared_ptr<WebSession> session)
+{
+	MutexLocker ml(__mutex);
 
-  // select thre right processor
-  std::shared_ptr<AdvertismentCapability> processor;
-  processor = std::dynamic_pointer_cast<AdvertismentCapability>(
-      processores_[bridge_prefix]);
+	// select thre right processor
+	std::shared_ptr<AdvertismentCapability> processor;
+	processor = std::dynamic_pointer_cast<AdvertismentCapability>(processores_[bridge_prefix]);
 
-  std::shared_ptr<Advertisment> advertisment;
+	std::shared_ptr<Advertisment> advertisment;
 
-  if (topic_Advertisment_.find(topic_name) != topic_Advertisment_.end()) {
+	if (topic_Advertisment_.find(topic_name) != topic_Advertisment_.end()) {
+		advertisment = topic_Advertisment_[topic_name];
 
-    advertisment = topic_Advertisment_[topic_name];
+		try {
+			processor->publish(id, latch, msg_jsonStr, advertisment, session);
+		} catch (Exception &e) {
+			throw e;
+		}
 
-    try {
-      processor->publish(id, latch, msg_jsonStr, advertisment, session);
-    } catch (Exception &e) {
-      throw e;
-    }
-
-    if (advertisment->empty()) {
-      topic_Advertisment_[topic_name]->finalize();
-      topic_Advertisment_.erase(topic_name);
-    }
-    return;
-  }
-  // throw exception that topic was not found
+		if (advertisment->empty()) {
+			topic_Advertisment_[topic_name]->finalize();
+			topic_Advertisment_.erase(topic_name);
+		}
+		return;
+	}
+	// throw exception that topic was not found
 }

--- a/src/plugins/webtools-bridge/advertisment_capability_manager.h
+++ b/src/plugins/webtools-bridge/advertisment_capability_manager.h
@@ -29,37 +29,43 @@ class Mutex;
 }
 
 class AdvertismentCapabilityManager
-    : public CapabilityManager,
-      public Callable,
-      public std::enable_shared_from_this<AdvertismentCapabilityManager> {
+: public CapabilityManager,
+  public Callable,
+  public std::enable_shared_from_this<AdvertismentCapabilityManager>
+{
 public:
-  AdvertismentCapabilityManager();
-  ~AdvertismentCapabilityManager();
+	AdvertismentCapabilityManager();
+	~AdvertismentCapabilityManager();
 
-  void init();
-  void finalize();
+	void init();
+	void finalize();
 
-  void handle_message(rapidjson::Document &d,
-                      std::shared_ptr<WebSession> session);
+	void handle_message(rapidjson::Document &d, std::shared_ptr<WebSession> session);
 
-  bool register_processor(std::shared_ptr<BridgeProcessor> processor);
+	bool register_processor(std::shared_ptr<BridgeProcessor> processor);
 
-  void callback(EventType event_type,
-                std::shared_ptr<EventEmitter> event_emitter);
+	void callback(EventType event_type, std::shared_ptr<EventEmitter> event_emitter);
 
 private:
-  void advertise(std::string bridge_prefix, std::string topic_name,
-                 std::string id, std::string type,
-                 std::shared_ptr<WebSession> session);
+	void advertise(std::string                 bridge_prefix,
+	               std::string                 topic_name,
+	               std::string                 id,
+	               std::string                 type,
+	               std::shared_ptr<WebSession> session);
 
-  void unadvertise(std::string bridge_prefix, std::string topic_name,
-                   std::string id, std::shared_ptr<WebSession> session);
+	void unadvertise(std::string                 bridge_prefix,
+	                 std::string                 topic_name,
+	                 std::string                 id,
+	                 std::shared_ptr<WebSession> session);
 
-  void publish(std::string bridge_prefix, std::string topic_name,
-               std::string id, bool latch, std::string msg_jsonStr,
-               std::shared_ptr<WebSession> session);
+	void publish(std::string                 bridge_prefix,
+	             std::string                 topic_name,
+	             std::string                 id,
+	             bool                        latch,
+	             std::string                 msg_jsonStr,
+	             std::shared_ptr<WebSession> session);
 
-  std::map<std::string, std::shared_ptr<Advertisment>> topic_Advertisment_;
+	std::map<std::string, std::shared_ptr<Advertisment>> topic_Advertisment_;
 
-  fawkes::Mutex *__mutex;
+	fawkes::Mutex *__mutex;
 };

--- a/src/plugins/webtools-bridge/blackboard_processor.cpp
+++ b/src/plugins/webtools-bridge/blackboard_processor.cpp
@@ -22,22 +22,19 @@
 
 #include "blackboard_processor.h"
 
-#include <core/exceptions/software.h>
-#include <core/exceptions/system.h>
-
-#include <utils/misc/string_conversions.h>
-#include <utils/misc/string_split.h>
-#include <utils/time/time.h>
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h" //TODO:: be moved when serializer is complete
 
 #include <blackboard/blackboard.h>
-#include <logging/logger.h>
-
+#include <core/exceptions/software.h>
+#include <core/exceptions/system.h>
 #include <interface/field_iterator.h>
 #include <interface/interface.h>
 #include <interface/interface_info.h>
-
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h" //TODO:: be moved when serializer is complete
+#include <logging/logger.h>
+#include <utils/misc/string_conversions.h>
+#include <utils/misc/string_split.h>
+#include <utils/time/time.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -62,23 +59,27 @@ using namespace rapidjson;
  * @param blackboard Fawkes blackboard
  * @param clock Fawkes clock
  */
-BridgeBlackBoardProcessor::BridgeBlackBoardProcessor(
-    std::string prefix, fawkes::Logger *logger, fawkes::Configuration *config,
-    fawkes::BlackBoard *blackboard, fawkes::Clock *clock)
-    : BridgeProcessor(prefix) {
-  logger_ = logger;
-  config_ = config;
-  blackboard_ = blackboard;
-  clock_ = clock;
-  logger_->log_info("BlackBoardProcessor::", "Initialized!");
+BridgeBlackBoardProcessor::BridgeBlackBoardProcessor(std::string            prefix,
+                                                     fawkes::Logger *       logger,
+                                                     fawkes::Configuration *config,
+                                                     fawkes::BlackBoard *   blackboard,
+                                                     fawkes::Clock *        clock)
+: BridgeProcessor(prefix)
+{
+	logger_     = logger;
+	config_     = config;
+	blackboard_ = blackboard;
+	clock_      = clock;
+	logger_->log_info("BlackBoardProcessor::", "Initialized!");
 }
 
 /** Destructor. */
-BridgeBlackBoardProcessor::~BridgeBlackBoardProcessor() {
-  // for (ifi_ = interface_.begin(); ifi_ != interface_.end(); ++ifi_) {
-  //   blackboard_->close(ifi_->second);
-  // }
-  // interface_.clear();
+BridgeBlackBoardProcessor::~BridgeBlackBoardProcessor()
+{
+	// for (ifi_ = interface_.begin(); ifi_ != interface_.end(); ++ifi_) {
+	//   blackboard_->close(ifi_->second);
+	// }
+	// interface_.clear();
 }
 
 /** Perform a Subscription to a Blackboard Topic (handling a "subscribe" opcode)
@@ -96,124 +97,138 @@ BridgeBlackBoardProcessor::~BridgeBlackBoardProcessor() {
  * on change of topic data
  * @return BlackboardSubscription
  */
-std::shared_ptr<Subscription> BridgeBlackBoardProcessor::subscribe(
-    std::string prefixed_topic_name, std::string id, std::string type,
-    std::string compression, unsigned int throttle_rate,
-    unsigned int queue_length, unsigned int fragment_size,
-    std::shared_ptr<WebSession> session) {
-  // TODO:: what happens if u subscribed to an interface before its posted.
-  // For now we throw an exception assuming something is wrong..but it could be
-  // that it we're just not there yet
+std::shared_ptr<Subscription>
+BridgeBlackBoardProcessor::subscribe(std::string                 prefixed_topic_name,
+                                     std::string                 id,
+                                     std::string                 type,
+                                     std::string                 compression,
+                                     unsigned int                throttle_rate,
+                                     unsigned int                queue_length,
+                                     unsigned int                fragment_size,
+                                     std::shared_ptr<WebSession> session)
+{
+	// TODO:: what happens if u subscribed to an interface before its posted.
+	// For now we throw an exception assuming something is wrong..but it could be
+	// that it we're just not there yet
 
-  // Extract prefix from the name
-  std::string topic_name = "";
+	// Extract prefix from the name
+	std::string topic_name = "";
 
-  std::size_t pos = prefixed_topic_name.find(prefix_, 0);
-  if (pos != std::string::npos && pos <= 1) {
-    topic_name = prefixed_topic_name.erase(
-        0, prefix_.length() + pos +
-               1); //+1 accounts for the leading '/' before the topic name
-  }
+	std::size_t pos = prefixed_topic_name.find(prefix_, 0);
+	if (pos != std::string::npos && pos <= 1) {
+		topic_name = prefixed_topic_name.erase(
+		  0, prefix_.length() + pos + 1); //+1 accounts for the leading '/' before the topic name
+	}
 
-  if (topic_name == "") {
-    // this should not happen
-    throw fawkes::SyntaxErrorException(
-        "BlackBoardProcessor: Topic Name '%s' does not contian prefix of %s "
-        "processor ",
-        prefixed_topic_name.c_str(), prefix_.c_str());
-  }
+	if (topic_name == "") {
+		// this should not happen
+		throw fawkes::SyntaxErrorException(
+		  "BlackBoardProcessor: Topic Name '%s' does not contian prefix of %s "
+		  "processor ",
+		  prefixed_topic_name.c_str(),
+		  prefix_.c_str());
+	}
 
-  // TODO::take care of the differnt ways the topic is spelled
+	// TODO::take care of the differnt ways the topic is spelled
 
-  // Extracet the BlackBoard Interface Type and Id
-  pos = topic_name.find("::", 0);
-  std::string if_id = topic_name;
-  std::string if_type = topic_name;
+	// Extracet the BlackBoard Interface Type and Id
+	pos                 = topic_name.find("::", 0);
+	std::string if_id   = topic_name;
+	std::string if_type = topic_name;
 
-  if (pos != std::string::npos) {
-    if_type.erase(pos, topic_name.length());
-    if_id.erase(0, pos + 2);
-    // logger_->log_info("BlackboardProcessor: if_type",if_type.c_str());
-    // logger_->log_info("BlackboardProcessor: if_id",if_id.c_str());
-  } else {
-    throw fawkes::SyntaxErrorException(
-        "BlackBoardProcessor: Wrong 'Topic Name' format!");
-  }
+	if (pos != std::string::npos) {
+		if_type.erase(pos, topic_name.length());
+		if_id.erase(0, pos + 2);
+		// logger_->log_info("BlackboardProcessor: if_type",if_type.c_str());
+		// logger_->log_info("BlackboardProcessor: if_id",if_id.c_str());
+	} else {
+		throw fawkes::SyntaxErrorException("BlackBoardProcessor: Wrong 'Topic Name' format!");
+	}
 
-  // Look for the topic in the BlackBoard intefaces
-  bool found = false;
+	// Look for the topic in the BlackBoard intefaces
+	bool found = false;
 
-  InterfaceInfoList *iil = blackboard_->list_all();
-  for (InterfaceInfoList::iterator i = iil->begin(); i != iil->end(); ++i) {
-    if (if_type.compare(i->type()) == 0 && if_id.compare(i->id()) == 0) {
-      found = true;
-      break;
-    }
-  }
-  delete iil;
+	InterfaceInfoList *iil = blackboard_->list_all();
+	for (InterfaceInfoList::iterator i = iil->begin(); i != iil->end(); ++i) {
+		if (if_type.compare(i->type()) == 0 && if_id.compare(i->id()) == 0) {
+			found = true;
+			break;
+		}
+	}
+	delete iil;
 
-  if (!found) {
-    throw fawkes::UnknownTypeException(
-        "BlackboardProcessor: Interface '%s' was not found!",
-        topic_name.c_str());
-  }
+	if (!found) {
+		throw fawkes::UnknownTypeException("BlackboardProcessor: Interface '%s' was not found!",
+		                                   topic_name.c_str());
+	}
 
-  std::shared_ptr<BlackBoardSubscription> new_subscirption;
-  // std::shared_ptr <Subscription> new_subscirption;
+	std::shared_ptr<BlackBoardSubscription> new_subscirption;
+	// std::shared_ptr <Subscription> new_subscirption;
 
-  // Open the interface and create a DORMANT subscription instance with it
-  try {
+	// Open the interface and create a DORMANT subscription instance with it
+	try {
+		new_subscirption =
+		  std::make_shared<BlackBoardSubscription>(topic_name,
+		                                           prefix_,
+		                                           logger_,
+		                                           clock_,
+		                                           blackboard_,
+		                                           blackboard_->open_for_reading(if_type.c_str(),
+		                                                                         if_id.c_str()));
 
-    new_subscirption = std::make_shared<BlackBoardSubscription>(
-        topic_name, prefix_, logger_, clock_, blackboard_,
-        blackboard_->open_for_reading(if_type.c_str(), if_id.c_str()));
+		// new_subscirption = std::make_shared <Subscription>(topic_name
+		//                                                           , prefix_
+		//                                                           , clock_ );
 
-    // new_subscirption = std::make_shared <Subscription>(topic_name
-    //                                                           , prefix_
-    //                                                           , clock_ );
+	} catch (fawkes::Exception &e) {
+		logger_->log_info("BlackBoardProcessor:",
+		                  "Failed to open subscribe to '%s': %s\n",
+		                  topic_name.c_str(),
+		                  e.what());
+		throw e;
+	}
 
-  } catch (fawkes::Exception &e) {
-    logger_->log_info(
-        "BlackBoardProcessor:", "Failed to open subscribe to '%s': %s\n",
-        topic_name.c_str(), e.what());
-    throw e;
-  }
+	logger_->log_info("BlackboardProcessor:",
+	                  "Interface '%s' Succefully Opened!",
+	                  topic_name.c_str());
 
-  logger_->log_info("BlackboardProcessor:", "Interface '%s' Succefully Opened!",
-                    topic_name.c_str());
+	// TODO:: add_request should be removed and the request is add on Subscription
+	// during construction/ OR moved to the SubscriptionCapabilty manager maybe.
+	new_subscirption->add_request(
+	  id, compression, throttle_rate, queue_length, fragment_size, session);
 
-  // TODO:: add_request should be removed and the request is add on Subscription
-  // during construction/ OR moved to the SubscriptionCapabilty manager maybe.
-  new_subscirption->add_request(id, compression, throttle_rate, queue_length,
-                                fragment_size, session);
-
-  return new_subscirption;
+	return new_subscirption;
 }
 
-void BridgeBlackBoardProcessor::unsubscribe(
-    std::string id, std::shared_ptr<Subscription> subscription,
-    std::shared_ptr<WebSession> session) {
-  std::shared_ptr<BlackBoardSubscription> bb_subscription =
-      std::static_pointer_cast<BlackBoardSubscription>(subscription);
+void
+BridgeBlackBoardProcessor::unsubscribe(std::string                   id,
+                                       std::shared_ptr<Subscription> subscription,
+                                       std::shared_ptr<WebSession>   session)
+{
+	std::shared_ptr<BlackBoardSubscription> bb_subscription =
+	  std::static_pointer_cast<BlackBoardSubscription>(subscription);
 
-  bb_subscription->remove_request(id, session);
+	bb_subscription->remove_request(id, session);
 }
 
 std::shared_ptr<Advertisment>
-BridgeBlackBoardProcessor::advertise(std::string topic_name, std::string id,
-                                     std::string type,
-                                     std::shared_ptr<WebSession> session) {
-  // To Be Implemented
-  std::shared_ptr<Advertisment> advertisment =
-      std::make_shared<Advertisment>(topic_name, prefix_);
-  advertisment->add_request(id, session);
-  return advertisment;
+BridgeBlackBoardProcessor::advertise(std::string                 topic_name,
+                                     std::string                 id,
+                                     std::string                 type,
+                                     std::shared_ptr<WebSession> session)
+{
+	// To Be Implemented
+	std::shared_ptr<Advertisment> advertisment = std::make_shared<Advertisment>(topic_name, prefix_);
+	advertisment->add_request(id, session);
+	return advertisment;
 }
 
-void BridgeBlackBoardProcessor::unadvertise(
-    std::string id, std::shared_ptr<Advertisment> advertisment,
-    std::shared_ptr<WebSession> session) {
-  // To Be Implemented
+void
+BridgeBlackBoardProcessor::unadvertise(std::string                   id,
+                                       std::shared_ptr<Advertisment> advertisment,
+                                       std::shared_ptr<WebSession>   session)
+{
+	// To Be Implemented
 }
 
 /** Handle opcode "publish", updating the topic data with the data in the json
@@ -227,15 +242,18 @@ void BridgeBlackBoardProcessor::unadvertise(
  * @param advertisment The Advertisement instance created to update this topic
  * @param session The session that will do the publishing
  */
-void BridgeBlackBoardProcessor::publish(
-    std::string id, bool latch,
-    std::string msg_in_json // TODO:: figure out a clever way to keep track of
-                            // msgs types and content without the need to have
-                            // the info before hands
-    ,
-    std::shared_ptr<Advertisment> advertisment,
-    std::shared_ptr<WebSession> session) {
-  // To Be Implemented
+void
+BridgeBlackBoardProcessor::publish(
+  std::string id,
+  bool        latch,
+  std::string msg_in_json // TODO:: figure out a clever way to keep track of
+                          // msgs types and content without the need to have
+                          // the info before hands
+  ,
+  std::shared_ptr<Advertisment> advertisment,
+  std::shared_ptr<WebSession>   session)
+{
+	// To Be Implemented
 }
 
 //====================================  Subscription
@@ -255,41 +273,55 @@ void BridgeBlackBoardProcessor::publish(
  * @param blackboard blackboard where the topic lives
  * @param interface interface to access the topic from blackboard
  */
-BlackBoardSubscription::BlackBoardSubscription(std::string topic_name,
-                                               std::string processor_prefix,
-                                               fawkes::Logger *logger,
-                                               fawkes::Clock *clock,
+BlackBoardSubscription::BlackBoardSubscription(std::string         topic_name,
+                                               std::string         processor_prefix,
+                                               fawkes::Logger *    logger,
+                                               fawkes::Clock *     clock,
                                                fawkes::BlackBoard *blackboard,
-                                               fawkes::Interface *interface)
-    : Subscription(topic_name, processor_prefix, logger, clock),
-      BlackBoardInterfaceListener("WebToolsBridgeListener"),
-      blackboard_(blackboard), interface_(interface) {}
+                                               fawkes::Interface * interface)
+: Subscription(topic_name, processor_prefix, logger, clock),
+  BlackBoardInterfaceListener("WebToolsBridgeListener"),
+  blackboard_(blackboard),
+  interface_(interface)
+{
+}
 
 /** Destructor */
-BlackBoardSubscription::~BlackBoardSubscription() {
-  // Not Needed
-  // if (interface_ != NULL )
-  // {
-  // delete this->interface_;
-  // }
+BlackBoardSubscription::~BlackBoardSubscription()
+{
+	// Not Needed
+	// if (interface_ != NULL )
+	// {
+	// delete this->interface_;
+	// }
 }
 
 /** @return the internal interface ptr */
-fawkes::Interface *BlackBoardSubscription::get_interface_ptr() {
-  return interface_;
+fawkes::Interface *
+BlackBoardSubscription::get_interface_ptr()
+{
+	return interface_;
 }
 
-void BlackBoardSubscription::activate_impl() {
-  bbil_add_data_interface(interface_);
-  blackboard_->register_listener(this);
+void
+BlackBoardSubscription::activate_impl()
+{
+	bbil_add_data_interface(interface_);
+	blackboard_->register_listener(this);
 }
 
-void BlackBoardSubscription::deactivate_impl() {
-  bbil_remove_data_interface(interface_);
-  blackboard_->unregister_listener(this);
+void
+BlackBoardSubscription::deactivate_impl()
+{
+	bbil_remove_data_interface(interface_);
+	blackboard_->unregister_listener(this);
 }
 
-void BlackBoardSubscription::finalize_impl() { blackboard_->close(interface_); }
+void
+BlackBoardSubscription::finalize_impl()
+{
+	blackboard_->close(interface_);
+}
 
 /**Creates a "publish" rosbridge protocol JSON Message
  * serializes the blackboard topic data into the "msg:" field of
@@ -299,183 +331,179 @@ void BlackBoardSubscription::finalize_impl() { blackboard_->close(interface_); }
  * @param id
  * @return the serialized JSON string
  */
-std::string BlackBoardSubscription::serialize(std::string op,
-                                              std::string topic_name,
-                                              std::string id) {
+std::string
+BlackBoardSubscription::serialize(std::string op, std::string topic_name, std::string id)
+{
+	std::string prefixed_topic_name = processor_prefix_ + "/" + topic_name;
 
-  std::string prefixed_topic_name = processor_prefix_ + "/" + topic_name;
+	// Default 'publish' header
+	StringBuffer         s;
+	Writer<StringBuffer> writer(s);
+	writer.StartObject();
 
-  // Default 'publish' header
-  StringBuffer s;
-  Writer<StringBuffer> writer(s);
-  writer.StartObject();
+	writer.String("op");
+	writer.String(op.c_str(), (SizeType)op.length());
 
-  writer.String("op");
-  writer.String(op.c_str(), (SizeType)op.length());
+	writer.String("id");
+	writer.String(id.c_str(), (SizeType)id.length());
 
-  writer.String("id");
-  writer.String(id.c_str(), (SizeType)id.length());
+	writer.String("topic");
+	writer.String(prefixed_topic_name.c_str(), (SizeType)prefixed_topic_name.length());
 
-  writer.String("topic");
-  writer.String(prefixed_topic_name.c_str(),
-                (SizeType)prefixed_topic_name.length());
+	writer.String("msg");
 
-  writer.String("msg");
+	// Start of Data Json creation
+	writer.StartObject();
 
-  // Start of Data Json creation
-  writer.StartObject();
+	// Data filling from interface
+	for (InterfaceFieldIterator fi = interface_->fields(); fi != interface_->fields_end(); ++fi) {
+		std::string fieldName = fi.get_name();
 
-  // Data filling from interface
-  for (InterfaceFieldIterator fi = interface_->fields();
-       fi != interface_->fields_end(); ++fi) {
+		writer.String(fieldName.c_str(), (SizeType)fieldName.length());
 
-    std::string fieldName = fi.get_name();
+		std::string fieldType = fi.get_typename();
 
-    writer.String(fieldName.c_str(), (SizeType)fieldName.length());
+		if (fi.get_length() > 1 && fieldType != "string") {
+			writer.StartArray();
 
-    std::string fieldType = fi.get_typename();
+			if (fieldType == "bool") {
+				bool *arr = fi.get_bools();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Bool(arr[i]);
+			}
 
-    if (fi.get_length() > 1 && fieldType != "string") {
+			else if (fieldType == "double") {
+				double *arr = fi.get_doubles();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Double(arr[i]);
+			}
 
-      writer.StartArray();
+			else if (fieldType == "float") {
+				float *arr = fi.get_floats();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Double(arr[i]);
+			}
 
-      if (fieldType == "bool") {
-        bool *arr = fi.get_bools();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Bool(arr[i]);
-      }
+			else if (fieldType == "uint64") {
+				uint64_t *arr = fi.get_uint64s();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Uint64(arr[i]);
+			}
 
-      else if (fieldType == "double") {
-        double *arr = fi.get_doubles();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Double(arr[i]);
-      }
+			else if (fieldType == "uint32") {
+				uint32_t *arr = fi.get_uint32s();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Uint(arr[i]);
+			}
 
-      else if (fieldType == "float") {
-        float *arr = fi.get_floats();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Double(arr[i]);
-      }
+			else if (fieldType == "uint16") {
+				uint16_t *arr = fi.get_uint16s();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Uint(arr[i]);
+			}
 
-      else if (fieldType == "uint64") {
-        uint64_t *arr = fi.get_uint64s();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Uint64(arr[i]);
-      }
+			else if (fieldType == "uint8") {
+				uint8_t *arr = fi.get_uint8s();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Uint(arr[i]);
+			}
 
-      else if (fieldType == "uint32") {
-        uint32_t *arr = fi.get_uint32s();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Uint(arr[i]);
-      }
+			else if (fieldType == "int64") {
+				uint64_t *arr = fi.get_uint64s();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Int64(arr[i]);
+			}
 
-      else if (fieldType == "uint16") {
-        uint16_t *arr = fi.get_uint16s();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Uint(arr[i]);
-      }
+			else if (fieldType == "int32") {
+				int32_t *arr = fi.get_int32s();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Int(arr[i]);
+			}
 
-      else if (fieldType == "uint8") {
-        uint8_t *arr = fi.get_uint8s();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Uint(arr[i]);
-      }
+			else if (fieldType == "int16") {
+				int16_t *arr = fi.get_int16s();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Int(arr[i]);
+			}
 
-      else if (fieldType == "int64") {
-        uint64_t *arr = fi.get_uint64s();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Int64(arr[i]);
-      }
+			else if (fieldType == "int8") {
+				int8_t *arr = fi.get_int8s();
+				for (unsigned i = 0; i < fi.get_length(); i++)
+					writer.Int(arr[i]);
+			}
 
-      else if (fieldType == "int32") {
-        int32_t *arr = fi.get_int32s();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Int(arr[i]);
-      }
+			writer.EndArray();
 
-      else if (fieldType == "int16") {
-        int16_t *arr = fi.get_int16s();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Int(arr[i]);
-      }
+		} else {
+			if (fieldType == "bool")
+				writer.Bool(fi.get_bool());
 
-      else if (fieldType == "int8") {
-        int8_t *arr = fi.get_int8s();
-        for (unsigned i = 0; i < fi.get_length(); i++)
-          writer.Int(arr[i]);
-      }
+			else if (fieldType == "string")
+				writer.String(fi.get_string());
 
-      writer.EndArray();
+			else if (fieldType == "double")
+				writer.Double(fi.get_double());
 
-    } else {
-      if (fieldType == "bool")
-        writer.Bool(fi.get_bool());
+			else if (fieldType == "float")
+				writer.Double(fi.get_float());
 
-      else if (fieldType == "string")
-        writer.String(fi.get_string());
+			else if (fieldType == "uint32")
+				writer.Uint(fi.get_uint32());
 
-      else if (fieldType == "double")
-        writer.Double(fi.get_double());
+			else if (fieldType == "int32")
+				writer.Int(fi.get_int32());
 
-      else if (fieldType == "float")
-        writer.Double(fi.get_float());
+			else if (fieldType == "int8")
+				writer.Int(fi.get_int8());
 
-      else if (fieldType == "uint32")
-        writer.Uint(fi.get_uint32());
+			else if (fieldType == "uint8")
+				writer.Uint(fi.get_uint8());
 
-      else if (fieldType == "int32")
-        writer.Int(fi.get_int32());
+			else if (fieldType == "int16")
+				writer.Int(fi.get_int16());
 
-      else if (fieldType == "int8")
-        writer.Int(fi.get_int8());
+			else if (fieldType == "uint16")
+				writer.Uint(fi.get_uint16());
 
-      else if (fieldType == "uint8")
-        writer.Uint(fi.get_uint8());
+			else if (fieldType == "int64")
+				writer.Int64(fi.get_int64());
 
-      else if (fieldType == "int16")
-        writer.Int(fi.get_int16());
+			else if (fieldType == "uint64")
+				writer.Uint64(fi.get_uint64());
 
-      else if (fieldType == "uint16")
-        writer.Uint(fi.get_uint16());
+			else
+				writer.String(fi.get_value_string());
+		}
 
-      else if (fieldType == "int64")
-        writer.Int64(fi.get_int64());
+		//  else if (fieldType== "byte");
+		//  else if (fieldType== "unknown")
+		//  else if (fieldType== "_info->enumtype") find out where is this coming
+		//  from
 
-      else if (fieldType == "uint64")
-        writer.Uint64(fi.get_uint64());
+		// writer.Null();  find what null means in blackboard...if it exists
+	}
 
-      else
-        writer.String(fi.get_value_string());
-    }
+	writer.EndObject(); // End of data json
 
-    //  else if (fieldType== "byte");
-    //  else if (fieldType== "unknown")
-    //  else if (fieldType== "_info->enumtype") find out where is this coming
-    //  from
+	writer.EndObject(); // End of complete Json_msg
 
-    // writer.Null();  find what null means in blackboard...if it exists
-  }
-
-  writer.EndObject(); // End of data json
-
-  writer.EndObject(); // End of complete Json_msg
-
-  return s.GetString();
+	return s.GetString();
 }
 
 /**  Register To Listen To BlackBoard Interface's Change Events
  * Trigger a publish whenever a change happens On the BlackBoard topic
  * @param interface The interface to listen too
  */
-void BlackBoardSubscription::bb_interface_data_changed(
-    fawkes::Interface *interface) throw() {
-  if (!is_active()) {
-    // this should not happen. listener should be deregistered in
-    // deactivate_impl()
-    return;
-  }
+void
+BlackBoardSubscription::bb_interface_data_changed(fawkes::Interface *interface) throw()
+{
+	if (!is_active()) {
+		// this should not happen. listener should be deregistered in
+		// deactivate_impl()
+		return;
+	}
 
-  interface_->read();
+	interface_->read();
 
-  publish();
+	publish();
 }

--- a/src/plugins/webtools-bridge/blackboard_processor.h
+++ b/src/plugins/webtools-bridge/blackboard_processor.h
@@ -23,15 +23,15 @@
 #ifndef __PLUGINS_BLACKBOARD_PROCESSOR_H_
 #define __PLUGINS_BLACKBOARD_PROCESSOR_H_
 
-#include <map>
-#include <string>
+#include "advertisment_capability.h"
+#include "bridge_processor.h"
+#include "subscription_capability.h"
 
 #include <blackboard/interface_listener.h>
 #include <config/config.h>
 
-#include "advertisment_capability.h"
-#include "bridge_processor.h"
-#include "subscription_capability.h"
+#include <map>
+#include <string>
 
 namespace fawkes {
 class Clock;
@@ -47,28 +47,30 @@ class WebSession;
 //=================================   Subscription
 //===================================
 
-class BlackBoardSubscription : public Subscription,
-                               public fawkes::BlackBoardInterfaceListener {
+class BlackBoardSubscription : public Subscription, public fawkes::BlackBoardInterfaceListener
+{
 public:
-  BlackBoardSubscription(std::string topic_name, std::string processor_prefix,
-                         fawkes::Logger *logger, fawkes::Clock *clock,
-                         fawkes::BlackBoard *blackboard,
-                         fawkes::Interface *interface);
+	BlackBoardSubscription(std::string         topic_name,
+	                       std::string         processor_prefix,
+	                       fawkes::Logger *    logger,
+	                       fawkes::Clock *     clock,
+	                       fawkes::BlackBoard *blackboard,
+	                       fawkes::Interface * interface);
 
-  ~BlackBoardSubscription();
+	~BlackBoardSubscription();
 
-  fawkes::Interface *get_interface_ptr();
+	fawkes::Interface *get_interface_ptr();
 
-  void activate_impl();
-  void deactivate_impl();
-  void finalize_impl();
-  std::string serialize(std::string op, std::string topic, std::string id);
+	void        activate_impl();
+	void        deactivate_impl();
+	void        finalize_impl();
+	std::string serialize(std::string op, std::string topic, std::string id);
 
-  void bb_interface_data_changed(fawkes::Interface *interface) throw();
+	void bb_interface_data_changed(fawkes::Interface *interface) throw();
 
 private:
-  fawkes::BlackBoard *blackboard_; /**< Fawkes blackboard */
-  fawkes::Interface *interface_;   /**< Fawkes interface */
+	fawkes::BlackBoard *blackboard_; /**< Fawkes blackboard */
+	fawkes::Interface * interface_;  /**< Fawkes interface */
 };
 
 //=================================   Processor
@@ -80,46 +82,53 @@ class BridgeBlackBoardProcessor : public BridgeProcessor,
 
 {
 public:
-  BridgeBlackBoardProcessor(std::string prefix, fawkes::Logger *logger,
-                            fawkes::Configuration *config,
-                            fawkes::BlackBoard *blackboard,
-                            fawkes::Clock *clock);
+	BridgeBlackBoardProcessor(std::string            prefix,
+	                          fawkes::Logger *       logger,
+	                          fawkes::Configuration *config,
+	                          fawkes::BlackBoard *   blackboard,
+	                          fawkes::Clock *        clock);
 
-  virtual ~BridgeBlackBoardProcessor();
+	virtual ~BridgeBlackBoardProcessor();
 
-  std::shared_ptr<Subscription>
-  subscribe(std::string topic_name, std::string id, std::string type,
-            std::string compression, unsigned int throttle_rate,
-            unsigned int queue_length, unsigned int fragment_size,
-            std::shared_ptr<WebSession> session);
+	std::shared_ptr<Subscription> subscribe(std::string                 topic_name,
+	                                        std::string                 id,
+	                                        std::string                 type,
+	                                        std::string                 compression,
+	                                        unsigned int                throttle_rate,
+	                                        unsigned int                queue_length,
+	                                        unsigned int                fragment_size,
+	                                        std::shared_ptr<WebSession> session);
 
-  void unsubscribe(std::string id, std::shared_ptr<Subscription> subscription,
-                   std::shared_ptr<WebSession> session);
+	void unsubscribe(std::string                   id,
+	                 std::shared_ptr<Subscription> subscription,
+	                 std::shared_ptr<WebSession>   session);
 
-  std::shared_ptr<Advertisment> advertise(std::string topic_name,
-                                          std::string id, std::string type,
-                                          std::shared_ptr<WebSession> session);
+	std::shared_ptr<Advertisment> advertise(std::string                 topic_name,
+	                                        std::string                 id,
+	                                        std::string                 type,
+	                                        std::shared_ptr<WebSession> session);
 
-  void unadvertise(std::string id, std::shared_ptr<Advertisment> advertisment,
-                   std::shared_ptr<WebSession> session);
+	void unadvertise(std::string                   id,
+	                 std::shared_ptr<Advertisment> advertisment,
+	                 std::shared_ptr<WebSession>   session);
 
-  void
-  publish(std::string id, bool latch,
-          std::string msg_in_json // TODO:: figure out a clever way to keep
-                                  // track of msgs types and content without
-                                  // the need to have the info before hands
-          ,
-          std::shared_ptr<Advertisment> advertisment,
-          std::shared_ptr<WebSession> session);
+	void publish(std::string id,
+	             bool        latch,
+	             std::string msg_in_json // TODO:: figure out a clever way to keep
+	                                     // track of msgs types and content without
+	                                     // the need to have the info before hands
+	             ,
+	             std::shared_ptr<Advertisment> advertisment,
+	             std::shared_ptr<WebSession>   session);
 
 private:
-  fawkes::Logger *logger_;         /**< Fawkes logger */
-  fawkes::Configuration *config_;  /**< Fawkes config */
-  fawkes::BlackBoard *blackboard_; /**< Fawkes blackboard */
-  fawkes::Clock *clock_;           /**< Fawkes clock */
+	fawkes::Logger *       logger_;     /**< Fawkes logger */
+	fawkes::Configuration *config_;     /**< Fawkes config */
+	fawkes::BlackBoard *   blackboard_; /**< Fawkes blackboard */
+	fawkes::Clock *        clock_;      /**< Fawkes clock */
 
-  std::map<std::string, fawkes::Interface *>::iterator
-      ifi_; /**< Iterator for Fawkes Interface list */
+	std::map<std::string, fawkes::Interface *>::iterator
+	  ifi_; /**< Iterator for Fawkes Interface list */
 };
 
 #endif

--- a/src/plugins/webtools-bridge/bridge_manager.cpp
+++ b/src/plugins/webtools-bridge/bridge_manager.cpp
@@ -55,17 +55,23 @@ using namespace rapidjson;
  */
 
 /** Constructor. */
-BridgeManager::BridgeManager() {}
+BridgeManager::BridgeManager()
+{
+}
 
 /** Destructor. */
-BridgeManager::~BridgeManager() {}
+BridgeManager::~BridgeManager()
+{
+}
 
 /** Finlize the instance */
-void BridgeManager::finalize() {
-  while (!operation_cpm_map_.empty()) {
-    operation_cpm_map_.begin()->second->finalize();
-    operation_cpm_map_.erase(operation_cpm_map_.begin());
-  }
+void
+BridgeManager::finalize()
+{
+	while (!operation_cpm_map_.empty()) {
+		operation_cpm_map_.begin()->second->finalize();
+		operation_cpm_map_.erase(operation_cpm_map_.begin());
+	}
 }
 
 /** Processes incoming requests .
@@ -75,28 +81,28 @@ void BridgeManager::finalize() {
  * @param session The websocket session that made that request, and the
  * destination for the replies
  */
-void BridgeManager::incoming(std::string json,
-                             std::shared_ptr<WebSession> session) {
-  Document d;
-  deserialize(json, d);
+void
+BridgeManager::incoming(std::string json, std::shared_ptr<WebSession> session)
+{
+	Document d;
+	deserialize(json, d);
 
-  if (!d.HasMember("op")) {
-    throw fawkes::MissingParameterException(
-        "BridgeManager: wrong json!, 'Op' field is missing!");
-  }
+	if (!d.HasMember("op")) {
+		throw fawkes::MissingParameterException("BridgeManager: wrong json!, 'Op' field is missing!");
+	}
 
-  std::string op_name = std::string(d["op"].GetString());
-  if (operation_cpm_map_.find(op_name) == operation_cpm_map_.end()) {
-    throw fawkes::UnknownTypeException("BridgeManager: There is no handler "
-                                       "registered for the given operation ");
-  }
-  try {
-    operation_cpm_map_[op_name]->handle_message(d, session);
-  }
+	std::string op_name = std::string(d["op"].GetString());
+	if (operation_cpm_map_.find(op_name) == operation_cpm_map_.end()) {
+		throw fawkes::UnknownTypeException("BridgeManager: There is no handler "
+		                                   "registered for the given operation ");
+	}
+	try {
+		operation_cpm_map_[op_name]->handle_message(d, session);
+	}
 
-  catch (fawkes::Exception &e) {
-    throw e;
-  }
+	catch (fawkes::Exception &e) {
+		throw e;
+	}
 }
 
 /** Parse the json strinf into a dom
@@ -104,17 +110,19 @@ void BridgeManager::incoming(std::string json,
  * @param d Dom that the message date will be stored into
  * @return true if parsing succeeded
  */
-bool BridgeManager::deserialize(std::string jsonStr, Document &d) {
-  const char *json = jsonStr.c_str();
+bool
+BridgeManager::deserialize(std::string jsonStr, Document &d)
+{
+	const char *json = jsonStr.c_str();
 
-  d.Parse(json);
+	d.Parse(json);
 
-  if (d.Parse(json).HasParseError()) {
-    // std::cout<< GetParseError_En(d.GetParseError());
-    return false;
-  }
+	if (d.Parse(json).HasParseError()) {
+		// std::cout<< GetParseError_En(d.GetParseError());
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
 /** Register the Operations Your Bridge Will Provide and Their Handlers.
@@ -134,17 +142,19 @@ bool BridgeManager::deserialize(std::string jsonStr, Document &d) {
 
 // Should only register the CapabilyManager with no Info about what they
 // provide.
-bool BridgeManager::register_operation_handler(
-    std::string op_name, std::shared_ptr<CapabilityManager> cpm) {
-  if (operation_cpm_map_.find(op_name) == operation_cpm_map_.end()) {
-    operation_cpm_map_[op_name] = cpm;
-    operation_cpm_map_[op_name]->init();
-    return true;
-  }
+bool
+BridgeManager::register_operation_handler(std::string                        op_name,
+                                          std::shared_ptr<CapabilityManager> cpm)
+{
+	if (operation_cpm_map_.find(op_name) == operation_cpm_map_.end()) {
+		operation_cpm_map_[op_name] = cpm;
+		operation_cpm_map_[op_name]->init();
+		return true;
+	}
 
-  // throw fawkes::IllegalArgumentException("BridgeManager: Operation '" +
-  // op_name.c_str()+ "' was already registered");
-  return false;
+	// throw fawkes::IllegalArgumentException("BridgeManager: Operation '" +
+	// op_name.c_str()+ "' was already registered");
+	return false;
 }
 
 /** Register a processor that implements a Capability or more for a Fawkes
@@ -158,14 +168,16 @@ bool BridgeManager::register_operation_handler(
  * or more for a certain Fawkes component.
  * @return true on success
  */
-bool BridgeManager::register_processor(
-    std::shared_ptr<BridgeProcessor> processor) {
-  for (std::map<std::string, std::shared_ptr<CapabilityManager>>::iterator it =
-           operation_cpm_map_.begin();
-       it != operation_cpm_map_.end(); ++it) {
-    it->second->register_processor(processor);
-  }
-  processor->init();
+bool
+BridgeManager::register_processor(std::shared_ptr<BridgeProcessor> processor)
+{
+	for (std::map<std::string, std::shared_ptr<CapabilityManager>>::iterator it =
+	       operation_cpm_map_.begin();
+	     it != operation_cpm_map_.end();
+	     ++it) {
+		it->second->register_processor(processor);
+	}
+	processor->init();
 
-  return true;
+	return true;
 }

--- a/src/plugins/webtools-bridge/bridge_manager.h
+++ b/src/plugins/webtools-bridge/bridge_manager.h
@@ -19,15 +19,15 @@
 #ifndef _BRIDGE_MANAGER_H
 #define _BRIDGE_MANAGER_H
 
-#include <memory>
-#include <string>
+#include "bridge_processor.h"
+#include "capability_manager.h"
+#include "web_session.h"
 
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h> //TODO:: move to the cpp
 
-#include "bridge_processor.h"
-#include "capability_manager.h"
-#include "web_session.h"
+#include <memory>
+#include <string>
 
 /*TODO:Change the name of this class suggestions
  * CapabiltiesDispatcher
@@ -39,30 +39,30 @@ class BridgeManager
 //:  public std::enable_shared_from_this<BridgeManager>
 {
 public:
-  BridgeManager();
-  ~BridgeManager();
+	BridgeManager();
+	~BridgeManager();
 
-  void finalize();
+	void finalize();
 
-  void incoming(std::string JsonMsg, std::shared_ptr<WebSession> session);
+	void incoming(std::string JsonMsg, std::shared_ptr<WebSession> session);
 
-  bool deserialize(std::string jsonStr, rapidjson::Document &d);
+	bool deserialize(std::string jsonStr, rapidjson::Document &d);
 
-  bool register_operation_handler(std::string operation_name,
-                                  std::shared_ptr<CapabilityManager> cpm);
+	bool register_operation_handler(std::string                        operation_name,
+	                                std::shared_ptr<CapabilityManager> cpm);
 
-  bool register_processor(std::shared_ptr<BridgeProcessor> processor);
+	bool register_processor(std::shared_ptr<BridgeProcessor> processor);
 
-  // bool unregister_operation_handler(std::string operation_name);
+	// bool unregister_operation_handler(std::string operation_name);
 
-  // bool unregister_processor(std::shared_ptr <BridgeProcessor> processor);
+	// bool unregister_processor(std::shared_ptr <BridgeProcessor> processor);
 
 private:
-  std::map<std::string, std::shared_ptr<CapabilityManager>> operation_cpm_map_;
-  // std::map <std::string, WebSessison>
-  // clients_;
+	std::map<std::string, std::shared_ptr<CapabilityManager>> operation_cpm_map_;
+	// std::map <std::string, WebSessison>
+	// clients_;
 
-  /*TO_BE_REFACTOR:register Cpability managers (not operations) and pull the
+	/*TO_BE_REFACTOR:register Cpability managers (not operations) and pull the
    provided operations list from the cpm  itself
    Each cpm should store what operations it provides*/
 };

--- a/src/plugins/webtools-bridge/bridge_processor.h
+++ b/src/plugins/webtools-bridge/bridge_processor.h
@@ -31,42 +31,53 @@
  *
  * @author Mostafa Gomaa
  */
-class BridgeProcessor {
-
+class BridgeProcessor
+{
 public:
-  /** Constructor
+	/** Constructor
    * @param prefix used to identity this processor and to rout requests to it.
    */
-  BridgeProcessor(std::string prefix)
-      : prefix_(prefix), initialized_(false), finalized_(false) {}
+	BridgeProcessor(std::string prefix) : prefix_(prefix), initialized_(false), finalized_(false)
+	{
+	}
 
-  /** Destructor */
-  virtual ~BridgeProcessor() {}
+	/** Destructor */
+	virtual ~BridgeProcessor()
+	{
+	}
 
-  /** Initialize the BridgeProcessor instance. */
-  virtual void init() {
-    if (!initialized_) {
-      initialized_ = true;
-    }
-  }
+	/** Initialize the BridgeProcessor instance. */
+	virtual void
+	init()
+	{
+		if (!initialized_) {
+			initialized_ = true;
+		}
+	}
 
-  /** finalize the BridgeProcessor instance. */
-  virtual void finalize() {
-    if (!finalized_) {
-      finalized_ = true;
-    }
-  }
+	/** finalize the BridgeProcessor instance. */
+	virtual void
+	finalize()
+	{
+		if (!finalized_) {
+			finalized_ = true;
+		}
+	}
 
-  /** Get the internal prefix identifying this BridgeProcessor
+	/** Get the internal prefix identifying this BridgeProcessor
    * @return the internal prefix that is used to identify this processor
    */
-  std::string get_prefix() { return prefix_; }
+	std::string
+	get_prefix()
+	{
+		return prefix_;
+	}
 
 protected:
-  std::string prefix_; /**< Internal name of the bridge processor used as topics
+	std::string prefix_;      /**< Internal name of the bridge processor used as topics
                           prefix to refer to this processor */
-  bool initialized_;   /**< Initialization status */
-  bool finalized_;     /**< Finalization status */
+	bool        initialized_; /**< Initialization status */
+	bool        finalized_;   /**< Finalization status */
 };
 
 #endif

--- a/src/plugins/webtools-bridge/callable.cpp
+++ b/src/plugins/webtools-bridge/callable.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "callable.h"
+
 #include "event_emitter.h"
 
 /** @class Callable "callable.h"
@@ -35,8 +36,9 @@
  * called.
  * @param handler the object instance initiated the callback method call.
  */
-void Callable::callback(EventType event_type,
-                        std::shared_ptr<EventEmitter> handler) {
-  // the event_type with dynamic_casting for the event_emitter should be enough
-  // to uniquily tell you what you want to do
+void
+Callable::callback(EventType event_type, std::shared_ptr<EventEmitter> handler)
+{
+	// the event_type with dynamic_casting for the event_emitter should be enough
+	// to uniquily tell you what you want to do
 }

--- a/src/plugins/webtools-bridge/callable.h
+++ b/src/plugins/webtools-bridge/callable.h
@@ -24,14 +24,15 @@
 #define _CALLABLE_H
 
 #include "event_type.h"
+
 #include <memory>
 
 // class WebSession;
 class EventEmitter;
-class Callable {
+class Callable
+{
 public:
-  virtual void callback(EventType event_type,
-                        std::shared_ptr<EventEmitter> handler);
+	virtual void callback(EventType event_type, std::shared_ptr<EventEmitter> handler);
 };
 
 #endif

--- a/src/plugins/webtools-bridge/capability_manager.h
+++ b/src/plugins/webtools-bridge/capability_manager.h
@@ -24,6 +24,7 @@
 #define _CAPABILTY_MANAGER_H
 
 #include "bridge_processor.h"
+
 #include <rapidjson/document.h> //todo:move to the cpps
 
 #include <map>
@@ -39,18 +40,22 @@ class WebSession;
  *
  * @author Mostafa Gomaa
  */
-class CapabilityManager {
+class CapabilityManager
+{
 public:
-  /** Constructor
+	/** Constructor
    * @param capability_name the manager is intended to handle*/
-  CapabilityManager(std::string capability_name)
-      : capability_name_(capability_name), initialized_(false),
-        finalized_(false) {}
+	CapabilityManager(std::string capability_name)
+	: capability_name_(capability_name), initialized_(false), finalized_(false)
+	{
+	}
 
-  /** Destructor */
-  ~CapabilityManager() {}
+	/** Destructor */
+	~CapabilityManager()
+	{
+	}
 
-  /** Implantation done by the extending classes.
+	/** Implantation done by the extending classes.
   * Decode the JSON message and dispatches the request to the
   * intended operation provided by the intended BridgeProcessor
   * (the intended operation is encoded in the 'opcode' of the JSON
@@ -59,55 +64,67 @@ public:
   * @param d the Dom object containg the JSON message
   * @param session the session issuing the request.
   */
-  virtual void handle_message(rapidjson::Document &d,
-                              std::shared_ptr<WebSession> session) {}
+	virtual void
+	handle_message(rapidjson::Document &d, std::shared_ptr<WebSession> session)
+	{
+	}
 
-  /** Initialize the capability manager */
-  virtual void init() {
-    if (!initialized_) {
-      initialized_ = true;
-    }
-  }
+	/** Initialize the capability manager */
+	virtual void
+	init()
+	{
+		if (!initialized_) {
+			initialized_ = true;
+		}
+	}
 
-  /** Initialize the capability manager */
-  virtual void finalize() {
-    if (!finalized_) {
-      while (!processores_.empty()) {
-        processores_.begin()->second->finalize();
-        processores_.erase(processores_.begin());
-      }
+	/** Initialize the capability manager */
+	virtual void
+	finalize()
+	{
+		if (!finalized_) {
+			while (!processores_.empty()) {
+				processores_.begin()->second->finalize();
+				processores_.erase(processores_.begin());
+			}
 
-      finalized_ = true;
-    }
-  }
+			finalized_ = true;
+		}
+	}
 
-  /** Implantation done by the extending classes.
+	/** Implantation done by the extending classes.
    * Register a BridgeProcessor that extends the capability managed
    * by this capability manager, by creating a registry entry of the processor
    * mapped to its prefix.
    * @param processor ptr to the BridgeProcessor to register
    * @return true if the capability class was implemented by the processor
    */
-  virtual bool register_processor(std::shared_ptr<BridgeProcessor> processor) {
-    return false;
-  }
+	virtual bool
+	register_processor(std::shared_ptr<BridgeProcessor> processor)
+	{
+		return false;
+	}
 
-  /** Get the name of the capability managed by this CapabilityManager
+	/** Get the name of the capability managed by this CapabilityManager
    * @return the internal name of the capability.
    */
-  std::string get_name() { return capability_name_; }
+	std::string
+	get_name()
+	{
+		return capability_name_;
+	}
 
 protected:
-  /// ProcessorMap is a map type, mapping Prefixes of BidgeProcessor to their
-  /// instances ptrs
-  typedef std::map<std::string, std::shared_ptr<BridgeProcessor>> ProcessorMap;
+	/// ProcessorMap is a map type, mapping Prefixes of BidgeProcessor to their
+	/// instances ptrs
+	typedef std::map<std::string, std::shared_ptr<BridgeProcessor>> ProcessorMap;
 
-  ProcessorMap processores_; /**< Registry to keep track or all processors and
+	ProcessorMap processores_;     /**< Registry to keep track or all processors and
                                 the prefixes used to identify them */
-  std::string capability_name_; /**< Internal name of the capability managed by
+	std::string  capability_name_; /**< Internal name of the capability managed by
                                    this CapabilityManager */
-  bool initialized_;            /**< Initialization status */
-  bool finalized_;              /**< Finalization status */
+	bool         initialized_;     /**< Initialization status */
+	bool         finalized_;       /**< Finalization status */
 };
 
 #endif

--- a/src/plugins/webtools-bridge/clips_processor.cpp
+++ b/src/plugins/webtools-bridge/clips_processor.cpp
@@ -21,23 +21,21 @@
  */
 
 #include "clips_processor.h"
-#include "serializer.h"
 
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h" //TODO:: be moved when serializer is complete
+#include "serializer.h"
 
-#include <map>
-
+#include <clips/clips.h> //am not sure i even need this ..lets see
 #include <core/exceptions/software.h>
 #include <core/exceptions/system.h>
 #include <core/threading/mutex_locker.h>
 #include <logging/logger.h>
 #include <plugins/clips/aspect/clips_env_manager.h>
 
-#include <clips/clips.h> //am not sure i even need this ..lets see
 #include <clipsmm.h>
-
 #include <iostream>
+#include <map>
 #include <thread>
 #include <unistd.h>
 
@@ -62,24 +60,38 @@ using namespace rapidjson;
  * @param clips_env_mgr the clips environment manager, necessary access the fact
  * data
  */
-ClipsSubscription::ClipsSubscription(
-    std::string topic_name, std::string processor_prefix,
-    fawkes::Logger *logger, fawkes::Clock *clock,
-    fawkes::LockPtr<CLIPS::Environment> &clips,
-    fawkes::LockPtr<fawkes::CLIPSEnvManager> &clips_env_mgr)
-    : Subscription(topic_name, processor_prefix, logger, clock), clips_(clips),
-      clips_env_mgr_(clips_env_mgr) {}
-
-ClipsSubscription::~ClipsSubscription() {}
-
-void ClipsSubscription::activate_impl() {
-  // std::thread t(&ClipsSubscription::publish_loop, this);
-  // t.detach();
+ClipsSubscription::ClipsSubscription(std::string                               topic_name,
+                                     std::string                               processor_prefix,
+                                     fawkes::Logger *                          logger,
+                                     fawkes::Clock *                           clock,
+                                     fawkes::LockPtr<CLIPS::Environment> &     clips,
+                                     fawkes::LockPtr<fawkes::CLIPSEnvManager> &clips_env_mgr)
+: Subscription(topic_name, processor_prefix, logger, clock),
+  clips_(clips),
+  clips_env_mgr_(clips_env_mgr)
+{
 }
 
-void ClipsSubscription::deactivate_impl() {}
+ClipsSubscription::~ClipsSubscription()
+{
+}
 
-void ClipsSubscription::finalize_impl() {}
+void
+ClipsSubscription::activate_impl()
+{
+	// std::thread t(&ClipsSubscription::publish_loop, this);
+	// t.detach();
+}
+
+void
+ClipsSubscription::deactivate_impl()
+{
+}
+
+void
+ClipsSubscription::finalize_impl()
+{
+}
 
 /* Creates the JSON message to be Published
  * This method is derived from Subscription, it prescribes how to get a
@@ -91,62 +103,61 @@ void ClipsSubscription::finalize_impl() {}
  * @param id
  * @return the serialized json string
  */
-std::string ClipsSubscription::serialize(std::string op, std::string topic_name,
-                                         std::string id) {
-  std::string prefixed_topic_name = processor_prefix_ + "/" + topic_name;
-  std::string tmpl_name = topic_name;
-  std::string env_name_ = "agent";
+std::string
+ClipsSubscription::serialize(std::string op, std::string topic_name, std::string id)
+{
+	std::string prefixed_topic_name = processor_prefix_ + "/" + topic_name;
+	std::string tmpl_name           = topic_name;
+	std::string env_name_           = "agent";
 
-  std::map<std::string, LockPtr<CLIPS::Environment>> envs =
-      clips_env_mgr_->environments();
-  if (envs.find(env_name_) == envs.end()) {
-    if (envs.size() == 1) { // if there is only one just select it
-      env_name_ = envs.begin()->first;
-    } else {
-      throw fawkes::UnknownTypeException(
-          "ClipsProcessor: Environment '%s' was not found!", env_name_.c_str());
-      // TODO:say what was wrong no envs Vs Wrong name
-    }
-  }
-  clips_ = envs[env_name_];
-  MutexLocker lock(clips_.objmutex_ptr());
-  CLIPS::Fact::pointer fact = clips_->get_facts(); // the first fact in the env
+	std::map<std::string, LockPtr<CLIPS::Environment>> envs = clips_env_mgr_->environments();
+	if (envs.find(env_name_) == envs.end()) {
+		if (envs.size() == 1) { // if there is only one just select it
+			env_name_ = envs.begin()->first;
+		} else {
+			throw fawkes::UnknownTypeException("ClipsProcessor: Environment '%s' was not found!",
+			                                   env_name_.c_str());
+			// TODO:say what was wrong no envs Vs Wrong name
+		}
+	}
+	clips_ = envs[env_name_];
+	MutexLocker          lock(clips_.objmutex_ptr());
+	CLIPS::Fact::pointer fact = clips_->get_facts(); // the first fact in the env
 
-  // does fact exist
-  bool fact_found = false;
-  while (fact) {
-    CLIPS::Template::pointer tmpl = fact->get_template();
-    if (tmpl->name().compare(tmpl_name) == 0) {
-      fact_found = true;
-      // std::cout << "found" << std::endl;
-      break;
-    }
-    fact = fact->next();
-  }
+	// does fact exist
+	bool fact_found = false;
+	while (fact) {
+		CLIPS::Template::pointer tmpl = fact->get_template();
+		if (tmpl->name().compare(tmpl_name) == 0) {
+			fact_found = true;
+			// std::cout << "found" << std::endl;
+			break;
+		}
+		fact = fact->next();
+	}
 
-  if (!fact_found) {
-    // logger_->log_info("ClipsProcessor", "couldn't find fact with template
-    // name %s for now", tmpl_name.c_str());
-    return "";
-  } else {
-    // Default 'publish' header
-    StringBuffer s;
-    Writer<StringBuffer> writer(s);
-    writer.StartObject();
+	if (!fact_found) {
+		// logger_->log_info("ClipsProcessor", "couldn't find fact with template
+		// name %s for now", tmpl_name.c_str());
+		return "";
+	} else {
+		// Default 'publish' header
+		StringBuffer         s;
+		Writer<StringBuffer> writer(s);
+		writer.StartObject();
 
-    writer.String("op");
-    writer.String(op.c_str(), (SizeType)op.length());
+		writer.String("op");
+		writer.String(op.c_str(), (SizeType)op.length());
 
-    writer.String("id");
-    writer.String(id.c_str(), (SizeType)id.length());
+		writer.String("id");
+		writer.String(id.c_str(), (SizeType)id.length());
 
-    writer.String("topic");
-    writer.String(prefixed_topic_name.c_str(),
-                  (SizeType)prefixed_topic_name.length());
+		writer.String("topic");
+		writer.String(prefixed_topic_name.c_str(), (SizeType)prefixed_topic_name.length());
 
-    writer.String("msg");
-    // Serilaize the all matching facts
-    /*
+		writer.String("msg");
+		// Serilaize the all matching facts
+		/*
     *Non-ordered fact:
     {fact: [
                  { slot1: [ value1, vlaue2] , slot2:[] } , //a mathcing fact
@@ -165,90 +176,80 @@ std::string ClipsSubscription::serialize(std::string op, std::string topic_name,
 
     {fact:[]} //a predicate
     */
-    writer.StartObject(); // start of msg json
-    std::string name = fact->get_template()->name();
-    writer.String(name.c_str(), (SizeType)name.length()); // factName: as the
-                                                          // Key
+		writer.StartObject(); // start of msg json
+		std::string name = fact->get_template()->name();
+		writer.String(name.c_str(), (SizeType)name.length()); // factName: as the
+		                                                      // Key
 
-    writer.StartArray(); // start of fact jsons array
-    CLIPS::Fact::pointer fact = clips_->get_facts();
-    while (fact) {
-      CLIPS::Template::pointer tmpl = fact->get_template();
-      if (tmpl->name().compare(tmpl_name) == 0) {
-        std::vector<std::string> slot_names = fact->slot_names();
-        bool ordered_fact =
-            slot_names.size() == 1 && slot_names[0] == "implied" ? true : false;
-        bool predicate_fact =
-            ordered_fact && fact->slot_value("").size() < 1 ? true : false;
+		writer.StartArray(); // start of fact jsons array
+		CLIPS::Fact::pointer fact = clips_->get_facts();
+		while (fact) {
+			CLIPS::Template::pointer tmpl = fact->get_template();
+			if (tmpl->name().compare(tmpl_name) == 0) {
+				std::vector<std::string> slot_names = fact->slot_names();
+				bool ordered_fact   = slot_names.size() == 1 && slot_names[0] == "implied" ? true : false;
+				bool predicate_fact = ordered_fact && fact->slot_value("").size() < 1 ? true : false;
 
-        // std::cout <<slot_names[0]<<std::endl;
+				// std::cout <<slot_names[0]<<std::endl;
 
-        // A Non-ordered Fact Serialization
-        if (!ordered_fact) {
-          writer.StartObject(); // start of 'A' fact json
-          for (std::vector<std::string>::iterator it = slot_names.begin();
-               slot_names.size() > 0 && it != slot_names.end(); it++) {
-            writer.String(it->c_str(),
-                          (SizeType)it->length()); // slot_name as key
-            CLIPS::Values values = fact->slot_value(*it);
-            writer.StartArray(); // array of slot values
-            for (CLIPS::Values::iterator it2 = values.begin();
-                 values.size() > 0 && it2 != values.end(); it2++) {
-              switch (it2->type()) {
-              case CLIPS::TYPE_INTEGER:
-                writer.Int64(it2->as_integer());
-                break;
-              case CLIPS::TYPE_FLOAT:
-                writer.Double(it2->as_float());
-                break;
-              default:
-                writer.String(it2->as_string().c_str(),
-                              (SizeType)it2->as_string().length());
-              }
-            }
-            writer.EndArray(); // end slot values array
-          }
-          writer.EndObject(); // end of 'one' fact json
-        }
+				// A Non-ordered Fact Serialization
+				if (!ordered_fact) {
+					writer.StartObject(); // start of 'A' fact json
+					for (std::vector<std::string>::iterator it = slot_names.begin();
+					     slot_names.size() > 0 && it != slot_names.end();
+					     it++) {
+						writer.String(it->c_str(),
+						              (SizeType)it->length()); // slot_name as key
+						CLIPS::Values values = fact->slot_value(*it);
+						writer.StartArray(); // array of slot values
+						for (CLIPS::Values::iterator it2 = values.begin();
+						     values.size() > 0 && it2 != values.end();
+						     it2++) {
+							switch (it2->type()) {
+							case CLIPS::TYPE_INTEGER: writer.Int64(it2->as_integer()); break;
+							case CLIPS::TYPE_FLOAT: writer.Double(it2->as_float()); break;
+							default: writer.String(it2->as_string().c_str(), (SizeType)it2->as_string().length());
+							}
+						}
+						writer.EndArray(); // end slot values array
+					}
+					writer.EndObject(); // end of 'one' fact json
+				}
 
-        // An Ordered Fact Serialization
-        else {
-          if (!predicate_fact) {
-            writer.StartObject();    // start of 'A' fact json
-            writer.String("fields"); // key for fields array
-            writer.StartArray();     // start of fields array
-            CLIPS::Values values = fact->slot_value("");
-            for (CLIPS::Values::iterator it = values.begin();
-                 values.size() != 0 && it != values.end(); it++) {
-              switch (it->type()) {
-              case CLIPS::TYPE_INTEGER:
-                writer.Int64(it->as_integer());
-                break;
-              case CLIPS::TYPE_FLOAT:
-                writer.Double(it->as_float());
-                break;
-              default:
-                writer.String(it->as_string().c_str(),
-                              (SizeType)it->as_string().length());
-                break;
-              }
-            }
-            writer.EndArray();  // end fields array
-            writer.EndObject(); // end 'A' fact json
-          }
-        }
-      }
-      fact = fact->next();
-    }
+				// An Ordered Fact Serialization
+				else {
+					if (!predicate_fact) {
+						writer.StartObject();    // start of 'A' fact json
+						writer.String("fields"); // key for fields array
+						writer.StartArray();     // start of fields array
+						CLIPS::Values values = fact->slot_value("");
+						for (CLIPS::Values::iterator it = values.begin();
+						     values.size() != 0 && it != values.end();
+						     it++) {
+							switch (it->type()) {
+							case CLIPS::TYPE_INTEGER: writer.Int64(it->as_integer()); break;
+							case CLIPS::TYPE_FLOAT: writer.Double(it->as_float()); break;
+							default:
+								writer.String(it->as_string().c_str(), (SizeType)it->as_string().length());
+								break;
+							}
+						}
+						writer.EndArray();  // end fields array
+						writer.EndObject(); // end 'A' fact json
+					}
+				}
+			}
+			fact = fact->next();
+		}
 
-    writer.EndArray();  // end of fact jsons array
-    writer.EndObject(); // End of msg json
+		writer.EndArray();  // end of fact jsons array
+		writer.EndObject(); // End of msg json
 
-    writer.EndObject(); // End of complete Json_msg
+		writer.EndObject(); // End of complete Json_msg
 
-    // std::cout << s.GetString()<<std::endl;
-    return s.GetString();
-  }
+		// std::cout << s.GetString()<<std::endl;
+		return s.GetString();
+	}
 }
 
 // void
@@ -278,124 +279,130 @@ std::string ClipsSubscription::serialize(std::string op, std::string topic_name,
  * @param clock Fawkes clock
  * @param clips_env_mgr the clips enviorment manager
  */
-ClipsProcessor::ClipsProcessor(
-    std::string prefix, fawkes::Logger *logger, fawkes::Configuration *config,
-    fawkes::Clock *clock,
-    fawkes::LockPtr<fawkes::CLIPSEnvManager> &clips_env_mgr)
-    : BridgeProcessor(prefix), env_name_("agent") // TODO: get from configs
+ClipsProcessor::ClipsProcessor(std::string                               prefix,
+                               fawkes::Logger *                          logger,
+                               fawkes::Configuration *                   config,
+                               fawkes::Clock *                           clock,
+                               fawkes::LockPtr<fawkes::CLIPSEnvManager> &clips_env_mgr)
+: BridgeProcessor(prefix), env_name_("agent") // TODO: get from configs
 {
-  clips_env_mgr_ = clips_env_mgr;
-  logger_ = logger;
-  config_ = config;
-  clock_ = clock;
+	clips_env_mgr_ = clips_env_mgr;
+	logger_        = logger;
+	config_        = config;
+	clock_         = clock;
 
-  logger_->log_info("ClipsProcessor::", "Initialized!");
+	logger_->log_info("ClipsProcessor::", "Initialized!");
 
-  // TODO set the env_name
+	// TODO set the env_name
 }
 
 /** Destructor. */
-ClipsProcessor::~ClipsProcessor() {}
+ClipsProcessor::~ClipsProcessor()
+{
+}
 
-void ClipsProcessor::init() {
-  if (!initialized_) {
-    std::map<std::string, LockPtr<CLIPS::Environment>> envs =
-        clips_env_mgr_->environments();
+void
+ClipsProcessor::init()
+{
+	if (!initialized_) {
+		std::map<std::string, LockPtr<CLIPS::Environment>> envs = clips_env_mgr_->environments();
 
-    if (envs.find(env_name_) == envs.end()) {
-      if (envs.size() == 1) { // if there is only one just select it
-        env_name_ = envs.begin()->first;
-      } else {
-        throw fawkes::UnknownTypeException(
-            "ClipsProcessor: Environment '%s' was not found!",
-            env_name_.c_str());
-        // say what was wrong no envs Vs Wrong name
-      }
-    }
+		if (envs.find(env_name_) == envs.end()) {
+			if (envs.size() == 1) { // if there is only one just select it
+				env_name_ = envs.begin()->first;
+			} else {
+				throw fawkes::UnknownTypeException("ClipsProcessor: Environment '%s' was not found!",
+				                                   env_name_.c_str());
+				// say what was wrong no envs Vs Wrong name
+			}
+		}
 
-    clips_ = envs[env_name_];
+		clips_ = envs[env_name_];
 
-    BridgeProcessor::init();
-  }
+		BridgeProcessor::init();
+	}
 }
 
 std::shared_ptr<Subscription>
-ClipsProcessor::subscribe(std::string prefixed_topic_name, std::string id,
-                          std::string type, std::string compression,
-                          unsigned int throttle_rate, unsigned int queue_length,
-                          unsigned int fragment_size,
-                          std::shared_ptr<WebSession> web_session) {
-  std::string tmpl_name = ""; // get it from the prefixed topic name
+ClipsProcessor::subscribe(std::string                 prefixed_topic_name,
+                          std::string                 id,
+                          std::string                 type,
+                          std::string                 compression,
+                          unsigned int                throttle_rate,
+                          unsigned int                queue_length,
+                          unsigned int                fragment_size,
+                          std::shared_ptr<WebSession> web_session)
+{
+	std::string tmpl_name = ""; // get it from the prefixed topic name
 
-  std::size_t pos = prefixed_topic_name.find(prefix_, 0);
-  if (pos != std::string::npos && pos <= 1) {
-    tmpl_name = prefixed_topic_name.substr(
-        pos + prefix_.length() +
-        1); //+1 accounts for the leading '/' before the topic name
-  }
+	std::size_t pos = prefixed_topic_name.find(prefix_, 0);
+	if (pos != std::string::npos && pos <= 1) {
+		tmpl_name = prefixed_topic_name.substr(
+		  pos + prefix_.length() + 1); //+1 accounts for the leading '/' before the topic name
+	}
 
-  std::map<std::string, LockPtr<CLIPS::Environment>> envs =
-      clips_env_mgr_->environments();
-  if (envs.find(env_name_) == envs.end()) {
-    if (envs.size() == 1) { // if there is only one just select it
-      env_name_ = envs.begin()->first;
-    } else {
-      throw fawkes::UnknownTypeException(
-          "ClipsProcessor: Environment '%s' was not found!", env_name_.c_str());
-      // say what was wrong no envs Vs Wrong name
-    }
-  }
-  clips_ = envs[env_name_];
-  MutexLocker lock(clips_.objmutex_ptr());
+	std::map<std::string, LockPtr<CLIPS::Environment>> envs = clips_env_mgr_->environments();
+	if (envs.find(env_name_) == envs.end()) {
+		if (envs.size() == 1) { // if there is only one just select it
+			env_name_ = envs.begin()->first;
+		} else {
+			throw fawkes::UnknownTypeException("ClipsProcessor: Environment '%s' was not found!",
+			                                   env_name_.c_str());
+			// say what was wrong no envs Vs Wrong name
+		}
+	}
+	clips_ = envs[env_name_];
+	MutexLocker lock(clips_.objmutex_ptr());
 
-  CLIPS::Fact::pointer fact =
-      clips_->get_facts(); // intialize it with the first fact
-  bool fact_found = false;
-  while (fact) {
-    CLIPS::Template::pointer tmpl = fact->get_template();
-    if (tmpl->name().compare(tmpl_name) == 0) {
-      fact_found = true;
-      break;
-      // for now, its just enough to know that there is a fact with this
-      // topic_name to make a subscription Realisticly, u need to know the
-      // constraint and fit to it more over if nothing fits now or no fact with
-      // tmp_name found..Does not mean that this subscription is not valid.
-      // Could mean that the fact has not been asserted yet and that we need to
-      // watch for it So basically i think there is no invalide subscriptions
-      // with clips..Just ones that u need to watch for.
-    }
-    fact = fact->next();
-  }
+	CLIPS::Fact::pointer fact       = clips_->get_facts(); // intialize it with the first fact
+	bool                 fact_found = false;
+	while (fact) {
+		CLIPS::Template::pointer tmpl = fact->get_template();
+		if (tmpl->name().compare(tmpl_name) == 0) {
+			fact_found = true;
+			break;
+			// for now, its just enough to know that there is a fact with this
+			// topic_name to make a subscription Realisticly, u need to know the
+			// constraint and fit to it more over if nothing fits now or no fact with
+			// tmp_name found..Does not mean that this subscription is not valid.
+			// Could mean that the fact has not been asserted yet and that we need to
+			// watch for it So basically i think there is no invalide subscriptions
+			// with clips..Just ones that u need to watch for.
+		}
+		fact = fact->next();
+	}
 
-  if (!fact_found)
-    logger_->log_info("ClipsProcessor",
-                      "couldn't find fact with template name %s for now",
-                      tmpl_name.c_str());
+	if (!fact_found)
+		logger_->log_info("ClipsProcessor",
+		                  "couldn't find fact with template name %s for now",
+		                  tmpl_name.c_str());
 
-  // for now, always make a subscription intstance for the subscription request
-  // (even if no fact found)
-  std::shared_ptr<ClipsSubscription> new_subscirption;
+	// for now, always make a subscription intstance for the subscription request
+	// (even if no fact found)
+	std::shared_ptr<ClipsSubscription> new_subscirption;
 
-  // a DORMANT subscription instance with it
-  try {
+	// a DORMANT subscription instance with it
+	try {
+		new_subscirption = std::make_shared<ClipsSubscription>(
+		  tmpl_name, prefix_, logger_, clock_, clips_, clips_env_mgr_);
 
-    new_subscirption = std::make_shared<ClipsSubscription>(
-        tmpl_name, prefix_, logger_, clock_, clips_, clips_env_mgr_);
+	} catch (fawkes::Exception &e) {
+		logger_->log_info(
+		  "ClipsProcessor:", "Failed to subscribe to '%s': %s\n", tmpl_name.c_str(), e.what());
+		throw e;
+	}
 
-  } catch (fawkes::Exception &e) {
-    logger_->log_info("ClipsProcessor:", "Failed to subscribe to '%s': %s\n",
-                      tmpl_name.c_str(), e.what());
-    throw e;
-  }
+	new_subscirption->add_request(
+	  id, compression, throttle_rate, queue_length, fragment_size, web_session);
 
-  new_subscirption->add_request(id, compression, throttle_rate, queue_length,
-                                fragment_size, web_session);
+	logger_->log_info("ClipsProcessor", "DONE");
 
-  logger_->log_info("ClipsProcessor", "DONE");
-
-  return new_subscirption;
+	return new_subscirption;
 }
 
-void ClipsProcessor::unsubscribe(std::string id,
-                                 std::shared_ptr<Subscription> subscription,
-                                 std::shared_ptr<WebSession> session) {}
+void
+ClipsProcessor::unsubscribe(std::string                   id,
+                            std::shared_ptr<Subscription> subscription,
+                            std::shared_ptr<WebSession>   session)
+{
+}

--- a/src/plugins/webtools-bridge/clips_processor.h
+++ b/src/plugins/webtools-bridge/clips_processor.h
@@ -23,14 +23,13 @@
 #ifndef __PLUGINS_CLIPS_PROCESSOR_H_
 #define __PLUGINS_CLIPS_PROCESSOR_H_
 
-#include <string>
-
-#include <core/utils/lockptr.h>
-
-#include <config/config.h>
-
 #include "bridge_processor.h"
 #include "subscription_capability.h"
+
+#include <config/config.h>
+#include <core/utils/lockptr.h>
+
+#include <string>
 
 namespace fawkes {
 class Clock;
@@ -48,59 +47,69 @@ class WebSession;
 //=================================   Subscription
 //===================================
 
-class ClipsSubscription : public Subscription {
+class ClipsSubscription : public Subscription
+{
 public:
-  ClipsSubscription(std::string topic_name, std::string processor_prefix,
-                    fawkes::Logger *logger, fawkes::Clock *clock,
-                    fawkes::LockPtr<CLIPS::Environment> &clips,
-                    fawkes::LockPtr<fawkes::CLIPSEnvManager> &clips_env_mgr);
+	ClipsSubscription(std::string                               topic_name,
+	                  std::string                               processor_prefix,
+	                  fawkes::Logger *                          logger,
+	                  fawkes::Clock *                           clock,
+	                  fawkes::LockPtr<CLIPS::Environment> &     clips,
+	                  fawkes::LockPtr<fawkes::CLIPSEnvManager> &clips_env_mgr);
 
-  ~ClipsSubscription();
+	~ClipsSubscription();
 
-  void activate_impl();
-  void deactivate_impl();
-  void finalize_impl();
+	void activate_impl();
+	void deactivate_impl();
+	void finalize_impl();
 
-  // void publish_loop();
+	// void publish_loop();
 
-  std::string serialize(std::string op, std::string topic, std::string id);
+	std::string serialize(std::string op, std::string topic, std::string id);
 
 private:
-  fawkes::LockPtr<CLIPS::Environment> clips_;
-  fawkes::LockPtr<fawkes::CLIPSEnvManager> clips_env_mgr_;
+	fawkes::LockPtr<CLIPS::Environment>      clips_;
+	fawkes::LockPtr<fawkes::CLIPSEnvManager> clips_env_mgr_;
 };
 
 //=================================   Processor
 //===================================
 
-class ClipsProcessor : public BridgeProcessor, public SubscriptionCapability {
+class ClipsProcessor : public BridgeProcessor, public SubscriptionCapability
+{
 public:
-  ClipsProcessor(std::string prefix, fawkes::Logger *logger,
-                 fawkes::Configuration *config, fawkes::Clock *clock,
-                 fawkes::LockPtr<fawkes::CLIPSEnvManager> &clips_env_mgr);
+	ClipsProcessor(std::string                               prefix,
+	               fawkes::Logger *                          logger,
+	               fawkes::Configuration *                   config,
+	               fawkes::Clock *                           clock,
+	               fawkes::LockPtr<fawkes::CLIPSEnvManager> &clips_env_mgr);
 
-  virtual ~ClipsProcessor(); // why did i leave this virtual. does it make sense
+	virtual ~ClipsProcessor(); // why did i leave this virtual. does it make sense
 
-  void init();
+	void init();
 
-  std::shared_ptr<Subscription>
-  subscribe(std::string topic_name, std::string id, std::string type,
-            std::string compression, unsigned int throttle_rate,
-            unsigned int queue_length, unsigned int fragment_size,
-            std::shared_ptr<WebSession> session);
+	std::shared_ptr<Subscription> subscribe(std::string                 topic_name,
+	                                        std::string                 id,
+	                                        std::string                 type,
+	                                        std::string                 compression,
+	                                        unsigned int                throttle_rate,
+	                                        unsigned int                queue_length,
+	                                        unsigned int                fragment_size,
+	                                        std::shared_ptr<WebSession> session);
 
-  void unsubscribe(std::string id, std::shared_ptr<Subscription> subscription,
-                   std::shared_ptr<WebSession> session);
+	void unsubscribe(std::string                   id,
+	                 std::shared_ptr<Subscription> subscription,
+	                 std::shared_ptr<WebSession>   session);
 
 private:
-  fawkes::Logger *logger_;
-  fawkes::Configuration *config_;
-  fawkes::Clock *clock_;
+	fawkes::Logger *       logger_;
+	fawkes::Configuration *config_;
+	fawkes::Clock *        clock_;
 
-  fawkes::LockPtr<fawkes::CLIPSEnvManager> clips_env_mgr_;
-  fawkes::LockPtr<CLIPS::Environment> clips_;
+	fawkes::LockPtr<fawkes::CLIPSEnvManager> clips_env_mgr_;
+	fawkes::LockPtr<CLIPS::Environment>      clips_;
 
-  std::string env_name_;
+	std::string env_name_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/event_emitter.cpp
+++ b/src/plugins/webtools-bridge/event_emitter.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "event_emitter.h"
+
 #include "callable.h"
 
 #include <core/threading/mutex.h>
@@ -38,12 +39,16 @@ using namespace fawkes;
  */
 
 /** Constructor. */
-EventEmitter::EventEmitter() { mutex_ = new fawkes::Mutex(); }
+EventEmitter::EventEmitter()
+{
+	mutex_ = new fawkes::Mutex();
+}
 
 /** Destructor. */
-EventEmitter::~EventEmitter() {
-  callbacks_.clear();
-  delete mutex_;
+EventEmitter::~EventEmitter()
+{
+	callbacks_.clear();
+	delete mutex_;
 }
 
 /** Call the callbacks of the Callable Objects
@@ -52,42 +57,45 @@ EventEmitter::~EventEmitter() {
  * Used to emulates signal emitting.
  * @param event_type what ever event you would like to signal (ex, TERMINATE)
  */
-void EventEmitter::emitt_event(EventType event_type) {
+void
+EventEmitter::emitt_event(EventType event_type)
+{
+	// for(it_callables_  = callbacks_ [event_type].begin();
+	// 	it_callables_ != callbacks_ [event_type].end() ;
+	// 	it_callables_++)
+	// {
+	// 	(*it_callables_)->callback(event_type , shared_from_this());
+	// }
 
-  // for(it_callables_  = callbacks_ [event_type].begin();
-  // 	it_callables_ != callbacks_ [event_type].end() ;
-  // 	it_callables_++)
-  // {
-  // 	(*it_callables_)->callback(event_type , shared_from_this());
-  // }
-
-  // do_on_event(event_type);
+	// do_on_event(event_type);
 }
 
 /** Register a callable to be called on some event type
  * @param event_type to receive a callback for
  * @param callable the class with the callback that handles the event.
  */
-void EventEmitter::register_callback(EventType event_type,
-                                     std::shared_ptr<Callable> callable) {
-  MutexLocker ml(mutex_);
+void
+EventEmitter::register_callback(EventType event_type, std::shared_ptr<Callable> callable)
+{
+	MutexLocker ml(mutex_);
 
-  callbacks_[event_type].push_back(callable);
+	callbacks_[event_type].push_back(callable);
 }
 
 /** Unregister a callable from emitter entries
  * @param event_type that the callable was registered to
  * @param callable to the class that wants to unregister.
  */
-void EventEmitter::unregister_callback(EventType event_type,
-                                       std::shared_ptr<Callable> callable) {
-  MutexLocker ml(mutex_);
+void
+EventEmitter::unregister_callback(EventType event_type, std::shared_ptr<Callable> callable)
+{
+	MutexLocker ml(mutex_);
 
-  it_callables_ = std::find_if(
-      callbacks_[event_type].begin(), callbacks_[event_type].end(),
-      [&](std::shared_ptr<Callable> const &c) { return c == callable; });
+	it_callables_ = std::find_if(callbacks_[event_type].begin(),
+	                             callbacks_[event_type].end(),
+	                             [&](std::shared_ptr<Callable> const &c) { return c == callable; });
 
-  if (it_callables_ != callbacks_[event_type].end()) {
-    callbacks_[event_type].erase(it_callables_);
-  }
+	if (it_callables_ != callbacks_[event_type].end()) {
+		callbacks_[event_type].erase(it_callables_);
+	}
 }

--- a/src/plugins/webtools-bridge/event_emitter.h
+++ b/src/plugins/webtools-bridge/event_emitter.h
@@ -23,12 +23,12 @@
 #ifndef _EVENT_HANDLER_H
 #define _EVENT_HANDLER_H
 
+#include "event_type.h"
+
 #include <algorithm>
 #include <list>
 #include <map>
 #include <memory>
-
-#include "event_type.h"
 
 class Callable;
 
@@ -36,30 +36,28 @@ namespace fawkes {
 class Mutex;
 }
 
-class EventEmitter {
+class EventEmitter
+{
 public:
-  EventEmitter();
-  virtual ~EventEmitter(); // To make it polymorfic (enabling casting from
-                           // Derived to Base )
+	EventEmitter();
+	virtual ~EventEmitter(); // To make it polymorfic (enabling casting from
+	                         // Derived to Base )
 
-  virtual void emitt_event(EventType event_type) = 0;
+	virtual void emitt_event(EventType event_type) = 0;
 
-  void register_callback(EventType event_type,
-                         std::shared_ptr<Callable> callable);
-  void unregister_callback(EventType event_type,
-                           std::shared_ptr<Callable> callable);
+	void register_callback(EventType event_type, std::shared_ptr<Callable> callable);
+	void unregister_callback(EventType event_type, std::shared_ptr<Callable> callable);
 
 protected:
-  /// Registry for each EventType and the a coresponding list of classes
-  /// registered for it
-  std::map<EventType, std::list<std::shared_ptr<Callable>>> callbacks_;
-  /// Iterator for the registry
-  std::map<EventType, std::list<std::shared_ptr<Callable>>>::iterator
-      it_events_;
-  /// Iterator for list of callables
-  std::list<std::shared_ptr<Callable>>::iterator it_callables_;
-  /// Mutex to lock the registry during operations
-  fawkes::Mutex *mutex_;
+	/// Registry for each EventType and the a coresponding list of classes
+	/// registered for it
+	std::map<EventType, std::list<std::shared_ptr<Callable>>> callbacks_;
+	/// Iterator for the registry
+	std::map<EventType, std::list<std::shared_ptr<Callable>>>::iterator it_events_;
+	/// Iterator for list of callables
+	std::list<std::shared_ptr<Callable>>::iterator it_callables_;
+	/// Mutex to lock the registry during operations
+	fawkes::Mutex *mutex_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/proxy_session.h
+++ b/src/plugins/webtools-bridge/proxy_session.h
@@ -24,19 +24,18 @@
 #ifndef _PROXY_SESSION_H
 #define _PROXY_SESSION_H
 
-#include <memory>
-
-#include <websocketpp/client.hpp>
-#include <websocketpp/config/asio_no_tls_client.hpp>
+#include "callable.h"
+#include "event_emitter.h"
+#include "event_type.h"
 
 #include <core/exceptions/software.h>
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
 #include <logging/logger.h>
 
-#include "callable.h"
-#include "event_emitter.h"
-#include "event_type.h"
+#include <memory>
+#include <websocketpp/client.hpp>
+#include <websocketpp/config/asio_no_tls_client.hpp>
 
 // TODO::move to commonNameSpace
 typedef websocketpp::client<websocketpp::config::asio_client> Client;
@@ -53,47 +52,45 @@ class ProxySession
 // , public Callable
 // , public std::enable_shared_from_this<ProxySession>
 {
-
 public:
-  ProxySession();
-  ~ProxySession();
+	ProxySession();
+	~ProxySession();
 
-  // void terminate();
+	// void terminate();
 
-  // void on_open(websocketpp::connection_hdl hdl , std::shared_ptr<Client>
-  // endpoint_ptr ); void on_fail(websocketpp::connection_hdl hdl); void
-  // on_close(websocketpp::connection_hdl hdl);//this will be called when
-  // session is closed from server
-  void on_message(
-      websocketpp::connection_hdl hdl,
-      websocketpp::client<websocketpp::config::asio_client>::message_ptr msg);
-  bool send(std::string const &msg);
+	// void on_open(websocketpp::connection_hdl hdl , std::shared_ptr<Client>
+	// endpoint_ptr ); void on_fail(websocketpp::connection_hdl hdl); void
+	// on_close(websocketpp::connection_hdl hdl);//this will be called when
+	// session is closed from server
+	void on_message(websocketpp::connection_hdl                                        hdl,
+	                websocketpp::client<websocketpp::config::asio_client>::message_ptr msg);
+	bool send(std::string const &msg);
 
-  void set_id(int id);
-  void set_connection_hdl(websocketpp::connection_hdl hdl);
-  void set_endpoint(std::shared_ptr<Client> endpoint_ptr);
-  void set_status(std::string status);
+	void set_id(int id);
+	void set_connection_hdl(websocketpp::connection_hdl hdl);
+	void set_endpoint(std::shared_ptr<Client> endpoint_ptr);
+	void set_status(std::string status);
 
-  int get_id();
-  std::string get_status();
-  websocketpp::connection_hdl get_connection_hdl();
-  std::shared_ptr<WebSession> get_web_session();
+	int                         get_id();
+	std::string                 get_status();
+	websocketpp::connection_hdl get_connection_hdl();
+	std::shared_ptr<WebSession> get_web_session();
 
-  void register_web_session(std::shared_ptr<WebSession> web_session);
-  void unregister_web_session();
+	void register_web_session(std::shared_ptr<WebSession> web_session);
+	void unregister_web_session();
 
 private:
-  // The websocket client session where all interactions to be mapped
-  std::shared_ptr<WebSession> web_session_;
-  bool web_session_available;
+	// The websocket client session where all interactions to be mapped
+	std::shared_ptr<WebSession> web_session_;
+	bool                        web_session_available;
 
-  websocketpp::connection_hdl hdl_;
-  std::shared_ptr<Client> endpoint_ptr_;
+	websocketpp::connection_hdl hdl_;
+	std::shared_ptr<Client>     endpoint_ptr_;
 
-  std::string status_;
-  int session_id_;
+	std::string status_;
+	int         session_id_;
 
-  fawkes::Mutex *mutex_;
+	fawkes::Mutex *mutex_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/rosbridge_proxy_processor.cpp
+++ b/src/plugins/webtools-bridge/rosbridge_proxy_processor.cpp
@@ -22,7 +22,9 @@
  */
 
 #include "rosbridge_proxy_processor.h"
+
 #include "proxy_session.h"
+#include "serializer.h"
 #include "web_session.h"
 
 #include <config/config.h>
@@ -31,8 +33,6 @@
 #include <core/threading/mutex_locker.h>
 #include <logging/logger.h>
 #include <utils/time/time.h>
-
-#include "serializer.h"
 
 using namespace websocketpp;
 using websocketpp::connection_hdl;
@@ -70,86 +70,92 @@ using namespace fawkes;
  * @param config Fawkes config
  * @param clock Fawkes clock
  */
-RosBridgeProxyProcessor::RosBridgeProxyProcessor(std::string prefix,
-                                                 fawkes::Logger *logger,
+RosBridgeProxyProcessor::RosBridgeProxyProcessor(std::string            prefix,
+                                                 fawkes::Logger *       logger,
                                                  fawkes::Configuration *config,
-                                                 fawkes::Clock *clock)
-    : BridgeProcessor(prefix), logger_(logger), clock_(clock) {
-  config_ = config;
-  rosbridge_uri_ = config_->get_string("/webtools-bridge/rosbridge-uri");
+                                                 fawkes::Clock *        clock)
+: BridgeProcessor(prefix), logger_(logger), clock_(clock)
+{
+	config_        = config;
+	rosbridge_uri_ = config_->get_string("/webtools-bridge/rosbridge-uri");
 
-  rosbridge_endpoint_ = websocketpp::lib::make_shared<Client>();
-  rosbridge_endpoint_->clear_access_channels(websocketpp::log::alevel::all);
-  //    rosbridge_endpoint_->clear_error_channels(websocketpp::log::elevel::all);
-  rosbridge_endpoint_->init_asio();
-  rosbridge_endpoint_->set_reuse_addr(true);
-  rosbridge_endpoint_->start_perpetual();
+	rosbridge_endpoint_ = websocketpp::lib::make_shared<Client>();
+	rosbridge_endpoint_->clear_access_channels(websocketpp::log::alevel::all);
+	//    rosbridge_endpoint_->clear_error_channels(websocketpp::log::elevel::all);
+	rosbridge_endpoint_->init_asio();
+	rosbridge_endpoint_->set_reuse_addr(true);
+	rosbridge_endpoint_->start_perpetual();
 
-  mutex_ = new fawkes::Mutex();
+	mutex_ = new fawkes::Mutex();
 }
 
 /** Destructor */
-RosBridgeProxyProcessor::~RosBridgeProxyProcessor() {
-  if (!finalized_) {
-    finalize();
-  }
+RosBridgeProxyProcessor::~RosBridgeProxyProcessor()
+{
+	if (!finalized_) {
+		finalize();
+	}
 
-  rosbridge_endpoint_->stop_perpetual();
-  if (!rosbridge_endpoint_->stopped()) {
-    rosbridge_endpoint_->stop();
-    usleep(100000);
-    logger_->log_info("RosBridgeProxyProcessor", "Stopping Asio");
-  }
+	rosbridge_endpoint_->stop_perpetual();
+	if (!rosbridge_endpoint_->stopped()) {
+		rosbridge_endpoint_->stop();
+		usleep(100000);
+		logger_->log_info("RosBridgeProxyProcessor", "Stopping Asio");
+	}
 
-  if (proxy_thread_ != NULL)
-    proxy_thread_->join();
+	if (proxy_thread_ != NULL)
+		proxy_thread_->join();
 
-  delete mutex_;
-  rosbridge_endpoint_.reset();
+	delete mutex_;
+	rosbridge_endpoint_.reset();
 }
 
-void RosBridgeProxyProcessor::init() {
-  if (!initialized_) {
-    proxy_thread_ = websocketpp::lib::make_shared<websocketpp::lib::thread>(
-        &websocketpp::client<websocketpp::config::asio_client>::run,
-        rosbridge_endpoint_);
-    logger_->log_info("RosBridgeProxyProcessor", " Proxy Thread Started");
+void
+RosBridgeProxyProcessor::init()
+{
+	if (!initialized_) {
+		proxy_thread_ = websocketpp::lib::make_shared<websocketpp::lib::thread>(
+		  &websocketpp::client<websocketpp::config::asio_client>::run, rosbridge_endpoint_);
+		logger_->log_info("RosBridgeProxyProcessor", " Proxy Thread Started");
 
-    BridgeProcessor::init();
-  }
+		BridgeProcessor::init();
+	}
 }
 
-void RosBridgeProxyProcessor::
-    finalize() { // Assumes that all web_sessions were terminated by my
-                 // termination callbacks. Done while WebServer is finalizing.
+void
+RosBridgeProxyProcessor::finalize()
+{ // Assumes that all web_sessions were terminated by my
+	// termination callbacks. Done while WebServer is finalizing.
 
-  MutexLocker ml(mutex_);
-  if (!finalized_) {
-    return;
-  }
+	MutexLocker ml(mutex_);
+	if (!finalized_) {
+		return;
+	}
 
-  websocketpp::lib::error_code ec;
-  logger_->log_info("RosBridgeProxyProcessor:", " Finalizing");
+	websocketpp::lib::error_code ec;
+	logger_->log_info("RosBridgeProxyProcessor:", " Finalizing");
 
-  for (it_peers_ = peers_.begin(); it_peers_ != peers_.end(); it_peers_++) {
-    (*it_peers_)->unregister_web_session();
-    rosbridge_endpoint_->close((*it_peers_)->get_connection_hdl(),
-                               websocketpp::close::status::going_away, "", ec);
+	for (it_peers_ = peers_.begin(); it_peers_ != peers_.end(); it_peers_++) {
+		(*it_peers_)->unregister_web_session();
+		rosbridge_endpoint_->close((*it_peers_)->get_connection_hdl(),
+		                           websocketpp::close::status::going_away,
+		                           "",
+		                           ec);
 
-    if (ec) {
-      logger_->log_info("RosBridgeProxyProcessor",
-                        " Error closing connection : : %s",
-                        ec.message().c_str());
-    }
-  }
+		if (ec) {
+			logger_->log_info("RosBridgeProxyProcessor",
+			                  " Error closing connection : : %s",
+			                  ec.message().c_str());
+		}
+	}
 
-  while (!peers_.empty()) {
-    logger_->log_info("ProxyServer", "force deleting sessions");
-    (*peers_.begin())->unregister_web_session();
-    peers_.erase(peers_.begin());
-  }
+	while (!peers_.empty()) {
+		logger_->log_info("ProxyServer", "force deleting sessions");
+		(*peers_.begin())->unregister_web_session();
+		peers_.erase(peers_.begin());
+	}
 
-  BridgeProcessor::finalize();
+	BridgeProcessor::finalize();
 }
 
 /*to think about: What if this asiorun thread wants to terminate before the
@@ -162,117 +168,117 @@ to make sure the session was joined right!
  * @param web_session ptr that is established to the webtools server
  * @param hdl websocket connection_hdl used to identify this  proxy session
  */
-void RosBridgeProxyProcessor::on_open(std::shared_ptr<WebSession> web_session,
-                                      connection_hdl hdl) {
+void
+RosBridgeProxyProcessor::on_open(std::shared_ptr<WebSession> web_session, connection_hdl hdl)
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return;
+	}
 
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return;
-  }
+	std::shared_ptr<ProxySession> rosbridge_session = std::make_shared<ProxySession>();
 
-  std::shared_ptr<ProxySession> rosbridge_session =
-      std::make_shared<ProxySession>();
+	// Register the termination call_back to RosBridgeProxyProcessor::call_back
+	// and terminate from here
 
-  // Register the termination call_back to RosBridgeProxyProcessor::call_back
-  // and terminate from here
+	web_session->register_callback(EventType::TERMINATE,
+	                               shared_from_this()); // Still a big question
+	  // The call_back should find the corresponding  Proxy
+	  // and terminates it
 
-  web_session->register_callback(
-      EventType::TERMINATE,
-      shared_from_this()); // Still a big question
-                           // The call_back should find the corresponding  Proxy
-                           // and terminates it
+	rosbridge_session->set_status("open");
+	rosbridge_session->set_connection_hdl(hdl);
+	rosbridge_session->set_endpoint(rosbridge_endpoint_);
+	rosbridge_session->register_web_session(web_session);
 
-  rosbridge_session->set_status("open");
-  rosbridge_session->set_connection_hdl(hdl);
-  rosbridge_session->set_endpoint(rosbridge_endpoint_);
-  rosbridge_session->register_web_session(web_session);
+	Client::connection_ptr con = rosbridge_endpoint_->get_con_from_hdl(hdl);
+	// Add server statelater: m_server = con->get_response_header("Server");
+	con->set_message_handler(websocketpp::lib::bind(&ProxySession::on_message,
+	                                                rosbridge_session,
+	                                                websocketpp::lib::placeholders::_1,
+	                                                websocketpp::lib::placeholders::_2));
 
-  Client::connection_ptr con = rosbridge_endpoint_->get_con_from_hdl(hdl);
-  // Add server statelater: m_server = con->get_response_header("Server");
-  con->set_message_handler(websocketpp::lib::bind(
-      &ProxySession::on_message, rosbridge_session,
-      websocketpp::lib::placeholders::_1, websocketpp::lib::placeholders::_2));
-
-  peers_.push_back(rosbridge_session);
-  logger_->log_info("RosBridgeProxyProcessor",
-                    " new connection to rosbirdge established");
+	peers_.push_back(rosbridge_session);
+	logger_->log_info("RosBridgeProxyProcessor", " new connection to rosbirdge established");
 }
 
 /** Called on failure to establish a connection .
  * @param hdl websocket connection_hdl used to identify this session
  */
-void RosBridgeProxyProcessor::on_fail(connection_hdl hdl) {
-  MutexLocker ml(mutex_);
-  // Just say that the session failed..There is no session created at this point
-  // The time out should take care of that if failed..
+void
+RosBridgeProxyProcessor::on_fail(connection_hdl hdl)
+{
+	MutexLocker ml(mutex_);
+	// Just say that the session failed..There is no session created at this point
+	// The time out should take care of that if failed..
 }
 
 /** Called on closing of a connection .
  * @param hdl websocket connection_hdl used to identify this session
  */
-void RosBridgeProxyProcessor::on_close(connection_hdl hdl) {
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return;
-  }
+void
+RosBridgeProxyProcessor::on_close(connection_hdl hdl)
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return;
+	}
 
-  it_peers_ =
-      std::find_if(peers_.begin(), peers_.end(),
-                   [&](const std::shared_ptr<ProxySession> &v) {
-                     return v->get_connection_hdl().lock() == hdl.lock();
-                   });
+	it_peers_ =
+	  std::find_if(peers_.begin(), peers_.end(), [&](const std::shared_ptr<ProxySession> &v) {
+		  return v->get_connection_hdl().lock() == hdl.lock();
+	  });
 
-  if (it_peers_ != peers_.end()) {
-    (*it_peers_)->unregister_web_session();
-    (*it_peers_)->set_status("closed");
+	if (it_peers_ != peers_.end()) {
+		(*it_peers_)->unregister_web_session();
+		(*it_peers_)->set_status("closed");
 
-    //( *it_peers_ ) -> terminate();
-    peers_.erase(it_peers_);
-    logger_->log_info("RosBridgeProxyProcessor", " proxy session deleted");
-  }
+		//( *it_peers_ ) -> terminate();
+		peers_.erase(it_peers_);
+		logger_->log_info("RosBridgeProxyProcessor", " proxy session deleted");
+	}
 }
 
 /** Establish a connection to rosbridge.
  * @param web_session ptr
  */
 // should only be called from within a Mutex
-void RosBridgeProxyProcessor::connect_to_rosbridge(
-    std::shared_ptr<WebSession> web_session) {
-  // MutexLocker ml(mutex_); will only be called from a mutexed_ threadh
-  // Is there an existing proxy_session for this web_session
-  it_peers_ =
-      std::find_if(peers_.begin(), peers_.end(),
-                   [&](const std::shared_ptr<ProxySession> &v) {
-                     return v->get_web_session().get() == web_session.get();
-                   });
+void
+RosBridgeProxyProcessor::connect_to_rosbridge(std::shared_ptr<WebSession> web_session)
+{
+	// MutexLocker ml(mutex_); will only be called from a mutexed_ threadh
+	// Is there an existing proxy_session for this web_session
+	it_peers_ =
+	  std::find_if(peers_.begin(), peers_.end(), [&](const std::shared_ptr<ProxySession> &v) {
+		  return v->get_web_session().get() == web_session.get();
+	  });
 
-  if (it_peers_ == peers_.end()) {
-    // create a proxy_session to act as a client to the "Ros Bridge Server".
+	if (it_peers_ == peers_.end()) {
+		// create a proxy_session to act as a client to the "Ros Bridge Server".
 
-    websocketpp::lib::error_code ec;
+		websocketpp::lib::error_code ec;
 
-    websocketpp::client<websocketpp::config::asio_client>::connection_ptr con;
-    con = rosbridge_endpoint_->get_connection(rosbridge_uri_, ec);
-    if (ec) {
-      logger_->log_info("RosBridgeProxyProcessor",
-                        " Connect initialization error: %s",
-                        ec.message().c_str());
-      return;
-      // throw
-    }
+		websocketpp::client<websocketpp::config::asio_client>::connection_ptr con;
+		con = rosbridge_endpoint_->get_connection(rosbridge_uri_, ec);
+		if (ec) {
+			logger_->log_info("RosBridgeProxyProcessor",
+			                  " Connect initialization error: %s",
+			                  ec.message().c_str());
+			return;
+			// throw
+		}
 
-    con->set_open_handler(websocketpp::lib::bind(
-        &RosBridgeProxyProcessor::on_open, this, web_session,
-        websocketpp::lib::placeholders::_1));
-    con->set_close_handler(
-        websocketpp::lib::bind(&RosBridgeProxyProcessor::on_close, this,
-                               websocketpp::lib::placeholders::_1));
-    con->set_fail_handler(
-        websocketpp::lib::bind(&RosBridgeProxyProcessor::on_fail, this,
-                               websocketpp::lib::placeholders::_1));
+		con->set_open_handler(websocketpp::lib::bind(
+		  &RosBridgeProxyProcessor::on_open, this, web_session, websocketpp::lib::placeholders::_1));
+		con->set_close_handler(websocketpp::lib::bind(&RosBridgeProxyProcessor::on_close,
+		                                              this,
+		                                              websocketpp::lib::placeholders::_1));
+		con->set_fail_handler(websocketpp::lib::bind(&RosBridgeProxyProcessor::on_fail,
+		                                             this,
+		                                             websocketpp::lib::placeholders::_1));
 
-    rosbridge_endpoint_->connect(con);
-  }
+		rosbridge_endpoint_->connect(con);
+	}
 }
 
 /** Forward the incoming request comming from the web_session to RosBridge using
@@ -281,205 +287,209 @@ void RosBridgeProxyProcessor::connect_to_rosbridge(
  * @param web_session
  * @param jsonMsg
  */
-void RosBridgeProxyProcessor::process_request(
-    std::shared_ptr<WebSession> web_session, std::string jsonMsg) {
+void
+RosBridgeProxyProcessor::process_request(std::shared_ptr<WebSession> web_session,
+                                         std::string                 jsonMsg)
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return;
+	}
 
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return;
-  }
+	const int time_out = 300; // time out in ms. TODO: Move to config
+	it_peers_ =
+	  std::find_if(peers_.begin(), peers_.end(), [&](const std::shared_ptr<ProxySession> &v) {
+		  return v->get_web_session().get() == web_session.get();
+	  });
 
-  const int time_out = 300; // time out in ms. TODO: Move to config
-  it_peers_ =
-      std::find_if(peers_.begin(), peers_.end(),
-                   [&](const std::shared_ptr<ProxySession> &v) {
-                     return v->get_web_session().get() == web_session.get();
-                   });
+	if (it_peers_ == peers_.end()) {
+		connect_to_rosbridge(web_session);
 
-  if (it_peers_ == peers_.end()) {
-    connect_to_rosbridge(web_session);
+		fawkes::Time now(clock_);
+		fawkes::Time time_out_start(clock_);
+		bool         time_out_reached = false;
 
-    fawkes::Time now(clock_);
-    fawkes::Time time_out_start(clock_);
-    bool time_out_reached = false;
+		do { // Give the connections thread time to try to connect
 
-    do { // Give the connections thread time to try to connect
+			ml.unlock();
+			usleep(10000);
+			MutexLocker ml(mutex_);
+			logger_->log_warn("RosBridgeProxyProcessor", " trying to connect to RosBridge");
 
-      ml.unlock();
-      usleep(10000);
-      MutexLocker ml(mutex_);
-      logger_->log_warn("RosBridgeProxyProcessor",
-                        " trying to connect to RosBridge");
+			if (finalized_) {
+				logger_->log_warn("RosBridgeProxyProcessor", " ProxyServer down while connecting");
+				return;
+			}
 
-      if (finalized_) {
-        logger_->log_warn("RosBridgeProxyProcessor",
-                          " ProxyServer down while connecting");
-        return;
-      }
+			it_peers_ =
+			  std::find_if(peers_.begin(), peers_.end(), [&](const std::shared_ptr<ProxySession> &v) {
+				  return v->get_web_session().get() == web_session.get();
+			  });
 
-      it_peers_ =
-          std::find_if(peers_.begin(), peers_.end(),
-                       [&](const std::shared_ptr<ProxySession> &v) {
-                         return v->get_web_session().get() == web_session.get();
-                       });
+			now.stamp();
+			time_out_reached = ((now.in_msec() - time_out_start.in_msec()) >= time_out);
 
-      now.stamp();
-      time_out_reached =
-          ((now.in_msec() - time_out_start.in_msec()) >= time_out);
+		} while (it_peers_ == peers_.end() && !time_out_reached);
 
-    } while (it_peers_ == peers_.end() && !time_out_reached);
+		if (time_out_reached) {
+			logger_->log_warn("RosBridgeProxyProcessor",
+			                  " could not connect to RosBridge. Connection timed out!");
+			return;
+		}
+	}
 
-    if (time_out_reached) {
-      logger_->log_warn(
-          "RosBridgeProxyProcessor",
-          " could not connect to RosBridge. Connection timed out!");
-      return;
-    }
-  }
+	if (it_peers_ != peers_.end()) {
+		if ((*it_peers_)->get_status() != "open") {
+			logger_->log_warn("RosBridgeProxyProcessor", " connected but session is unknown state");
+			return;
+		}
 
-  if (it_peers_ != peers_.end()) {
-    if ((*it_peers_)->get_status() != "open") {
-      logger_->log_warn("RosBridgeProxyProcessor",
-                        " connected but session is unknown state");
-      return;
-    }
-
-    (*it_peers_)->send(jsonMsg);
-  } else {
-    // should never happen..just log it
-    logger_->log_warn("RosBridgeProxyProcessor",
-                      " connected but session is not found!!");
-  }
+		(*it_peers_)->send(jsonMsg);
+	} else {
+		// should never happen..just log it
+		logger_->log_warn("RosBridgeProxyProcessor", " connected but session is not found!!");
+	}
 }
 
-void RosBridgeProxyProcessor::callback(
-    EventType event_type, std::shared_ptr<EventEmitter> event_emitter) {
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return;
-  }
+void
+RosBridgeProxyProcessor::callback(EventType event_type, std::shared_ptr<EventEmitter> event_emitter)
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return;
+	}
 
-  try {
-    // check if the event emitter was a session
-    std::shared_ptr<WebSession> web_session;
-    web_session = std::dynamic_pointer_cast<WebSession>(event_emitter);
-    if (web_session != NULL) {
-      if (event_type == EventType::TERMINATE) {
-        it_peers_ = std::find_if(peers_.begin(), peers_.end(),
-                                 [&](const std::shared_ptr<ProxySession> &v) {
-                                   return v->get_web_session().get() ==
-                                          web_session.get();
-                                 });
+	try {
+		// check if the event emitter was a session
+		std::shared_ptr<WebSession> web_session;
+		web_session = std::dynamic_pointer_cast<WebSession>(event_emitter);
+		if (web_session != NULL) {
+			if (event_type == EventType::TERMINATE) {
+				it_peers_ =
+				  std::find_if(peers_.begin(), peers_.end(), [&](const std::shared_ptr<ProxySession> &v) {
+					  return v->get_web_session().get() == web_session.get();
+				  });
 
-        if (it_peers_ != peers_.end()) {
-          // std::cout<< "removing web_peer session" << std::endl;
-          (*it_peers_)->unregister_web_session();
+				if (it_peers_ != peers_.end()) {
+					// std::cout<< "removing web_peer session" << std::endl;
+					(*it_peers_)->unregister_web_session();
 
-          websocketpp::lib::error_code ec;
-          rosbridge_endpoint_->close((*it_peers_)->get_connection_hdl(),
-                                     websocketpp::close::status::going_away, "",
-                                     ec);
+					websocketpp::lib::error_code ec;
+					rosbridge_endpoint_->close((*it_peers_)->get_connection_hdl(),
+					                           websocketpp::close::status::going_away,
+					                           "",
+					                           ec);
 
-          if (ec) {
-            logger_->log_info("RosBridgeProxyProcessor",
-                              " Error closing connection : : %s",
-                              ec.message().c_str());
-          }
-        }
-      }
-    }
-  } catch (Exception &e) {
-    // if exception was fired it only means that the casting failed becasue the
-    // emitter is not a session
-  }
+					if (ec) {
+						logger_->log_info("RosBridgeProxyProcessor",
+						                  " Error closing connection : : %s",
+						                  ec.message().c_str());
+					}
+				}
+			}
+		}
+	} catch (Exception &e) {
+		// if exception was fired it only means that the casting failed becasue the
+		// emitter is not a session
+	}
 }
 
-std::shared_ptr<Subscription> RosBridgeProxyProcessor::subscribe(
-    std::string topic_name, std::string id, std::string type,
-    std::string compression, unsigned int throttle_rate,
-    unsigned int queue_length, unsigned int fragment_size,
-    std::shared_ptr<WebSession> web_session) {
-  std::string jsonMsg =
-      Serializer::op_subscribe(topic_name, id, type, compression, throttle_rate,
-                               queue_length, fragment_size);
-  // try catch
-  process_request(web_session, jsonMsg);
+std::shared_ptr<Subscription>
+RosBridgeProxyProcessor::subscribe(std::string                 topic_name,
+                                   std::string                 id,
+                                   std::string                 type,
+                                   std::string                 compression,
+                                   unsigned int                throttle_rate,
+                                   unsigned int                queue_length,
+                                   unsigned int                fragment_size,
+                                   std::shared_ptr<WebSession> web_session)
+{
+	std::string jsonMsg = Serializer::op_subscribe(
+	  topic_name, id, type, compression, throttle_rate, queue_length, fragment_size);
+	// try catch
+	process_request(web_session, jsonMsg);
 
-  // create a DORMANT  Subscribtion instace (to keep consistancy with other
-  // Bridge_processors)
-  std::shared_ptr<Subscription> new_subscirption;
-  try {
-    new_subscirption =
-        std::make_shared<Subscription>(topic_name, prefix_, logger_, clock_);
-  } catch (fawkes::Exception &e) {
-    logger_->log_info(
-        "Processor:", "Failed to subscribe to '%s': queue_length%s\n",
-        topic_name.c_str(), e.what());
-    throw e;
-  }
+	// create a DORMANT  Subscribtion instace (to keep consistancy with other
+	// Bridge_processors)
+	std::shared_ptr<Subscription> new_subscirption;
+	try {
+		new_subscirption = std::make_shared<Subscription>(topic_name, prefix_, logger_, clock_);
+	} catch (fawkes::Exception &e) {
+		logger_->log_info(
+		  "Processor:", "Failed to subscribe to '%s': queue_length%s\n", topic_name.c_str(), e.what());
+		throw e;
+	}
 
-  new_subscirption->add_request(id, compression, throttle_rate, queue_length,
-                                fragment_size, web_session);
+	new_subscirption->add_request(
+	  id, compression, throttle_rate, queue_length, fragment_size, web_session);
 
-  return new_subscirption;
+	return new_subscirption;
 }
 
-void RosBridgeProxyProcessor::unsubscribe(
-    std::string id, std::shared_ptr<Subscription> subscription,
-    std::shared_ptr<WebSession> web_session) {
-  std::string jsonMsg =
-      Serializer::op_unsubscribe(subscription->get_topic_name(), id);
-  // try catch
-  logger_->log_info("Processor:", "%s", jsonMsg.c_str());
-  process_request(web_session, jsonMsg);
-  subscription->remove_request(id, web_session);
+void
+RosBridgeProxyProcessor::unsubscribe(std::string                   id,
+                                     std::shared_ptr<Subscription> subscription,
+                                     std::shared_ptr<WebSession>   web_session)
+{
+	std::string jsonMsg = Serializer::op_unsubscribe(subscription->get_topic_name(), id);
+	// try catch
+	logger_->log_info("Processor:", "%s", jsonMsg.c_str());
+	process_request(web_session, jsonMsg);
+	subscription->remove_request(id, web_session);
 }
 
 std::shared_ptr<Advertisment>
-RosBridgeProxyProcessor::advertise(std::string topic_name, std::string id,
-                                   std::string type,
-                                   std::shared_ptr<WebSession> web_session) {
-  std::string jsonMsg = Serializer::op_advertise(topic_name, id, type);
-  // try catch
-  process_request(web_session, jsonMsg);
+RosBridgeProxyProcessor::advertise(std::string                 topic_name,
+                                   std::string                 id,
+                                   std::string                 type,
+                                   std::shared_ptr<WebSession> web_session)
+{
+	std::string jsonMsg = Serializer::op_advertise(topic_name, id, type);
+	// try catch
+	process_request(web_session, jsonMsg);
 
-  // create a DORMANT  Subscribtion instace (to keep consistancy with other
-  // Bridge_processors)
-  std::shared_ptr<Advertisment> new_advertisment;
-  try {
-    new_advertisment = std::make_shared<Advertisment>(topic_name, prefix_);
-  } catch (fawkes::Exception &e) {
-    logger_->log_error("Processor:", "Failed to advertise to '%s': %s",
-                       topic_name.c_str(), e.what());
-    throw e;
-  }
+	// create a DORMANT  Subscribtion instace (to keep consistancy with other
+	// Bridge_processors)
+	std::shared_ptr<Advertisment> new_advertisment;
+	try {
+		new_advertisment = std::make_shared<Advertisment>(topic_name, prefix_);
+	} catch (fawkes::Exception &e) {
+		logger_->log_error(
+		  "Processor:", "Failed to advertise to '%s': %s", topic_name.c_str(), e.what());
+		throw e;
+	}
 
-  new_advertisment->add_request(id, web_session);
+	new_advertisment->add_request(id, web_session);
 
-  return new_advertisment;
+	return new_advertisment;
 }
 
-void RosBridgeProxyProcessor::unadvertise(
-    std::string id, std::shared_ptr<Advertisment> advertisment,
-    std::shared_ptr<WebSession> web_session) {
-  std::string jsonMsg =
-      Serializer::op_unadvertise(advertisment->get_topic_name(), id);
-  process_request(web_session, jsonMsg);
-  advertisment->remove_request(id, web_session);
+void
+RosBridgeProxyProcessor::unadvertise(std::string                   id,
+                                     std::shared_ptr<Advertisment> advertisment,
+                                     std::shared_ptr<WebSession>   web_session)
+{
+	std::string jsonMsg = Serializer::op_unadvertise(advertisment->get_topic_name(), id);
+	process_request(web_session, jsonMsg);
+	advertisment->remove_request(id, web_session);
 }
 
-void RosBridgeProxyProcessor::publish(
-    std::string id, bool latch, std::string msg_in_json,
-    std::shared_ptr<Advertisment> advertisment,
-    std::shared_ptr<WebSession> web_session) {
-  std::string jsonMsg = Serializer::op_publish(advertisment->get_topic_name(),
-                                               id, latch, msg_in_json);
-  process_request(web_session, jsonMsg);
+void
+RosBridgeProxyProcessor::publish(std::string                   id,
+                                 bool                          latch,
+                                 std::string                   msg_in_json,
+                                 std::shared_ptr<Advertisment> advertisment,
+                                 std::shared_ptr<WebSession>   web_session)
+{
+	std::string jsonMsg =
+	  Serializer::op_publish(advertisment->get_topic_name(), id, latch, msg_in_json);
+	process_request(web_session, jsonMsg);
 }
 
-void RosBridgeProxyProcessor::call_service(
-    std::string srv_call_json, std::shared_ptr<WebSession> web_session) {
-  logger_->log_info(
-      "Processor:", "calling service'%s':", srv_call_json.c_str());
-  process_request(web_session, srv_call_json);
+void
+RosBridgeProxyProcessor::call_service(std::string                 srv_call_json,
+                                      std::shared_ptr<WebSession> web_session)
+{
+	logger_->log_info("Processor:", "calling service'%s':", srv_call_json.c_str());
+	process_request(web_session, srv_call_json);
 }

--- a/src/plugins/webtools-bridge/rosbridge_proxy_processor.h
+++ b/src/plugins/webtools-bridge/rosbridge_proxy_processor.h
@@ -26,18 +26,17 @@
 
 #include "advertisment_capability.h"
 #include "bridge_processor.h"
+#include "callable.h"
 #include "service_capability.h"
 #include "subscription_capability.h"
 
-#include "callable.h"
-
 // TODO:move includes to cpp and use from namespace
+#include <logging/logger.h>
+
 #include <websocketpp/client.hpp>
 #include <websocketpp/common/memory.hpp>
 #include <websocketpp/common/thread.hpp>
 #include <websocketpp/config/asio_no_tls_client.hpp>
-
-#include <logging/logger.h>
 
 namespace fawkes {
 class Clock;
@@ -60,74 +59,79 @@ class WebSession;
 class ProxySession;
 class EventEmitter;
 
-class RosBridgeProxyProcessor
-    : public BridgeProcessor,
-      public SubscriptionCapability,
-      public AdvertismentCapability,
-      public ServiceCapability,
-      public Callable,
-      public std::enable_shared_from_this<RosBridgeProxyProcessor> {
+class RosBridgeProxyProcessor : public BridgeProcessor,
+                                public SubscriptionCapability,
+                                public AdvertismentCapability,
+                                public ServiceCapability,
+                                public Callable,
+                                public std::enable_shared_from_this<RosBridgeProxyProcessor>
+{
 public:
-  RosBridgeProxyProcessor(std::string prefix, fawkes::Logger *logger,
-                          fawkes::Configuration *config, fawkes::Clock *clock);
+	RosBridgeProxyProcessor(std::string            prefix,
+	                        fawkes::Logger *       logger,
+	                        fawkes::Configuration *config,
+	                        fawkes::Clock *        clock);
 
-  virtual ~RosBridgeProxyProcessor();
+	virtual ~RosBridgeProxyProcessor();
 
-  void init();
-  void finalize();
+	void init();
+	void finalize();
 
-  void on_open(std::shared_ptr<WebSession> web_session, connection_hdl hdl);
-  void on_fail(connection_hdl hdl);
-  void on_close(connection_hdl hdl);
+	void on_open(std::shared_ptr<WebSession> web_session, connection_hdl hdl);
+	void on_fail(connection_hdl hdl);
+	void on_close(connection_hdl hdl);
 
-  std::shared_ptr<Subscription>
-  subscribe(std::string topic_name, std::string id, std::string type,
-            std::string compression, unsigned int throttle_rate,
-            unsigned int queue_length, unsigned int fragment_size,
-            std::shared_ptr<WebSession> session);
+	std::shared_ptr<Subscription> subscribe(std::string                 topic_name,
+	                                        std::string                 id,
+	                                        std::string                 type,
+	                                        std::string                 compression,
+	                                        unsigned int                throttle_rate,
+	                                        unsigned int                queue_length,
+	                                        unsigned int                fragment_size,
+	                                        std::shared_ptr<WebSession> session);
 
-  void unsubscribe(std::string id, std::shared_ptr<Subscription> subscription,
-                   std::shared_ptr<WebSession> session);
+	void unsubscribe(std::string                   id,
+	                 std::shared_ptr<Subscription> subscription,
+	                 std::shared_ptr<WebSession>   session);
 
-  std::shared_ptr<Advertisment> advertise(std::string topic_name,
-                                          std::string id, std::string type,
-                                          std::shared_ptr<WebSession> session);
+	std::shared_ptr<Advertisment> advertise(std::string                 topic_name,
+	                                        std::string                 id,
+	                                        std::string                 type,
+	                                        std::shared_ptr<WebSession> session);
 
-  void unadvertise(std::string id, std::shared_ptr<Advertisment> advertisment,
-                   std::shared_ptr<WebSession> session);
+	void unadvertise(std::string                   id,
+	                 std::shared_ptr<Advertisment> advertisment,
+	                 std::shared_ptr<WebSession>   session);
 
-  void
-  publish(std::string id, bool latch,
-          std::string msg_in_json // TODO:: figure out a clever way to keep
-                                  // track of msgs types and content without
-                                  // the need to have the info before hands
-          ,
-          std::shared_ptr<Advertisment> advertisment,
-          std::shared_ptr<WebSession> session);
+	void publish(std::string id,
+	             bool        latch,
+	             std::string msg_in_json // TODO:: figure out a clever way to keep
+	                                     // track of msgs types and content without
+	                                     // the need to have the info before hands
+	             ,
+	             std::shared_ptr<Advertisment> advertisment,
+	             std::shared_ptr<WebSession>   session);
 
-  void call_service(std::string srv_call_json,
-                    std::shared_ptr<WebSession> session);
+	void call_service(std::string srv_call_json, std::shared_ptr<WebSession> session);
 
-  void callback(EventType event_type, std::shared_ptr<EventEmitter> handler);
+	void callback(EventType event_type, std::shared_ptr<EventEmitter> handler);
 
-  void process_request(std::shared_ptr<WebSession> session,
-                       std::string message);
-  void connect_to_rosbridge(std::shared_ptr<WebSession> session);
+	void process_request(std::shared_ptr<WebSession> session, std::string message);
+	void connect_to_rosbridge(std::shared_ptr<WebSession> session);
 
 private:
-  std::string rosbridge_uri_;
+	std::string rosbridge_uri_;
 
-  fawkes::Logger *logger_;
-  fawkes::Configuration *config_;
-  fawkes::Clock *clock_;
-  fawkes::Mutex *mutex_;
+	fawkes::Logger *       logger_;
+	fawkes::Configuration *config_;
+	fawkes::Clock *        clock_;
+	fawkes::Mutex *        mutex_;
 
-  std::list<std::shared_ptr<ProxySession>> peers_;
-  std::list<std::shared_ptr<ProxySession>>::iterator it_peers_;
+	std::list<std::shared_ptr<ProxySession>>           peers_;
+	std::list<std::shared_ptr<ProxySession>>::iterator it_peers_;
 
-  std::shared_ptr<websocketpp::client<websocketpp::config::asio_client>>
-      rosbridge_endpoint_;
-  std::shared_ptr<websocketpp::lib::thread> proxy_thread_;
+	std::shared_ptr<websocketpp::client<websocketpp::config::asio_client>> rosbridge_endpoint_;
+	std::shared_ptr<websocketpp::lib::thread>                              proxy_thread_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/serializer.cpp
+++ b/src/plugins/webtools-bridge/serializer.cpp
@@ -54,52 +54,54 @@ using namespace rapidjson;
  * @param fragment_size provided in the JSON message of the rosbridge protocol
  * @return serialized json string corresponding to rosbridge protocol message
  */
-std::string Serializer::op_subscribe(std::string prefixed_topic_name,
-                                     std::string id, std::string type,
-                                     std::string compression,
-                                     unsigned int throttle_rate,
-                                     unsigned int queue_length,
-                                     unsigned int fragment_size) {
-  std::string op = "subscribe";
+std::string
+Serializer::op_subscribe(std::string  prefixed_topic_name,
+                         std::string  id,
+                         std::string  type,
+                         std::string  compression,
+                         unsigned int throttle_rate,
+                         unsigned int queue_length,
+                         unsigned int fragment_size)
+{
+	std::string op = "subscribe";
 
-  StringBuffer s;
-  Writer<StringBuffer> writer(s);
-  writer.StartObject();
+	StringBuffer         s;
+	Writer<StringBuffer> writer(s);
+	writer.StartObject();
 
-  writer.String("op");
-  writer.String(op.c_str(), (SizeType)op.length());
+	writer.String("op");
+	writer.String(op.c_str(), (SizeType)op.length());
 
-  writer.String("id");
-  writer.String(id.c_str(), (SizeType)id.length());
+	writer.String("id");
+	writer.String(id.c_str(), (SizeType)id.length());
 
-  writer.String("type");
-  writer.String(type.c_str(), (SizeType)type.length());
+	writer.String("type");
+	writer.String(type.c_str(), (SizeType)type.length());
 
-  writer.String("topic");
-  writer.String(prefixed_topic_name.c_str(),
-                (SizeType)prefixed_topic_name.length());
+	writer.String("topic");
+	writer.String(prefixed_topic_name.c_str(), (SizeType)prefixed_topic_name.length());
 
-  writer.String("throttle_rate");
-  writer.Uint(throttle_rate);
+	writer.String("throttle_rate");
+	writer.Uint(throttle_rate);
 
-  writer.String("queue_length");
-  if (queue_length < 1)
-    queue_length = 1;
-  writer.Uint(queue_length);
+	writer.String("queue_length");
+	if (queue_length < 1)
+		queue_length = 1;
+	writer.Uint(queue_length);
 
-  if (fragment_size != 0) {
-    writer.String("fragment_size");
-    writer.Uint(fragment_size);
-  }
+	if (fragment_size != 0) {
+		writer.String("fragment_size");
+		writer.Uint(fragment_size);
+	}
 
-  writer.String("compression");
-  writer.String(compression.c_str(), (SizeType)compression.length());
+	writer.String("compression");
+	writer.String(compression.c_str(), (SizeType)compression.length());
 
-  writer.EndObject(); // End of complete Json_msg
+	writer.EndObject(); // End of complete Json_msg
 
-  ////std::cout << s.GetString() << std::endl;
+	////std::cout << s.GetString() << std::endl;
 
-  return s.GetString();
+	return s.GetString();
 }
 
 /** Create an unsubscribe message
@@ -115,29 +117,29 @@ std::string Serializer::op_subscribe(std::string prefixed_topic_name,
  * @param id
  * @return serialized json string corresponding to rosbridge protocol message
  */
-std::string Serializer::op_unsubscribe(std::string prefixed_topic_name,
-                                       std::string id) {
-  std::string op = "unsubscribe";
+std::string
+Serializer::op_unsubscribe(std::string prefixed_topic_name, std::string id)
+{
+	std::string op = "unsubscribe";
 
-  StringBuffer s;
-  Writer<StringBuffer> writer(s);
-  writer.StartObject();
+	StringBuffer         s;
+	Writer<StringBuffer> writer(s);
+	writer.StartObject();
 
-  writer.String("op");
-  writer.String(op.c_str(), (SizeType)op.length());
+	writer.String("op");
+	writer.String(op.c_str(), (SizeType)op.length());
 
-  writer.String("id");
-  writer.String(id.c_str(), (SizeType)id.length());
+	writer.String("id");
+	writer.String(id.c_str(), (SizeType)id.length());
 
-  writer.String("topic");
-  writer.String(prefixed_topic_name.c_str(),
-                (SizeType)prefixed_topic_name.length());
+	writer.String("topic");
+	writer.String(prefixed_topic_name.c_str(), (SizeType)prefixed_topic_name.length());
 
-  writer.EndObject(); // End of complete Json_msg
+	writer.EndObject(); // End of complete Json_msg
 
-  ////std::cout << s.GetString() << std::endl;
+	////std::cout << s.GetString() << std::endl;
 
-  return s.GetString();
+	return s.GetString();
 }
 
 /** Create an advertise message
@@ -155,38 +157,38 @@ std::string Serializer::op_unsubscribe(std::string prefixed_topic_name,
  * @param type  specified in the  JSON message
  * @return serialized json string corresponding to rosbridge protocol message
  */
-std::string Serializer::op_advertise(std::string prefixed_topic_name,
-                                     std::string id, std::string type) {
-  std::string op = "advertise";
+std::string
+Serializer::op_advertise(std::string prefixed_topic_name, std::string id, std::string type)
+{
+	std::string op = "advertise";
 
-  StringBuffer s;
-  Writer<StringBuffer> writer(s);
-  writer.StartObject();
+	StringBuffer         s;
+	Writer<StringBuffer> writer(s);
+	writer.StartObject();
 
-  writer.String("op");
-  writer.String(op.c_str(), (SizeType)op.length());
+	writer.String("op");
+	writer.String(op.c_str(), (SizeType)op.length());
 
-  writer.String("id");
-  writer.String(id.c_str(), (SizeType)id.length());
+	writer.String("id");
+	writer.String(id.c_str(), (SizeType)id.length());
 
-  writer.String("topic");
-  writer.String(prefixed_topic_name.c_str(),
-                (SizeType)prefixed_topic_name.length());
+	writer.String("topic");
+	writer.String(prefixed_topic_name.c_str(), (SizeType)prefixed_topic_name.length());
 
-  writer.String("type");
-  writer.String(type.c_str(), (SizeType)type.length());
+	writer.String("type");
+	writer.String(type.c_str(), (SizeType)type.length());
 
-  writer.String("latch");
-  writer.Bool(false);
+	writer.String("latch");
+	writer.Bool(false);
 
-  writer.String("queue_size");
-  writer.Int(100);
+	writer.String("queue_size");
+	writer.Int(100);
 
-  writer.EndObject(); // End of complete Json_msg
+	writer.EndObject(); // End of complete Json_msg
 
-  ////std::cout << s.GetString() << std::endl;
+	////std::cout << s.GetString() << std::endl;
 
-  return s.GetString();
+	return s.GetString();
 }
 
 /** Create an unadvertise message
@@ -202,29 +204,29 @@ std::string Serializer::op_advertise(std::string prefixed_topic_name,
  * @param id
  * @return serialized json string corresponding to rosbridge protocol message
  */
-std::string Serializer::op_unadvertise(std::string prefixed_topic_name,
-                                       std::string id) {
-  std::string op = "unadvertise";
+std::string
+Serializer::op_unadvertise(std::string prefixed_topic_name, std::string id)
+{
+	std::string op = "unadvertise";
 
-  StringBuffer s;
-  Writer<StringBuffer> writer(s);
-  writer.StartObject();
+	StringBuffer         s;
+	Writer<StringBuffer> writer(s);
+	writer.StartObject();
 
-  writer.String("op");
-  writer.String(op.c_str(), (SizeType)op.length());
+	writer.String("op");
+	writer.String(op.c_str(), (SizeType)op.length());
 
-  writer.String("id");
-  writer.String(id.c_str(), (SizeType)id.length());
+	writer.String("id");
+	writer.String(id.c_str(), (SizeType)id.length());
 
-  writer.String("topic");
-  writer.String(prefixed_topic_name.c_str(),
-                (SizeType)prefixed_topic_name.length());
+	writer.String("topic");
+	writer.String(prefixed_topic_name.c_str(), (SizeType)prefixed_topic_name.length());
 
-  writer.EndObject(); // End of complete Json_msg
+	writer.EndObject(); // End of complete Json_msg
 
-  ////std::cout << s.GetString() << std::endl;
+	////std::cout << s.GetString() << std::endl;
 
-  return s.GetString();
+	return s.GetString();
 }
 
 /** Create an publish message
@@ -243,44 +245,46 @@ std::string Serializer::op_unadvertise(std::string prefixed_topic_name,
  * @param msg_in_json The topic data in JSON
  * @return serialized json string corresponding to rosbridge protocol message
  */
-std::string Serializer::op_publish(std::string prefixed_topic_name,
-                                   std::string id, bool latch,
-                                   std::string msg_in_json) {
-  std::string op = "publish";
+std::string
+Serializer::op_publish(std::string prefixed_topic_name,
+                       std::string id,
+                       bool        latch,
+                       std::string msg_in_json)
+{
+	std::string op = "publish";
 
-  StringBuffer s;
-  Writer<StringBuffer> writer(s);
-  writer.StartObject();
+	StringBuffer         s;
+	Writer<StringBuffer> writer(s);
+	writer.StartObject();
 
-  writer.String("op");
-  writer.String(op.c_str(), (SizeType)op.length());
+	writer.String("op");
+	writer.String(op.c_str(), (SizeType)op.length());
 
-  writer.String("id");
-  writer.String(id.c_str(), (SizeType)id.length());
+	writer.String("id");
+	writer.String(id.c_str(), (SizeType)id.length());
 
-  writer.String("topic");
-  writer.String(prefixed_topic_name.c_str(),
-                (SizeType)prefixed_topic_name.length());
+	writer.String("topic");
+	writer.String(prefixed_topic_name.c_str(), (SizeType)prefixed_topic_name.length());
 
-  writer.String("latch");
-  writer.Bool(latch);
+	writer.String("latch");
+	writer.Bool(latch);
 
-  writer.String("msg");
-  Document d;
+	writer.String("msg");
+	Document d;
 
-  if (d.Parse(msg_in_json.c_str()).HasParseError()) {
-    ////std::cout<< GetParseError_En(d.GetParseError());
-    return "";
-    // throw
-  }
-  d.Parse(msg_in_json.c_str());
-  d.Accept(writer);
+	if (d.Parse(msg_in_json.c_str()).HasParseError()) {
+		////std::cout<< GetParseError_En(d.GetParseError());
+		return "";
+		// throw
+	}
+	d.Parse(msg_in_json.c_str());
+	d.Accept(writer);
 
-  writer.EndObject(); // End of complete Json_msg
+	writer.EndObject(); // End of complete Json_msg
 
-  ////std::cout << s.GetString() << std::endl;
+	////std::cout << s.GetString() << std::endl;
 
-  return s.GetString();
+	return s.GetString();
 }
 
 // Serialier::append_json(	Writer<StringBuffer> &writer, std::string
@@ -302,66 +306,57 @@ std::string Serializer::op_publish(std::string prefixed_topic_name,
  * @param fact clips fact to serialize
  * @return serialized json string corresponding to rosbridge protocol message
  */
-std::string Serializer::serialize(CLIPS::Fact::pointer fact) {
+std::string
+Serializer::serialize(CLIPS::Fact::pointer fact)
+{
+	StringBuffer         s;
+	Writer<StringBuffer> writer(s);
+	writer.StartObject();
 
-  StringBuffer s;
-  Writer<StringBuffer> writer(s);
-  writer.StartObject();
+	std::string name = fact->get_template()->name();
+	writer.String("name"); // key for fact_name
+	writer.String(name.c_str(), (SizeType)name.length());
 
-  std::string name = fact->get_template()->name();
-  writer.String("name"); // key for fact_name
-  writer.String(name.c_str(), (SizeType)name.length());
+	std::vector<std::string> slot_names = fact->slot_names();
+	if (slot_names.size() > 0) // is it a non-ordered fact
+	{
+		for (std::vector<std::string>::iterator it = slot_names.begin();
+		     slot_names.size() > 0 && it != slot_names.end();
+		     it++) {
+			writer.String(it->c_str(),
+			              (SizeType)it->length()); // write slot name as a key for JOSN pair
 
-  std::vector<std::string> slot_names = fact->slot_names();
-  if (slot_names.size() > 0) // is it a non-ordered fact
-  {
-    for (std::vector<std::string>::iterator it = slot_names.begin();
-         slot_names.size() > 0 && it != slot_names.end(); it++) {
-      writer.String(
-          it->c_str(),
-          (SizeType)it->length()); // write slot name as a key for JOSN pair
+			CLIPS::Values values     = fact->slot_value(*it);
+			bool          multifield = values.size() > 0;
+			if (multifield)
+				writer.StartArray(); // write values of slot as a json array only if
+				                     // slot is multi field
+			for (CLIPS::Values::iterator it2 = values.begin(); it2 != values.end(); it2++) {
+				switch (it2->type()) {
+				case CLIPS::TYPE_INTEGER: writer.Int(it2->as_integer());
+				case CLIPS::TYPE_FLOAT: writer.Double(it2->as_float());
+				default: writer.String(it2->as_string().c_str(), (SizeType)it2->as_string().length());
+				}
+			}
+			if (multifield)
+				writer.EndArray();
+		}
+	} else {                   // ordered fact
+		writer.String("fields"); // write the json pair key that will be used to
+		                         // reference the fields of the fact
+		CLIPS::Values values = fact->slot_value("");
+		writer.StartArray(); // field values will be stored in a json array
+		for (CLIPS::Values::iterator it = values.begin(); it != values.end(); it++) {
+			switch (it->type()) {
+			case CLIPS::TYPE_INTEGER: writer.Int(it->as_integer());
+			case CLIPS::TYPE_FLOAT: writer.Double(it->as_float());
+			default: writer.String(it->as_string().c_str(), (SizeType)it->as_string().length());
+			}
+		}
+		writer.EndArray();
+	}
 
-      CLIPS::Values values = fact->slot_value(*it);
-      bool multifield = values.size() > 0;
-      if (multifield)
-        writer.StartArray(); // write values of slot as a json array only if
-                             // slot is multi field
-      for (CLIPS::Values::iterator it2 = values.begin(); it2 != values.end();
-           it2++) {
-        switch (it2->type()) {
-        case CLIPS::TYPE_INTEGER:
-          writer.Int(it2->as_integer());
-        case CLIPS::TYPE_FLOAT:
-          writer.Double(it2->as_float());
-        default:
-          writer.String(it2->as_string().c_str(),
-                        (SizeType)it2->as_string().length());
-        }
-      }
-      if (multifield)
-        writer.EndArray();
-    }
-  } else {                   // ordered fact
-    writer.String("fields"); // write the json pair key that will be used to
-                             // reference the fields of the fact
-    CLIPS::Values values = fact->slot_value("");
-    writer.StartArray(); // field values will be stored in a json array
-    for (CLIPS::Values::iterator it = values.begin(); it != values.end();
-         it++) {
-      switch (it->type()) {
-      case CLIPS::TYPE_INTEGER:
-        writer.Int(it->as_integer());
-      case CLIPS::TYPE_FLOAT:
-        writer.Double(it->as_float());
-      default:
-        writer.String(it->as_string().c_str(),
-                      (SizeType)it->as_string().length());
-      }
-    }
-    writer.EndArray();
-  }
+	writer.EndObject();
 
-  writer.EndObject();
-
-  return s.GetString();
+	return s.GetString();
 }

--- a/src/plugins/webtools-bridge/serializer.h
+++ b/src/plugins/webtools-bridge/serializer.h
@@ -23,23 +23,25 @@
 #include <clipsmm.h>
 #include <string>
 
-class Serializer {
+class Serializer
+{
 public:
-  static std::string op_subscribe(std::string topic_name, std::string id,
-                                  std::string type, std::string compression,
-                                  unsigned int throttle_rate,
-                                  unsigned int queue_length,
-                                  unsigned int fragment_size);
+	static std::string op_subscribe(std::string  topic_name,
+	                                std::string  id,
+	                                std::string  type,
+	                                std::string  compression,
+	                                unsigned int throttle_rate,
+	                                unsigned int queue_length,
+	                                unsigned int fragment_size);
 
-  static std::string op_unsubscribe(std::string topic_name, std::string id);
+	static std::string op_unsubscribe(std::string topic_name, std::string id);
 
-  static std::string op_advertise(std::string topic_name, std::string id,
-                                  std::string type);
-  static std::string op_unadvertise(std::string topic_name, std::string id);
-  static std::string op_publish(std::string topic_name, std::string id,
-                                bool latch, std::string msg_in_json);
+	static std::string op_advertise(std::string topic_name, std::string id, std::string type);
+	static std::string op_unadvertise(std::string topic_name, std::string id);
+	static std::string
+	op_publish(std::string topic_name, std::string id, bool latch, std::string msg_in_json);
 
-  static std::string serialize(CLIPS::Fact::pointer fact);
+	static std::string serialize(CLIPS::Fact::pointer fact);
 };
 
 #endif

--- a/src/plugins/webtools-bridge/service_capability.h
+++ b/src/plugins/webtools-bridge/service_capability.h
@@ -29,14 +29,14 @@
  *
  * @author Mostafa Gomaa
  */
-class ServiceCapability {
+class ServiceCapability
+{
 public:
-  /** To be implemented by the bridge processor for domain specific semantics
+	/** To be implemented by the bridge processor for domain specific semantics
    * @param srv_call_json
    * @param session the session requesting the advertise
    */
-  virtual void call_service(std::string srv_call_json,
-                            std::shared_ptr<WebSession> session) = 0;
+	virtual void call_service(std::string srv_call_json, std::shared_ptr<WebSession> session) = 0;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/service_capability_manager.cpp
+++ b/src/plugins/webtools-bridge/service_capability_manager.cpp
@@ -18,14 +18,15 @@
  */
 
 #include "service_capability_manager.h"
-#include "service_capability.h"
-#include <iostream>
 
+#include "service_capability.h"
+
+#include <core/exceptions/software.h>
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-#include <core/exceptions/software.h>
+#include <iostream>
 
 using namespace fawkes;
 using namespace rapidjson;
@@ -37,30 +38,33 @@ using namespace rapidjson;
    BridgeProcessor's registered here all provide ServiceCapability
 */
 
-ServiceCapabilityManager::ServiceCapabilityManager()
-    : CapabilityManager("Service") {}
-
-ServiceCapabilityManager::~ServiceCapabilityManager() {
-  // TODO: check if something needs to be changed
+ServiceCapabilityManager::ServiceCapabilityManager() : CapabilityManager("Service")
+{
 }
 
-bool ServiceCapabilityManager::register_processor(
-    std::shared_ptr<BridgeProcessor> processor) {
-  std::shared_ptr<ServiceCapability> service_processor;
-  service_processor = std::dynamic_pointer_cast<ServiceCapability>(processor);
-  if (service_processor == NULL) {
-    return false;
-  }
-  // find if it was used before
-  std::string processor_prefix = processor->get_prefix();
+ServiceCapabilityManager::~ServiceCapabilityManager()
+{
+	// TODO: check if something needs to be changed
+}
 
-  if (processores_.find(processor_prefix) == processores_.end()) {
-    // throw exception this prefix name is invalide coz it was used before
-  }
+bool
+ServiceCapabilityManager::register_processor(std::shared_ptr<BridgeProcessor> processor)
+{
+	std::shared_ptr<ServiceCapability> service_processor;
+	service_processor = std::dynamic_pointer_cast<ServiceCapability>(processor);
+	if (service_processor == NULL) {
+		return false;
+	}
+	// find if it was used before
+	std::string processor_prefix = processor->get_prefix();
 
-  processores_[processor_prefix] = processor;
+	if (processores_.find(processor_prefix) == processores_.end()) {
+		// throw exception this prefix name is invalide coz it was used before
+	}
 
-  return true;
+	processores_[processor_prefix] = processor;
+
+	return true;
 }
 
 /** Handles the Service Call Requests.
@@ -74,46 +78,45 @@ bool ServiceCapabilityManager::register_processor(
  * @param session the session issuing the request.
  */
 // TODO::remnam it (DispatchtoCapability)
-void ServiceCapabilityManager::handle_message(
-    Document &d, std::shared_ptr<WebSession> session) {
-  // std::cout<< "in manager"<< std::endl;
+void
+ServiceCapabilityManager::handle_message(Document &d, std::shared_ptr<WebSession> session)
+{
+	// std::cout<< "in manager"<< std::endl;
 
-  // TODO::MOVE ALL THE TYPE RELATED STUFF TO a proper protocol Class
-  if (!d.HasMember("op")) {
-    throw fawkes::MissingParameterException(
-        "ServiceCPM: Wrong Json Msg, topic name or id missing!");
-  }
+	// TODO::MOVE ALL THE TYPE RELATED STUFF TO a proper protocol Class
+	if (!d.HasMember("op")) {
+		throw fawkes::MissingParameterException(
+		  "ServiceCPM: Wrong Json Msg, topic name or id missing!");
+	}
 
-  // TODO::Pass the Dom the a Protocol Class that will have the deserialized
-  // types
-  std::string msg_op = std::string(d["op"].GetString());
+	// TODO::Pass the Dom the a Protocol Class that will have the deserialized
+	// types
+	std::string msg_op = std::string(d["op"].GetString());
 
-  // set the processor to ros_processor. (the only processor that implements
-  // Services for now)
-  std::string processor_prefix = "/";
-  if (processores_.find(processor_prefix) != processores_.end()) {
-    // std::cout<< "found processor"<< std::endl;
+	// set the processor to ros_processor. (the only processor that implements
+	// Services for now)
+	std::string processor_prefix = "/";
+	if (processores_.find(processor_prefix) != processores_.end()) {
+		// std::cout<< "found processor"<< std::endl;
 
-    std::shared_ptr<ServiceCapability> service_processor;
-    service_processor = std::dynamic_pointer_cast<ServiceCapability>(
-        processores_[processor_prefix]);
-    if (service_processor == NULL) {
-      throw fawkes::MissingParameterException(
-          "ServiceCPM: processor type issue!");
-    }
-    // Just serilize the Dom back to a json and forward it to the processor as
-    // it is.
-    if (msg_op == "call_service") {
+		std::shared_ptr<ServiceCapability> service_processor;
+		service_processor =
+		  std::dynamic_pointer_cast<ServiceCapability>(processores_[processor_prefix]);
+		if (service_processor == NULL) {
+			throw fawkes::MissingParameterException("ServiceCPM: processor type issue!");
+		}
+		// Just serilize the Dom back to a json and forward it to the processor as
+		// it is.
+		if (msg_op == "call_service") {
+			// std::cout<< "op is call service"<< std::endl;
+			// TEMP: for now keep the msg as a json and just forward it to ros
+			StringBuffer         buffer;
+			Writer<StringBuffer> writer(buffer);
+			d.Accept(writer);
+			std::string srv_call_json = buffer.GetString();
 
-      // std::cout<< "op is call service"<< std::endl;
-      // TEMP: for now keep the msg as a json and just forward it to ros
-      StringBuffer buffer;
-      Writer<StringBuffer> writer(buffer);
-      d.Accept(writer);
-      std::string srv_call_json = buffer.GetString();
-
-      service_processor->call_service(srv_call_json, session);
-    }
-  }
-  // std::cout<< "end manager"<< std::endl;
+			service_processor->call_service(srv_call_json, session);
+		}
+	}
+	// std::cout<< "end manager"<< std::endl;
 }

--- a/src/plugins/webtools-bridge/service_capability_manager.h
+++ b/src/plugins/webtools-bridge/service_capability_manager.h
@@ -21,13 +21,13 @@
 
 class ServiceCapability;
 
-class ServiceCapabilityManager : public CapabilityManager {
+class ServiceCapabilityManager : public CapabilityManager
+{
 public:
-  ServiceCapabilityManager();
-  ~ServiceCapabilityManager();
+	ServiceCapabilityManager();
+	~ServiceCapabilityManager();
 
-  void handle_message(rapidjson::Document &d,
-                      std::shared_ptr<WebSession> session);
+	void handle_message(rapidjson::Document &d, std::shared_ptr<WebSession> session);
 
-  bool register_processor(std::shared_ptr<BridgeProcessor> processor);
+	bool register_processor(std::shared_ptr<BridgeProcessor> processor);
 };

--- a/src/plugins/webtools-bridge/subscription_capability.cpp
+++ b/src/plugins/webtools-bridge/subscription_capability.cpp
@@ -18,17 +18,17 @@
  */
 
 #include "subscription_capability.h"
-#include "web_session.h"
 
-#include <rapidjson/document.h> //To be removed from here after serialzer is moved
-#include <rapidjson/error/en.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
+#include "web_session.h"
 
 #include <core/exceptions/software.h>
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
 #include <logging/logger.h>
+#include <rapidjson/document.h> //To be removed from here after serialzer is moved
+#include <rapidjson/error/en.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 #include <utils/time/time.h>
 
 using namespace rapidjson;
@@ -155,47 +155,53 @@ using namespace fawkes;
  * @param logger Fawkes logger
  * @param clock Fawkes clock
  */
-Subscription::Subscription(std::string topic_name, std::string prefix,
-                           fawkes::Logger *logger, fawkes::Clock *clock)
-    : active_status_(DORMANT), topic_name_(topic_name),
-      processor_prefix_(prefix), clock_(clock), finalized_(false) {
-  logger_ = logger;
-  __mutex = new fawkes::Mutex();
+Subscription::Subscription(std::string     topic_name,
+                           std::string     prefix,
+                           fawkes::Logger *logger,
+                           fawkes::Clock * clock)
+: active_status_(DORMANT),
+  topic_name_(topic_name),
+  processor_prefix_(prefix),
+  clock_(clock),
+  finalized_(false)
+{
+	logger_ = logger;
+	__mutex = new fawkes::Mutex();
 }
 
 /** Destructor */
-Subscription::~Subscription() {
-
-  subscriptions_.clear();
-  delete __mutex;
+Subscription::~Subscription()
+{
+	subscriptions_.clear();
+	delete __mutex;
 }
 
 /** Finalize a subscription before terminating the instance. */
-void Subscription::finalize() {
-  MutexLocker ml(__mutex);
-  if (!finalized_) {
-    return;
-  }
+void
+Subscription::finalize()
+{
+	MutexLocker ml(__mutex);
+	if (!finalized_) {
+		return;
+	}
 
-  // If still active deactivate
-  if (is_active()) {
-    deactivate();
-  }
-  // call the extended version
-  finalize_impl();
+	// If still active deactivate
+	if (is_active()) {
+		deactivate();
+	}
+	// call the extended version
+	finalize_impl();
 
-  // Deregister from sessions and remove them
-  if (!empty()) {
+	// Deregister from sessions and remove them
+	if (!empty()) {
+		for (it_subscriptions_ = subscriptions_.begin(); it_subscriptions_ != subscriptions_.end();) {
+			remove_session(it_subscriptions_->first);
+			it_subscriptions_->second.clear();
+			subscriptions_.erase(it_subscriptions_++);
+		}
 
-    for (it_subscriptions_ = subscriptions_.begin();
-         it_subscriptions_ != subscriptions_.end();) {
-      remove_session(it_subscriptions_->first);
-      it_subscriptions_->second.clear();
-      subscriptions_.erase(it_subscriptions_++);
-    }
-
-    finalized_ = true;
-  }
+		finalized_ = true;
+	}
 }
 
 /** Activate This Subscription instance
@@ -206,11 +212,13 @@ void Subscription::finalize() {
  * main one and it should be able to publish. The method will call
  * Activate_impl() by default to execute any extended behaviours.
  */
-void Subscription::activate() {
-  if (!is_active()) {
-    activate_impl();
-    active_status_ = ACTIVE;
-  }
+void
+Subscription::activate()
+{
+	if (!is_active()) {
+		activate_impl();
+		active_status_ = ACTIVE;
+	}
 }
 
 /** Make The Subscription DORMANT
@@ -219,31 +227,47 @@ void Subscription::activate() {
  * The method will call deactivate_impl() by default to execute any extended
  * behaviours.
  */
-void Subscription::deactivate() {
-  if (is_active()) {
-    deactivate_impl();
-    active_status_ = DORMANT;
-  }
+void
+Subscription::deactivate()
+{
+	if (is_active()) {
+		deactivate_impl();
+		active_status_ = DORMANT;
+	}
 }
 
 /** @return True when its an ACTIVE instance */
-bool Subscription::is_active() { return (active_status_ == ACTIVE); }
+bool
+Subscription::is_active()
+{
+	return (active_status_ == ACTIVE);
+}
 
 /** Is the Subscription Empty ?
  * A subscription is empty if it has no sessions that own any requests.
  * @return true if subscribtion has no sessions registered
  */
-bool Subscription::empty() {
-  // This assumes that the clients removal and the removal of their
-  // subscriptions were done correctly
-  return subscriptions_.empty();
+bool
+Subscription::empty()
+{
+	// This assumes that the clients removal and the removal of their
+	// subscriptions were done correctly
+	return subscriptions_.empty();
 }
 
 /** @return topic name maintained by this advertisement instance */
-std::string Subscription::get_topic_name() { return topic_name_; }
+std::string
+Subscription::get_topic_name()
+{
+	return topic_name_;
+}
 
 /** @return the processor prefix of that topic */
-std::string Subscription::get_processor_prefix() { return processor_prefix_; }
+std::string
+Subscription::get_processor_prefix()
+{
+	return processor_prefix_;
+}
 
 /** Finalize extended behaviour
  * This method will be called by default from Finalize()
@@ -251,8 +275,10 @@ std::string Subscription::get_processor_prefix() { return processor_prefix_; }
  * Subscription. After this the your Subscription should be ready to go out of
  * scope or deleted.
  */
-void Subscription::finalize_impl() {
-  // Override to extend behaviour
+void
+Subscription::finalize_impl()
+{
+	// Override to extend behaviour
 }
 
 /** Activate extended behaviour
@@ -262,16 +288,20 @@ void Subscription::finalize_impl() {
  * events listener relevant to topics changes, Or prescribing when the publish
  * should be triggered.
  */
-void Subscription::activate_impl() {
-  // Override to extend behaviour
+void
+Subscription::activate_impl()
+{
+	// Override to extend behaviour
 }
 
 /** Deactivate extended behaviour
  * This method will be called by default from dectivate()
  * any operation done to make the Subscription active "could be" undone here.
  */
-void Subscription::deactivate_impl() {
-  // Override to extend behaviour
+void
+Subscription::deactivate_impl()
+{
+	// Override to extend behaviour
 }
 
 /**Subsumes a DORMANT Subscription instance into an ACTIVE one.
@@ -284,44 +314,46 @@ void Subscription::deactivate_impl() {
  * could be safely deleted.
  * @param dormant_subscription The Dormant Subscription Instance to subsume
  */
-void Subscription::subsume(std::shared_ptr<Subscription> dormant_subscription) {
+void
+Subscription::subsume(std::shared_ptr<Subscription> dormant_subscription)
+{
+	if (topic_name_ != dormant_subscription->get_topic_name()) {
+		// throw exceptoin that they dont belong to the same topic and cant be
+		// merged
+		return;
+	}
 
-  if (topic_name_ != dormant_subscription->get_topic_name()) {
-    // throw exceptoin that they dont belong to the same topic and cant be
-    // merged
-    return;
-  }
+	if (!is_active()) {
+		// throw exceptoin that they dont belong to the same topic and cant be
+		// merged
+		return;
+	}
 
-  if (!is_active()) {
-    // throw exceptoin that they dont belong to the same topic and cant be
-    // merged
-    return;
-  }
+	if (dormant_subscription->is_active()) {
+		// throw exceptoin that they dont belong to the same topic and cant be
+		// merged
+		return;
+	}
 
-  if (dormant_subscription->is_active()) {
-    // throw exceptoin that they dont belong to the same topic and cant be
-    // merged
-    return;
-  }
+	for (std::map<std::shared_ptr<WebSession>, std::list<Request>>::iterator it_subscriptions =
+	       dormant_subscription->subscriptions_.begin();
+	     it_subscriptions != dormant_subscription->subscriptions_.end();
+	     it_subscriptions++) {
+		for (std::list<Request>::iterator it_requests = it_subscriptions->second.begin();
+		     it_requests != it_subscriptions->second.end();
+		     it_requests++) {
+			add_request(it_requests->id,
+			            it_requests->compression,
+			            it_requests->throttle_rate,
+			            it_requests->queue_length,
+			            it_requests->fragment_size,
+			            it_subscriptions->first);
 
-  for (std::map<std::shared_ptr<WebSession>, std::list<Request>>::iterator
-           it_subscriptions = dormant_subscription->subscriptions_.begin();
-       it_subscriptions != dormant_subscription->subscriptions_.end();
-       it_subscriptions++) {
-
-    for (std::list<Request>::iterator it_requests =
-             it_subscriptions->second.begin();
-         it_requests != it_subscriptions->second.end(); it_requests++) {
-
-      add_request(it_requests->id, it_requests->compression,
-                  it_requests->throttle_rate, it_requests->queue_length,
-                  it_requests->fragment_size, it_subscriptions->first);
-
-      // dormant_subscription->remove_request( it_requests ->id ,
-      // it_subscriptions ->first);
-    }
-  }
-  dormant_subscription->finalize();
+			// dormant_subscription->remove_request( it_requests ->id ,
+			// it_subscriptions ->first);
+		}
+	}
+	dormant_subscription->finalize();
 }
 
 /** Add A Subscription Request to A Session
@@ -339,51 +371,49 @@ void Subscription::subsume(std::shared_ptr<Subscription> dormant_subscription) {
  * @param session the session requesting to advertise the topic maintained by
  * this instance.
  */
-void Subscription::add_request(std::string id, std::string compression,
-                               unsigned int throttle_rate,
-                               unsigned int queue_length,
-                               unsigned int fragment_size,
-                               std::shared_ptr<WebSession> session) {
+void
+Subscription::add_request(std::string                 id,
+                          std::string                 compression,
+                          unsigned int                throttle_rate,
+                          unsigned int                queue_length,
+                          unsigned int                fragment_size,
+                          std::shared_ptr<WebSession> session)
+{
+	Request request;
+	// CHANGE:this matches for the pointer not the object
+	MutexLocker ml(__mutex);
 
-  Request request;
-  // CHANGE:this matches for the pointer not the object
-  MutexLocker ml(__mutex);
+	it_subscriptions_ = subscriptions_.find(session);
 
-  it_subscriptions_ = subscriptions_.find(session);
+	// if it is a new session, register my terminate_handler for the session's
+	// callbacks
+	if (it_subscriptions_ == subscriptions_.end()) {
+		add_new_session(session);
+	}
 
-  // if it is a new session, register my terminate_handler for the session's
-  // callbacks
-  if (it_subscriptions_ == subscriptions_.end()) {
-    add_new_session(session);
-  }
+	// if there was older requests for this session,  point to the same
+	// last_published_time
+	if (it_subscriptions_ != subscriptions_.end() && !(subscriptions_[session].empty())) {
+		// if(subscriptions_[session].find(id) != subscriptions_[session].end())
+		// {
+		// 	//throw exception..That id already exists for that client on that topic
+		// }
 
-  // if there was older requests for this session,  point to the same
-  // last_published_time
-  if (it_subscriptions_ != subscriptions_.end() &&
-      !(subscriptions_[session].empty())) {
+		request.last_published_time = subscriptions_[session].front().last_published_time;
+	} else {
+		request.last_published_time = std::make_shared<fawkes::Time>(clock_);
+	}
 
-    // if(subscriptions_[session].find(id) != subscriptions_[session].end())
-    // {
-    // 	//throw exception..That id already exists for that client on that topic
-    // }
+	request.id            = id;
+	request.compression   = compression;
+	request.throttle_rate = throttle_rate;
+	request.queue_length  = queue_length;
+	request.fragment_size = fragment_size;
 
-    request.last_published_time =
-        subscriptions_[session].front().last_published_time;
-  } else {
-    request.last_published_time = std::make_shared<fawkes::Time>(clock_);
-  }
-
-  request.id = id;
-  request.compression = compression;
-  request.throttle_rate = throttle_rate;
-  request.queue_length = queue_length;
-  request.fragment_size = fragment_size;
-
-  // sub_list_mutex_->lock();
-  subscriptions_[session].push_back(request);
-  subscriptions_[session].sort(
-      compare_throttle_rate); // replace by a lambda function
-  // sub_list_mutex_->unlock();
+	// sub_list_mutex_->lock();
+	subscriptions_[session].push_back(request);
+	subscriptions_[session].sort(compare_throttle_rate); // replace by a lambda function
+	// sub_list_mutex_->unlock();
 }
 
 /** Remove A Request Upon an Unsubscribe Operation
@@ -392,42 +422,46 @@ void Subscription::add_request(std::string id, std::string compression,
  * @param subscription_id ID of the request to be removed
  * @param session that initiated the request
  */
-void Subscription::remove_request(std::string subscription_id,
-                                  std::shared_ptr<WebSession> session) {
-  MutexLocker ml(__mutex);
+void
+Subscription::remove_request(std::string subscription_id, std::shared_ptr<WebSession> session)
+{
+	MutexLocker ml(__mutex);
 
-  it_subscriptions_ = subscriptions_.find(session);
+	it_subscriptions_ = subscriptions_.find(session);
 
-  if (it_subscriptions_ == subscriptions_.end()) {
-    // there is no such session. Maybe session was closed before the request is
-    // processed
-    return;
-  }
+	if (it_subscriptions_ == subscriptions_.end()) {
+		// there is no such session. Maybe session was closed before the request is
+		// processed
+		return;
+	}
 
-  for (it_requests_ = subscriptions_[session].begin();
-       it_requests_ != subscriptions_[session].end(); it_requests_++) {
+	for (it_requests_ = subscriptions_[session].begin();
+	     it_requests_ != subscriptions_[session].end();
+	     it_requests_++) {
+		if ((*it_requests_).id == subscription_id) {
+			subscriptions_[session].erase(it_requests_);
+			break;
+		}
+	}
 
-    if ((*it_requests_).id == subscription_id) {
-      subscriptions_[session].erase(it_requests_);
-      break;
-    }
-  }
-
-  // sub_list_mutex_->lock();
-  if (subscriptions_[session].empty()) {
-    remove_session(session);
-    subscriptions_.erase(session);
-  } else {
-    // Always have the least throttel rate on the top
-    subscriptions_[session].sort(compare_throttle_rate);
-  }
+	// sub_list_mutex_->lock();
+	if (subscriptions_[session].empty()) {
+		remove_session(session);
+		subscriptions_.erase(session);
+	} else {
+		// Always have the least throttel rate on the top
+		subscriptions_[session].sort(compare_throttle_rate);
+	}
 }
 
-void Subscription::emitt_event(EventType event_type) {
-  for (it_callables_ = callbacks_[event_type].begin();
-       it_callables_ != callbacks_[event_type].end(); it_callables_++) {
-    (*it_callables_)->callback(event_type, shared_from_this());
-  }
+void
+Subscription::emitt_event(EventType event_type)
+{
+	for (it_callables_ = callbacks_[event_type].begin();
+	     it_callables_ != callbacks_[event_type].end();
+	     it_callables_++) {
+		(*it_callables_)->callback(event_type, shared_from_this());
+	}
 }
 
 /** Callback To Be Called On Events The Subscription Instance Is Registered To
@@ -437,84 +471,89 @@ void Subscription::emitt_event(EventType event_type) {
  * @param event_type of event responsible for this call
  * @param event_emitter is a ptr to the instance that emitted that event
  */
-void Subscription::callback(EventType event_type,
-                            std::shared_ptr<EventEmitter> event_emitter) {
-  // sub_list_mutex_->lock();
-  MutexLocker ml(__mutex);
-  if (finalized_) {
-    return;
-  }
+void
+Subscription::callback(EventType event_type, std::shared_ptr<EventEmitter> event_emitter)
+{
+	// sub_list_mutex_->lock();
+	MutexLocker ml(__mutex);
+	if (finalized_) {
+		return;
+	}
 
-  if (event_type == EventType::PUBLISH) {
-    ml.unlock();
-    publish();
-  }
+	if (event_type == EventType::PUBLISH) {
+		ml.unlock();
+		publish();
+	}
 
-  try {
-    // check if the event emitter was a session
-    std::shared_ptr<WebSession> session;
-    session = std::dynamic_pointer_cast<WebSession>(event_emitter);
-    if (session != NULL) {
-      if (event_type == EventType::TERMINATE) {
-        // make sure the session is still there and was not deleted while
-        // waiting for the mutex
-        if (subscriptions_.find(session) != subscriptions_.end())
-          subscriptions_.erase(session);
+	try {
+		// check if the event emitter was a session
+		std::shared_ptr<WebSession> session;
+		session = std::dynamic_pointer_cast<WebSession>(event_emitter);
+		if (session != NULL) {
+			if (event_type == EventType::TERMINATE) {
+				// make sure the session is still there and was not deleted while
+				// waiting for the mutex
+				if (subscriptions_.find(session) != subscriptions_.end())
+					subscriptions_.erase(session);
 
-        // was it the last session? if yes, Subscription emit TERMINATTION event
-        // and destories itself.
-        if (subscriptions_.empty()) {
-          std::shared_ptr<Subscription> my_self =
-              shared_from_this(); // Just to keep object alive till after its
-                                  // deleted from manager
-          ml.unlock(); // to allow others to call finialize or do whatever is
-                       // necessary to the object
-          emitt_event(EventType::TERMINATE);
-        }
+				// was it the last session? if yes, Subscription emit TERMINATTION event
+				// and destories itself.
+				if (subscriptions_.empty()) {
+					std::shared_ptr<Subscription> my_self =
+					  shared_from_this(); // Just to keep object alive till after its
+					                      // deleted from manager
+					ml.unlock();          // to allow others to call finialize or do whatever is
+					                      // necessary to the object
+					emitt_event(EventType::TERMINATE);
+				}
 
-        // std::cout<< "Session terminated NICELY :D" << std::endl;
+				// std::cout<< "Session terminated NICELY :D" << std::endl;
 
-        // was it the last session? if yes, Subscription emit TERMINATTION event
-        // and destories itself.
-        // if(subscriptions_.empty()){
-        // 	std::shared_ptr<Subscription> my_self= shared_from_this();//
-        // Just to keep object alive till after its deleted from manager
-        // 	emitt_event(EventType::TERMINATE);
+				// was it the last session? if yes, Subscription emit TERMINATTION event
+				// and destories itself.
+				// if(subscriptions_.empty()){
+				// 	std::shared_ptr<Subscription> my_self= shared_from_this();//
+				// Just to keep object alive till after its deleted from manager
+				// 	emitt_event(EventType::TERMINATE);
 
-        // 	ml.unlock();
-        // 	my_self->finalize();
-        // 	//std::cout<< "Subscripton topic terminated!" << std::endl;
+				// 	ml.unlock();
+				// 	my_self->finalize();
+				// 	//std::cout<< "Subscripton topic terminated!" << std::endl;
 
-        // 	//finalize will need the mutex
-        // }
-        // TODO:check if subscription became empty and trigger the delete from
-        // the owning class if that was the case
-      }
-    }
+				// 	//finalize will need the mutex
+				// }
+				// TODO:check if subscription became empty and trigger the delete from
+				// the owning class if that was the case
+			}
+		}
 
-  } catch (Exception &e) {
-    // if exception was fired it only means that the casting failed becasue the
-    // emitter is not a session
-  }
+	} catch (Exception &e) {
+		// if exception was fired it only means that the casting failed becasue the
+		// emitter is not a session
+	}
 }
 
 /** Register the session to recive callbacks on emmited Termination Events
  * @param session
  */
-void Subscription::add_new_session(std::shared_ptr<WebSession> session) {
-  // register termination handler
-  session->register_callback(EventType::TERMINATE, shared_from_this());
-  //	subscriptions_[session];// Check if okay
+void
+Subscription::add_new_session(std::shared_ptr<WebSession> session)
+{
+	// register termination handler
+	session->register_callback(EventType::TERMINATE, shared_from_this());
+	//	subscriptions_[session];// Check if okay
 }
 
 /** Unregister the session from receiving callbacks on emmited Termination
  * Events
  * @param session
  */
-void Subscription::remove_session(std::shared_ptr<WebSession> session) {
-  // deregister termination handler
-  session->unregister_callback(EventType::TERMINATE, shared_from_this());
-  //	subscriptions_.erase(session);
+void
+Subscription::remove_session(std::shared_ptr<WebSession> session)
+{
+	// deregister termination handler
+	session->unregister_callback(EventType::TERMINATE, shared_from_this());
+	//	subscriptions_.erase(session);
 }
 
 /** Publish A Topic Data To The Sessions.
@@ -528,55 +567,54 @@ void Subscription::remove_session(std::shared_ptr<WebSession> session) {
  * request parameters with the least Throttle_rate is used if multiple requests
  * exist for the same session .
  */
-void Subscription::publish() {
-  MutexLocker ml(__mutex);
-  if (is_active()) {
+void
+Subscription::publish()
+{
+	MutexLocker ml(__mutex);
+	if (is_active()) {
+		for (it_subscriptions_ = subscriptions_.begin(); it_subscriptions_ != subscriptions_.end();
+		     it_subscriptions_++) {
+			if (it_subscriptions_->second.empty()) {
+				// This means unsubscribe() didnt work properly to delete that session
+				// after unsubscribing all clients components throw some exception
+				remove_session(it_subscriptions_->first);
+				subscriptions_.erase(it_subscriptions_++);
+				continue;
+			}
 
-    for (it_subscriptions_ = subscriptions_.begin();
-         it_subscriptions_ != subscriptions_.end(); it_subscriptions_++) {
-      if (it_subscriptions_->second.empty()) {
-        // This means unsubscribe() didnt work properly to delete that session
-        // after unsubscribing all clients components throw some exception
-        remove_session(it_subscriptions_->first);
-        subscriptions_.erase(it_subscriptions_++);
-        continue;
-      }
+			// Checking if it is time to publish topic
+			// sub_list_mutex_->lock();
+			fawkes::Time now(clock_);
+			// smallest throttle_rate always on the top
+			unsigned int throttle_rate = it_subscriptions_->second.front().throttle_rate;
+			std::string  id =
+			  it_subscriptions_->second.front().id; // could be done here to minimize locking
+			unsigned int last_published =
+			  it_subscriptions_->second.front().last_published_time->in_msec();
+			unsigned int time_passed = (now.in_msec() - last_published);
+			// sub_list_mutex_->unlock();
 
-      // Checking if it is time to publish topic
-      // sub_list_mutex_->lock();
-      fawkes::Time now(clock_);
-      // smallest throttle_rate always on the top
-      unsigned int throttle_rate =
-          it_subscriptions_->second.front().throttle_rate;
-      std::string id = it_subscriptions_->second.front()
-                           .id; // could be done here to minimize locking
-      unsigned int last_published =
-          it_subscriptions_->second.front().last_published_time->in_msec();
-      unsigned int time_passed = (now.in_msec() - last_published);
-      // sub_list_mutex_->unlock();
+			if (time_passed >= throttle_rate) {
+				std::string complete_json_msg = serialize("publish", topic_name_, id);
 
-      if (time_passed >= throttle_rate) {
+				// Only stamp if it was sent
+				// time_mutex_->lock();
+				it_subscriptions_->second.front().last_published_time->stamp();
+				// time_mutex_->unlock();
 
-        std::string complete_json_msg = serialize("publish", topic_name_, id);
+				// Unnecessary right now. No Mutex at session
+				//// To avoid deadlock if the session mutex was locked to process a
+				/// request
+				////(and the request cant add coz ur locking the subscription)
+				////ml.unlock();
 
-        // Only stamp if it was sent
-        // time_mutex_->lock();
-        it_subscriptions_->second.front().last_published_time->stamp();
-        // time_mutex_->unlock();
-
-        // Unnecessary right now. No Mutex at session
-        //// To avoid deadlock if the session mutex was locked to process a
-        /// request
-        ////(and the request cant add coz ur locking the subscription)
-        ////ml.unlock();
-
-        // send msg it to session
-        if (complete_json_msg.size() > 1)
-          it_subscriptions_->first->send(complete_json_msg);
-        ////ml.relock();
-      }
-    }
-  }
+				// send msg it to session
+				if (complete_json_msg.size() > 1)
+					it_subscriptions_->first->send(complete_json_msg);
+				////ml.relock();
+			}
+		}
+	}
 }
 
 /** Serialize the Topic's Data in a "Publish" message
@@ -596,39 +634,38 @@ void Subscription::publish() {
  * @todo
  * Serialization could be moved later to a Protocol handling utility.
  */
-std::string Subscription::serialize(std::string op, std::string topic_name,
-                                    std::string id) {
-  // MutexLocker ml(mutex_);
+std::string
+Subscription::serialize(std::string op, std::string topic_name, std::string id)
+{
+	// MutexLocker ml(mutex_);
 
-  // std::cout <<" default serialzer shoudl not come here "<< std::endl;
-  std::string prefixed_topic_name =
-      processor_prefix_ + "/" +
-      topic_name_; // not always the cast. (for its ros /topic_name)
+	// std::cout <<" default serialzer shoudl not come here "<< std::endl;
+	std::string prefixed_topic_name =
+	  processor_prefix_ + "/" + topic_name_; // not always the cast. (for its ros /topic_name)
 
-  StringBuffer s;
-  Writer<StringBuffer> writer(s);
-  writer.StartObject();
+	StringBuffer         s;
+	Writer<StringBuffer> writer(s);
+	writer.StartObject();
 
-  writer.String("op");
-  writer.String(op.c_str(), (SizeType)op.length());
+	writer.String("op");
+	writer.String(op.c_str(), (SizeType)op.length());
 
-  writer.String("id");
-  writer.String(id.c_str(), (SizeType)id.length());
+	writer.String("id");
+	writer.String(id.c_str(), (SizeType)id.length());
 
-  writer.String("topic");
-  writer.String(prefixed_topic_name.c_str(),
-                (SizeType)prefixed_topic_name.length());
+	writer.String("topic");
+	writer.String(prefixed_topic_name.c_str(), (SizeType)prefixed_topic_name.length());
 
-  writer.String("msg");
-  writer.StartObject();
-  // Serialize you data json here
-  writer.EndObject(); // End if data json
+	writer.String("msg");
+	writer.StartObject();
+	// Serialize you data json here
+	writer.EndObject(); // End if data json
 
-  writer.EndObject(); // End of complete Json_msg
+	writer.EndObject(); // End of complete Json_msg
 
-  ////std::cout << s.GetString() << std::endl;
+	////std::cout << s.GetString() << std::endl;
 
-  return s.GetString();
+	return s.GetString();
 }
 
 //-------------To be removed
@@ -640,6 +677,8 @@ std::string Subscription::serialize(std::string op, std::string topic_name,
  * @todo
  * replace by a lambda function
  */
-bool Subscription::compare_throttle_rate(Request first, Request second) {
-  return (first.throttle_rate <= second.throttle_rate);
+bool
+Subscription::compare_throttle_rate(Request first, Request second)
+{
+	return (first.throttle_rate <= second.throttle_rate);
 }

--- a/src/plugins/webtools-bridge/subscription_capability.h
+++ b/src/plugins/webtools-bridge/subscription_capability.h
@@ -20,13 +20,13 @@
 #ifndef __PLUGINS_SUBSCRIPTION_CAPABILITY_H_
 #define __PLUGINS_SUBSCRIPTION_CAPABILITY_H_
 
-#include <list>
-#include <map>
-#include <memory>
-
 #include "callable.h"
 #include "event_emitter.h"
 #include "event_type.h"
+
+#include <list>
+#include <map>
+#include <memory>
 
 namespace fawkes {
 class Clock;
@@ -46,9 +46,10 @@ class EventEmitter;
  *
  * @author Mostafa Gomaa
  */
-class SubscriptionCapability {
+class SubscriptionCapability
+{
 public:
-  /** To be implemented by the bridge processor for domain specific semantics
+	/** To be implemented by the bridge processor for domain specific semantics
    * @param topic_name the session wishes to subscribe
    * @param id provided in the JSON message of the rosbridge protocol
    * @param type provided in the JSON message of the rosbridge protocol
@@ -59,116 +60,120 @@ public:
    * @param session the session provided the advertise of the rosbridge protocol
    * @return ptr to a newly created dormant subscription instance
    */
-  virtual std::shared_ptr<Subscription>
-  subscribe(std::string topic_name, std::string id, std::string type,
-            std::string compression, unsigned int throttle_rate,
-            unsigned int queue_length, unsigned int fragment_size,
-            std::shared_ptr<WebSession> session) = 0;
+	virtual std::shared_ptr<Subscription> subscribe(std::string                 topic_name,
+	                                                std::string                 id,
+	                                                std::string                 type,
+	                                                std::string                 compression,
+	                                                unsigned int                throttle_rate,
+	                                                unsigned int                queue_length,
+	                                                unsigned int                fragment_size,
+	                                                std::shared_ptr<WebSession> session) = 0;
 
-  /** To be implemented by the bridge processor for domain specific semantics
+	/** To be implemented by the bridge processor for domain specific semantics
    * @param id included in the JSON message
    * @param subscription ptr to the instance that wish to unsubscribe from
    * @param session the session initiating requesting
    */
-  virtual void unsubscribe(std::string id,
-                           std::shared_ptr<Subscription> subscription,
-                           std::shared_ptr<WebSession> session) = 0;
+	virtual void unsubscribe(std::string                   id,
+	                         std::shared_ptr<Subscription> subscription,
+	                         std::shared_ptr<WebSession>   session) = 0;
 };
 
 class Subscription : public Callable,
                      public EventEmitter,
-                     public std::enable_shared_from_this<Subscription> {
+                     public std::enable_shared_from_this<Subscription>
+{
 public:
-  Subscription(std::string topic_name, std::string processor_prefix,
-               fawkes::Logger *logger, fawkes::Clock *clock);
+	Subscription(std::string     topic_name,
+	             std::string     processor_prefix,
+	             fawkes::Logger *logger,
+	             fawkes::Clock * clock);
 
-  virtual ~Subscription();
+	virtual ~Subscription();
 
-  void finalize(); // Implicitly calles deactivate
-  void activate();
-  void deactivate();
-  bool is_active();
-  bool empty();
-  std::string get_topic_name();
-  std::string get_processor_prefix();
-  void subsume(std::shared_ptr<Subscription> another_subscription);
+	void        finalize(); // Implicitly calles deactivate
+	void        activate();
+	void        deactivate();
+	bool        is_active();
+	bool        empty();
+	std::string get_topic_name();
+	std::string get_processor_prefix();
+	void        subsume(std::shared_ptr<Subscription> another_subscription);
 
-  void add_request(std::string id, std::string compression,
-                   unsigned int throttle_rate, unsigned int queue_length,
-                   unsigned int fragment_size,
-                   std::shared_ptr<WebSession> session);
-  void remove_request(std::string id, std::shared_ptr<WebSession> session);
+	void add_request(std::string                 id,
+	                 std::string                 compression,
+	                 unsigned int                throttle_rate,
+	                 unsigned int                queue_length,
+	                 unsigned int                fragment_size,
+	                 std::shared_ptr<WebSession> session);
+	void remove_request(std::string id, std::shared_ptr<WebSession> session);
 
-  void callback(EventType event_type, std::shared_ptr<EventEmitter> handler);
+	void callback(EventType event_type, std::shared_ptr<EventEmitter> handler);
 
-  void emitt_event(EventType event_type);
+	void emitt_event(EventType event_type);
 
-  void publish();
+	void publish();
 
 protected:
-  virtual void
-  finalize_impl(); /**< Implicitly called from finalize(), implement when need
+	virtual void        finalize_impl(); /**< Implicitly called from finalize(), implement when need
                       to extend finalization behaviour */
-  virtual void
-  activate_impl(); /**< Implicitly called from  activate(), implement when need
+	virtual void        activate_impl(); /**< Implicitly called from  activate(), implement when need
                       to extend activate behaviour  */
-  virtual void
-  deactivate_impl(); /**< Implicitly called from deactivate(), implement when
+	virtual void        deactivate_impl(); /**< Implicitly called from deactivate(), implement when
                         need to extend deactivat behaviour */
-  virtual std::string serialize(std::string op, std::string topic,
-                                std::string id);
+	virtual std::string serialize(std::string op, std::string topic, std::string id);
 
-  fawkes::Mutex *__mutex; /**< needed to lock the eternal registry */
+	fawkes::Mutex *__mutex; /**< needed to lock the eternal registry */
 
 protected:
-  void add_new_session(std::shared_ptr<WebSession> session);
-  void remove_session(std::shared_ptr<WebSession> session);
+	void add_new_session(std::shared_ptr<WebSession> session);
+	void remove_session(std::shared_ptr<WebSession> session);
 
-  /** @brief the posible status of an instance. A DORMANT instance only keeps
+	/** @brief the posible status of an instance. A DORMANT instance only keeps
    * the data. */
-  enum Status { ACTIVE, DORMANT };
+	enum Status { ACTIVE, DORMANT };
 
-  /** @brief a single Request mad by a session for subscription. A session
+	/** @brief a single Request mad by a session for subscription. A session
    * can make multiple requests with different request parameters. */
-  struct Request {
-    Request()
-        : id(""), compression(""), throttle_rate(0), queue_length(1),
-          fragment_size(0) {}
-    ~Request() { last_published_time.reset(); }
-    std::string id;          /**< specified in rosbridge protocol JSON request*/
-    std::string compression; /**< specified in rosbridge protocol JSON request*/
-    unsigned int
-        throttle_rate; /**< specified in rosbridge protocol JSON request*/
-    unsigned int
-        queue_length; /**< specified in rosbridge protocol JSON request*/
-    unsigned int
-        fragment_size; /**< specified in rosbridge protocol JSON request*/
-    std::shared_ptr<fawkes::Time>
-        last_published_time; /**< specified in rosbridge protocol JSON request*/
-  };
+	struct Request
+	{
+		Request() : id(""), compression(""), throttle_rate(0), queue_length(1), fragment_size(0)
+		{
+		}
+		~Request()
+		{
+			last_published_time.reset();
+		}
+		std::string  id;            /**< specified in rosbridge protocol JSON request*/
+		std::string  compression;   /**< specified in rosbridge protocol JSON request*/
+		unsigned int throttle_rate; /**< specified in rosbridge protocol JSON request*/
+		unsigned int queue_length;  /**< specified in rosbridge protocol JSON request*/
+		unsigned int fragment_size; /**< specified in rosbridge protocol JSON request*/
+		std::shared_ptr<fawkes::Time>
+		  last_published_time; /**< specified in rosbridge protocol JSON request*/
+	};
 
-  Status active_status_;         /**< Tracks the status of the instance */
-  std::string topic_name_;       /**< Topic name this instance is maintaining*/
-  std::string processor_prefix_; /**< processor specific prefix included in that
+	Status      active_status_;    /**< Tracks the status of the instance */
+	std::string topic_name_;       /**< Topic name this instance is maintaining*/
+	std::string processor_prefix_; /**< processor specific prefix included in that
                                     topic name*/
 
-  fawkes::Clock *clock_;   /**< Fawkes clock needed for periodic publishing*/
-  fawkes::Logger *logger_; /**< Fawkes logger*/
+	fawkes::Clock * clock_;  /**< Fawkes clock needed for periodic publishing*/
+	fawkes::Logger *logger_; /**< Fawkes logger*/
 
-  bool finalized_; /**< Is set to true if it was Object was finalized before */
+	bool finalized_; /**< Is set to true if it was Object was finalized before */
 
-  /// Contains mapping of session to request it made
-  std::map<std::shared_ptr<WebSession>, std::list<Request>> subscriptions_;
-  /// Iterator for subsciption_map
-  std::map<std::shared_ptr<WebSession>, std::list<Request>>::iterator
-      it_subscriptions_;
-  /// Iterator for requests list
-  std::list<Request>::iterator it_requests_;
+	/// Contains mapping of session to request it made
+	std::map<std::shared_ptr<WebSession>, std::list<Request>> subscriptions_;
+	/// Iterator for subsciption_map
+	std::map<std::shared_ptr<WebSession>, std::list<Request>>::iterator it_subscriptions_;
+	/// Iterator for requests list
+	std::list<Request>::iterator it_requests_;
 
-  bool static compare_throttle_rate(Request first, Request second);
+	bool static compare_throttle_rate(Request first, Request second);
 
-  // fawkes::Mutex				*sub_list_mutex_;
-  // fawkes::Mutex 				*time_mutex_;
+	// fawkes::Mutex				*sub_list_mutex_;
+	// fawkes::Mutex 				*time_mutex_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/subscription_capability_manager.cpp
+++ b/src/plugins/webtools-bridge/subscription_capability_manager.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "subscription_capability_manager.h"
+
 #include "subscription_capability.h"
 
 #include <core/exceptions/software.h>
@@ -54,66 +55,71 @@ using namespace rapidjson;
  */
 
 /** Constructor. */
-SubscriptionCapabilityManager::SubscriptionCapabilityManager()
-    : CapabilityManager("Subscription") {
-  __mutex = new fawkes::Mutex();
-  __publish_mutex = new fawkes::Mutex();
+SubscriptionCapabilityManager::SubscriptionCapabilityManager() : CapabilityManager("Subscription")
+{
+	__mutex         = new fawkes::Mutex();
+	__publish_mutex = new fawkes::Mutex();
 }
 
 /** Destructor. */
-SubscriptionCapabilityManager::~SubscriptionCapabilityManager() {
-  // TODO: check if something needs to be changed
-  if (!finalized_) {
-    finalize();
-  }
+SubscriptionCapabilityManager::~SubscriptionCapabilityManager()
+{
+	// TODO: check if something needs to be changed
+	if (!finalized_) {
+		finalize();
+	}
 
-  if (publisher_thread != NULL) {
-    publisher_thread->join();
-  }
+	if (publisher_thread != NULL) {
+		publisher_thread->join();
+	}
 
-  delete __mutex;
-  topic_Subscription_.clear();
+	delete __mutex;
+	topic_Subscription_.clear();
 }
 
-void SubscriptionCapabilityManager::init() {
-  if (!initialized_) {
-    // TODO::the publish_loop is a temporary way to publish those topics that do
-    // not have their own publish on topic update mechanism it runs on a
-    // separate thread dedicated to emit periodic publish events causing any
-    // subscription registered to this periodic publisher, to call its internal
-    // publish
-    run_publish_loop = true;
-    publisher_thread = std::make_shared<std::thread>(
-        &SubscriptionCapabilityManager::publish_loop, this);
+void
+SubscriptionCapabilityManager::init()
+{
+	if (!initialized_) {
+		// TODO::the publish_loop is a temporary way to publish those topics that do
+		// not have their own publish on topic update mechanism it runs on a
+		// separate thread dedicated to emit periodic publish events causing any
+		// subscription registered to this periodic publisher, to call its internal
+		// publish
+		run_publish_loop = true;
+		publisher_thread =
+		  std::make_shared<std::thread>(&SubscriptionCapabilityManager::publish_loop, this);
 
-    // std::cout << "publisher loop intrialized"<<std::endl;
+		// std::cout << "publisher loop intrialized"<<std::endl;
 
-    CapabilityManager::init();
-  }
+		CapabilityManager::init();
+	}
 }
 
-void SubscriptionCapabilityManager::finalize() {
-  MutexLocker ml(__mutex);
-  MutexLocker ml_publish(__publish_mutex);
+void
+SubscriptionCapabilityManager::finalize()
+{
+	MutexLocker ml(__mutex);
+	MutexLocker ml_publish(__publish_mutex);
 
-  if (!finalized_) {
+	if (!finalized_) {
+		run_publish_loop = false;
 
-    run_publish_loop = false;
+		for (std::map<std::string, std::shared_ptr<Subscription>>::iterator it =
+		       topic_Subscription_.begin();
+		     it != topic_Subscription_.end();
+		     it++) {
+			// TODO::Completely remove this hard coding after creating a proper
+			// publisher
+			if (it->second->get_processor_prefix() == "clips") {
+				unregister_callback(EventType::PUBLISH, it->second);
+			}
 
-    for (std::map<std::string, std::shared_ptr<Subscription>>::iterator it =
-             topic_Subscription_.begin();
-         it != topic_Subscription_.end(); it++) {
-      // TODO::Completely remove this hard coding after creating a proper
-      // publisher
-      if (it->second->get_processor_prefix() == "clips") {
-        unregister_callback(EventType::PUBLISH, it->second);
-      }
+			it->second->finalize();
+		}
 
-      it->second->finalize();
-    }
-
-    CapabilityManager::finalize();
-  }
+		CapabilityManager::finalize();
+	}
 }
 
 /** Register A BridgeProcessor
@@ -126,24 +132,24 @@ void SubscriptionCapabilityManager::finalize() {
  * @param processor
  * @return true on sucess
  */
-bool SubscriptionCapabilityManager::register_processor(
-    std::shared_ptr<BridgeProcessor> processor) {
-  std::shared_ptr<SubscriptionCapability> Subscription_processor;
-  Subscription_processor =
-      std::dynamic_pointer_cast<SubscriptionCapability>(processor);
-  if (Subscription_processor == NULL) {
-    return false;
-  }
-  // find if it was used before
-  std::string processor_prefix = processor->get_prefix();
+bool
+SubscriptionCapabilityManager::register_processor(std::shared_ptr<BridgeProcessor> processor)
+{
+	std::shared_ptr<SubscriptionCapability> Subscription_processor;
+	Subscription_processor = std::dynamic_pointer_cast<SubscriptionCapability>(processor);
+	if (Subscription_processor == NULL) {
+		return false;
+	}
+	// find if it was used before
+	std::string processor_prefix = processor->get_prefix();
 
-  if (processores_.find(processor_prefix) == processores_.end()) {
-    // throw exception this prefix name is invalide coz it was used before
-  }
+	if (processores_.find(processor_prefix) == processores_.end()) {
+		// throw exception this prefix name is invalide coz it was used before
+	}
 
-  processores_[processor_prefix] = processor;
+	processores_[processor_prefix] = processor;
 
-  return true;
+	return true;
 }
 
 /** Handle Subscription Related Requests
@@ -155,91 +161,97 @@ bool SubscriptionCapabilityManager::register_processor(
  * @param d The Dom object containing the deserialized JSON request
  * @param session that made the request and where the replies should be sent.
  */
-void SubscriptionCapabilityManager::handle_message(
-    Document &d, std::shared_ptr<WebSession> session) {
+void
+SubscriptionCapabilityManager::handle_message(Document &d, std::shared_ptr<WebSession> session)
+{
+	// TODO::MOVE ALL THE TYPE RELATED STUFF TO a proper protocol Class
+	if (!d.HasMember("topic") || !d.HasMember("id")) {
+		throw fawkes::MissingParameterException(
+		  "SubscriptionCPM: Wrong Json Msg, topic name or id missing!");
+	}
 
-  // TODO::MOVE ALL THE TYPE RELATED STUFF TO a proper protocol Class
-  if (!d.HasMember("topic") || !d.HasMember("id")) {
-    throw fawkes::MissingParameterException(
-        "SubscriptionCPM: Wrong Json Msg, topic name or id missing!");
-  }
+	// TODO::Pass the Dom the a Protocol Class that will have the deserialized
+	// types
+	std::string msg_op = std::string(d["op"].GetString());
 
-  // TODO::Pass the Dom the a Protocol Class that will have the deserialized
-  // types
-  std::string msg_op = std::string(d["op"].GetString());
+	std::string msg_topic    = std::string(d["topic"].GetString());
+	std::string match_prefix = "";
 
-  std::string msg_topic = std::string(d["topic"].GetString());
-  std::string match_prefix = "";
+	// Find longest matching processor presfix within topic_name
+	// TODO:Check the logic..might be wrong
+	// TODO:posible Optimization. if the same topic name exists in the
+	// topic_subscription just get the prefix from there
+	for (ProcessorMap::iterator it = processores_.begin(); it != processores_.end(); it++) {
+		std::string processor_prefix = it->first;
+		std::size_t found_at         = msg_topic.find(processor_prefix, 0);
 
-  // Find longest matching processor presfix within topic_name
-  // TODO:Check the logic..might be wrong
-  // TODO:posible Optimization. if the same topic name exists in the
-  // topic_subscription just get the prefix from there
-  for (ProcessorMap::iterator it = processores_.begin();
-       it != processores_.end(); it++) {
-    std::string processor_prefix = it->first;
-    std::size_t found_at = msg_topic.find(processor_prefix, 0);
+		if (found_at != std::string::npos) {
+			// allows freedom of 2 characters before the match to account
+			// for leading "/" ot "//" or and other startting charachters
+			if (found_at <= 1) {
+				if (processor_prefix.length() == match_prefix.length()) {
+					// Throw an exception. That there are 2 names with confusion prefixs
+					// a conflict like "/bl" and  "bl1" when looking for "bl".
+					// this cozed by the fliexibility
+					throw fawkes::IllegalArgumentException(
+					  "SubscriptionCPM: Could not select processor, 2 conflicting "
+					  "names!");
 
-    if (found_at != std::string::npos) {
-      // allows freedom of 2 characters before the match to account
-      // for leading "/" ot "//" or and other startting charachters
-      if (found_at <= 1) {
-        if (processor_prefix.length() == match_prefix.length()) {
-          // Throw an exception. That there are 2 names with confusion prefixs
-          // a conflict like "/bl" and  "bl1" when looking for "bl".
-          // this cozed by the fliexibility
-          throw fawkes::IllegalArgumentException(
-              "SubscriptionCPM: Could not select processor, 2 conflicting "
-              "names!");
+				} else if (processor_prefix.length() > match_prefix.length()) {
+					match_prefix = processor_prefix;
+				}
+			}
+		}
+	}
 
-        } else if (processor_prefix.length() > match_prefix.length()) {
-          match_prefix = processor_prefix;
-        }
-      }
-    }
-  }
+	if (match_prefix.length() == 0) {
+		throw fawkes::IllegalArgumentException(
+		  "SubscriptionCPM: No processor recognized for this topic!");
+	}
 
-  if (match_prefix.length() == 0) {
-    throw fawkes::IllegalArgumentException(
-        "SubscriptionCPM: No processor recognized for this topic!");
-  }
+	// Go with To the proper operation with the bridge_prefix and the request
+	// Paramters
+	if (msg_op == "subscribe") {
+		std::string  topic_name    = "";
+		std::string  id            = "";
+		std::string  type          = "";
+		std::string  compression   = "";
+		unsigned int throttle_rate = 0;
+		unsigned int queue_length  = 1;
+		unsigned int fragment_size = 0;
 
-  // Go with To the proper operation with the bridge_prefix and the request
-  // Paramters
-  if (msg_op == "subscribe") {
-    std::string topic_name = "";
-    std::string id = "";
-    std::string type = "";
-    std::string compression = "";
-    unsigned int throttle_rate = 0;
-    unsigned int queue_length = 1;
-    unsigned int fragment_size = 0;
+		if (d.HasMember("topic"))
+			topic_name = std::string(d["topic"].GetString());
+		if (d.HasMember("id"))
+			id = std::string(d["id"].GetString());
+		if (d.HasMember("type"))
+			type = std::string(d["type"].GetString());
+		if (d.HasMember("compression"))
+			compression = std::string(d["compression"].GetString());
+		if (d.HasMember("throttle_rate"))
+			throttle_rate = d["throttle_rate"].GetUint();
+		if (d.HasMember("queue_length"))
+			queue_length = d["queue_length"].GetUint();
+		if (d.HasMember("fragment_size"))
+			fragment_size = d["fragment_size"].GetUint();
 
-    if (d.HasMember("topic"))
-      topic_name = std::string(d["topic"].GetString());
-    if (d.HasMember("id"))
-      id = std::string(d["id"].GetString());
-    if (d.HasMember("type"))
-      type = std::string(d["type"].GetString());
-    if (d.HasMember("compression"))
-      compression = std::string(d["compression"].GetString());
-    if (d.HasMember("throttle_rate"))
-      throttle_rate = d["throttle_rate"].GetUint();
-    if (d.HasMember("queue_length"))
-      queue_length = d["queue_length"].GetUint();
-    if (d.HasMember("fragment_size"))
-      fragment_size = d["fragment_size"].GetUint();
+		subscribe(match_prefix,
+		          topic_name,
+		          id,
+		          type,
+		          compression,
+		          throttle_rate,
+		          queue_length,
+		          fragment_size,
+		          session);
+	} else
 
-    subscribe(match_prefix, topic_name, id, type, compression, throttle_rate,
-              queue_length, fragment_size, session);
-  } else
+	  if (msg_op == "unsubscribe") {
+		std::string topic_name = std::string(d["topic"].GetString());
+		std::string id         = std::string(d["id"].GetString());
 
-      if (msg_op == "unsubscribe") {
-    std::string topic_name = std::string(d["topic"].GetString());
-    std::string id = std::string(d["id"].GetString());
-
-    unsubscribe(match_prefix, topic_name, id, session);
-  }
+		unsubscribe(match_prefix, topic_name, id, session);
+	}
 }
 
 /** Callback to Handle Events, The SubscriptionCapabilityManager is Registered
@@ -251,46 +263,44 @@ void SubscriptionCapabilityManager::handle_message(
  * called.
  * @param event_emitter the object instance initiated the callback method call.
  */
-void SubscriptionCapabilityManager::callback(
-    EventType event_type, std::shared_ptr<EventEmitter> event_emitter) {
+void
+SubscriptionCapabilityManager::callback(EventType                     event_type,
+                                        std::shared_ptr<EventEmitter> event_emitter)
+{
+	MutexLocker ml(__mutex);
+	if (finalized_) {
+		return;
+	}
 
-  MutexLocker ml(__mutex);
-  if (finalized_) {
-    return;
-  }
+	try {
+		// check if the event emitter was a Subscription
+		std::shared_ptr<Subscription> subscription;
+		subscription = std::dynamic_pointer_cast<Subscription>(event_emitter);
+		if (subscription != NULL) {
+			if (event_type == EventType::TERMINATE) {
+				// construct the prefixed_name from info in the subscription
+				std::string prefixed_topic_name;
+				if (subscription->get_processor_prefix() == "/") // temp fix to accommodate both prefixes
+					prefixed_topic_name = subscription->get_topic_name();
+				else
+					prefixed_topic_name =
+					  subscription->get_processor_prefix() + "/" + subscription->get_topic_name();
 
-  try {
-    // check if the event emitter was a Subscription
-    std::shared_ptr<Subscription> subscription;
-    subscription = std::dynamic_pointer_cast<Subscription>(event_emitter);
-    if (subscription != NULL) {
-      if (event_type == EventType::TERMINATE) {
-        // construct the prefixed_name from info in the subscription
-        std::string prefixed_topic_name;
-        if (subscription->get_processor_prefix() ==
-            "/") // temp fix to accommodate both prefixes
-          prefixed_topic_name = subscription->get_topic_name();
-        else
-          prefixed_topic_name = subscription->get_processor_prefix() + "/" +
-                                subscription->get_topic_name();
+				// does the subscription exist (unique per topic_name)
+				if (topic_Subscription_.find(prefixed_topic_name) != topic_Subscription_.end()) {
+					if (subscription->get_processor_prefix() == "clips") {
+						unregister_callback(EventType::PUBLISH, subscription);
+					}
 
-        // does the subscription exist (unique per topic_name)
-        if (topic_Subscription_.find(prefixed_topic_name) !=
-            topic_Subscription_.end()) {
-          if (subscription->get_processor_prefix() == "clips") {
-
-            unregister_callback(EventType::PUBLISH, subscription);
-          }
-
-          topic_Subscription_[prefixed_topic_name]->finalize();
-          topic_Subscription_.erase(prefixed_topic_name);
-        }
-      }
-    }
-  } catch (Exception &e) {
-    // if exception was fired it only means that the casting failed because the
-    // emitter is not a subscription
-  }
+					topic_Subscription_[prefixed_topic_name]->finalize();
+					topic_Subscription_.erase(prefixed_topic_name);
+				}
+			}
+		}
+	} catch (Exception &e) {
+		// if exception was fired it only means that the casting failed because the
+		// emitter is not a subscription
+	}
 }
 
 /** Create a Subscription For A Topic and maintains Subscription Book keeping
@@ -321,66 +331,70 @@ void SubscriptionCapabilityManager::callback(
  * @param session The session that made the subscription request, and where
  * publishing for the topic will be sent
  */
-void SubscriptionCapabilityManager::subscribe(
-    std::string bridge_prefix, std::string topic_name, std::string id,
-    std::string type, std::string compression, unsigned int throttle_rate,
-    unsigned int queue_length, unsigned int fragment_size,
-    std::shared_ptr<WebSession> session) {
-  MutexLocker ml(__mutex);
-  if (finalized_) {
-    return;
-  }
+void
+SubscriptionCapabilityManager::subscribe(std::string                 bridge_prefix,
+                                         std::string                 topic_name,
+                                         std::string                 id,
+                                         std::string                 type,
+                                         std::string                 compression,
+                                         unsigned int                throttle_rate,
+                                         unsigned int                queue_length,
+                                         unsigned int                fragment_size,
+                                         std::shared_ptr<WebSession> session)
+{
+	MutexLocker ml(__mutex);
+	if (finalized_) {
+		return;
+	}
 
-  std::shared_ptr<SubscriptionCapability> processor;
-  processor = std::dynamic_pointer_cast<SubscriptionCapability>(
-      processores_[bridge_prefix]);
+	std::shared_ptr<SubscriptionCapability> processor;
+	processor = std::dynamic_pointer_cast<SubscriptionCapability>(processores_[bridge_prefix]);
 
-  // always creates a new subscription for that topic with the given Session and
-  // request parameters
-  std::shared_ptr<Subscription> subscription;
-  try {
-    // TODO:: pass the pure string arguments or a "protocol" type
-    subscription =
-        processor->subscribe(topic_name, id, type, compression, throttle_rate,
-                             queue_length, fragment_size, session);
+	// always creates a new subscription for that topic with the given Session and
+	// request parameters
+	std::shared_ptr<Subscription> subscription;
+	try {
+		// TODO:: pass the pure string arguments or a "protocol" type
+		subscription = processor->subscribe(
+		  topic_name, id, type, compression, throttle_rate, queue_length, fragment_size, session);
 
-  } catch (Exception &e) {
-    throw e;
-  } // TODO
+	} catch (Exception &e) {
+		throw e;
+	} // TODO
 
-  // push it to the topic_subscription_map maintain only ONE Subscription
-  // instance per topic. ps.Subscription contains all the sessions mapped to
-  // their individual requests
+	// push it to the topic_subscription_map maintain only ONE Subscription
+	// instance per topic. ps.Subscription contains all the sessions mapped to
+	// their individual requests
 
-  // Is it a new topic? Just push it to the map and activate the Subscription
-  if (topic_Subscription_.find(topic_name) == topic_Subscription_.end()) {
-    topic_Subscription_[topic_name] = subscription;
+	// Is it a new topic? Just push it to the map and activate the Subscription
+	if (topic_Subscription_.find(topic_name) == topic_Subscription_.end()) {
+		topic_Subscription_[topic_name] = subscription;
 
-    // Activate the listeners or whatever that publishs
-    subscription->activate();
+		// Activate the listeners or whatever that publishs
+		subscription->activate();
 
-    // Register for Subscriptions to notify me if it was terminated (by calling
-    // my callback)
-    subscription->register_callback(EventType::TERMINATE, shared_from_this());
+		// Register for Subscriptions to notify me if it was terminated (by calling
+		// my callback)
+		subscription->register_callback(EventType::TERMINATE, shared_from_this());
 
-    // HUGE TODO :: REMOVE THIS SHIT and make another publishing
-    // skeem...subscriptions should allow someone to register a publisher.. (who
-    // ever that is publisher..he should emit events..and when the event is
-    // emitted.
-    // It will call all the publish() from the subscription by the power of
-    // call_backes
-    if (bridge_prefix == "clips")
-      register_callback(EventType::PUBLISH, topic_Subscription_[topic_name]);
+		// HUGE TODO :: REMOVE THIS SHIT and make another publishing
+		// skeem...subscriptions should allow someone to register a publisher.. (who
+		// ever that is publisher..he should emit events..and when the event is
+		// emitted.
+		// It will call all the publish() from the subscription by the power of
+		// call_backes
+		if (bridge_prefix == "clips")
+			register_callback(EventType::PUBLISH, topic_Subscription_[topic_name]);
 
-  } else {
-    topic_Subscription_[topic_name]->subsume(subscription);
-  }
+	} else {
+		topic_Subscription_[topic_name]->subsume(subscription);
+	}
 
-  // To be moved back to the subscrib() if the processor
-  //..Or does it! u want to keep track of the subscription all the time..leaving
-  // that as a choice to the processor does not seem right.
-  // topic_Subscription_[topic_name]->add_request(id , compression ,
-  // throttle_rate , queue_length , fragment_size , session);
+	// To be moved back to the subscrib() if the processor
+	//..Or does it! u want to keep track of the subscription all the time..leaving
+	// that as a choice to the processor does not seem right.
+	// topic_Subscription_[topic_name]->add_request(id , compression ,
+	// throttle_rate , queue_length , fragment_size , session);
 }
 
 /** Remove A Subscription For A Topic and maintain the Subscription Book
@@ -394,65 +408,71 @@ void SubscriptionCapabilityManager::subscribe(
  * @param session The session that made the subscription request, and the
  * destination for the publishing events of that topic.
  */
-void SubscriptionCapabilityManager::unsubscribe(
-    std::string bridge_prefix, std::string topic_name, std::string id,
-    std::shared_ptr<WebSession> session) {
-  MutexLocker ml(__mutex);
-  if (finalized_) {
-    return;
-  }
+void
+SubscriptionCapabilityManager::unsubscribe(std::string                 bridge_prefix,
+                                           std::string                 topic_name,
+                                           std::string                 id,
+                                           std::shared_ptr<WebSession> session)
+{
+	MutexLocker ml(__mutex);
+	if (finalized_) {
+		return;
+	}
 
-  // Cast the BridgeProcessor to a SubscriptioCapability to perform the
-  // operation
-  std::shared_ptr<SubscriptionCapability> processor;
-  processor = std::dynamic_pointer_cast<SubscriptionCapability>(
-      processores_[bridge_prefix]);
+	// Cast the BridgeProcessor to a SubscriptioCapability to perform the
+	// operation
+	std::shared_ptr<SubscriptionCapability> processor;
+	processor = std::dynamic_pointer_cast<SubscriptionCapability>(processores_[bridge_prefix]);
 
-  std::shared_ptr<Subscription> subscription;
-  if (topic_Subscription_.find(topic_name) != topic_Subscription_.end()) {
-    subscription = topic_Subscription_[topic_name];
+	std::shared_ptr<Subscription> subscription;
+	if (topic_Subscription_.find(topic_name) != topic_Subscription_.end()) {
+		subscription = topic_Subscription_[topic_name];
 
-    try {
-      processor->unsubscribe(id, subscription, session);
-    } catch (Exception &e) {
-      throw e;
-    }
+		try {
+			processor->unsubscribe(id, subscription, session);
+		} catch (Exception &e) {
+			throw e;
+		}
 
-    if (subscription->empty()) {
-      topic_Subscription_[topic_name]->finalize();
-      topic_Subscription_.erase(topic_name);
+		if (subscription->empty()) {
+			topic_Subscription_[topic_name]->finalize();
+			topic_Subscription_.erase(topic_name);
 
-      if (bridge_prefix == "clips") {
-        unregister_callback(EventType::PUBLISH,
-                            topic_Subscription_[topic_name]);
-      }
-    }
+			if (bridge_prefix == "clips") {
+				unregister_callback(EventType::PUBLISH, topic_Subscription_[topic_name]);
+			}
+		}
 
-    return;
-  }
+		return;
+	}
 
-  // throw exception that topic was not found
+	// throw exception that topic was not found
 }
 
 /** Publish periodically */
 // TODO:: this will be replaced with a more proper Publishing mechanism
-void SubscriptionCapabilityManager::publish_loop() {
-  MutexLocker ml(__publish_mutex);
+void
+SubscriptionCapabilityManager::publish_loop()
+{
+	MutexLocker ml(__publish_mutex);
 
-  while (run_publish_loop) {
-    emitt_event(EventType::PUBLISH);
-    ml.unlock();
-    usleep(100000);
-    MutexLocker ml(__publish_mutex);
-  }
+	while (run_publish_loop) {
+		emitt_event(EventType::PUBLISH);
+		ml.unlock();
+		usleep(100000);
+		MutexLocker ml(__publish_mutex);
+	}
 }
 
-void SubscriptionCapabilityManager::emitt_event(EventType event_type) {
-  MutexLocker ml(mutex_);
+void
+SubscriptionCapabilityManager::emitt_event(EventType event_type)
+{
+	MutexLocker ml(mutex_);
 
-  for (it_callables_ = callbacks_[event_type].begin();
-       it_callables_ != callbacks_[event_type].end(); it_callables_++) {
-    (*it_callables_)->callback(event_type, shared_from_this());
-  }
-  // do_on_event(event_type);
+	for (it_callables_ = callbacks_[event_type].begin();
+	     it_callables_ != callbacks_[event_type].end();
+	     it_callables_++) {
+		(*it_callables_)->callback(event_type, shared_from_this());
+	}
+	// do_on_event(event_type);
 }

--- a/src/plugins/webtools-bridge/subscription_capability_manager.h
+++ b/src/plugins/webtools-bridge/subscription_capability_manager.h
@@ -32,43 +32,48 @@ class Mutex;
 }
 
 class SubscriptionCapabilityManager
-    : public CapabilityManager,
-      public EventEmitter,
-      public Callable,
-      public std::enable_shared_from_this<SubscriptionCapabilityManager> {
+: public CapabilityManager,
+  public EventEmitter,
+  public Callable,
+  public std::enable_shared_from_this<SubscriptionCapabilityManager>
+{
 public:
-  SubscriptionCapabilityManager();
-  ~SubscriptionCapabilityManager();
+	SubscriptionCapabilityManager();
+	~SubscriptionCapabilityManager();
 
-  void init();
-  void finalize();
+	void init();
+	void finalize();
 
-  void handle_message(rapidjson::Document &d,
-                      std::shared_ptr<WebSession> session);
+	void handle_message(rapidjson::Document &d, std::shared_ptr<WebSession> session);
 
-  bool register_processor(std::shared_ptr<BridgeProcessor> processor);
+	bool register_processor(std::shared_ptr<BridgeProcessor> processor);
 
-  void callback(EventType event_type,
-                std::shared_ptr<EventEmitter> event_emitter);
+	void callback(EventType event_type, std::shared_ptr<EventEmitter> event_emitter);
 
-  void publish_loop();
+	void publish_loop();
 
-  void emitt_event(EventType event_type);
+	void emitt_event(EventType event_type);
 
 private:
-  void subscribe(std::string bridge_prefix, std::string topic_name,
-                 std::string id, std::string type, std::string compression,
-                 unsigned int throttle_rate, unsigned int queue_length,
-                 unsigned int fragment_size,
-                 std::shared_ptr<WebSession> session);
+	void subscribe(std::string                 bridge_prefix,
+	               std::string                 topic_name,
+	               std::string                 id,
+	               std::string                 type,
+	               std::string                 compression,
+	               unsigned int                throttle_rate,
+	               unsigned int                queue_length,
+	               unsigned int                fragment_size,
+	               std::shared_ptr<WebSession> session);
 
-  void unsubscribe(std::string bridge_prefix, std::string topic_name,
-                   std::string id, std::shared_ptr<WebSession> session);
+	void unsubscribe(std::string                 bridge_prefix,
+	                 std::string                 topic_name,
+	                 std::string                 id,
+	                 std::shared_ptr<WebSession> session);
 
-  std::map<std::string, std::shared_ptr<Subscription>> topic_Subscription_;
-  std::shared_ptr<std::thread> publisher_thread;
-  bool run_publish_loop;
+	std::map<std::string, std::shared_ptr<Subscription>> topic_Subscription_;
+	std::shared_ptr<std::thread>                         publisher_thread;
+	bool                                                 run_publish_loop;
 
-  fawkes::Mutex *__mutex;
-  fawkes::Mutex *__publish_mutex;
+	fawkes::Mutex *__mutex;
+	fawkes::Mutex *__publish_mutex;
 };

--- a/src/plugins/webtools-bridge/web_session.cpp
+++ b/src/plugins/webtools-bridge/web_session.cpp
@@ -18,9 +18,12 @@
  */
 
 #include "web_session.h"
+
 #include "callable.h"
+
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
+
 #include <exception>
 
 using namespace fawkes;
@@ -33,50 +36,76 @@ using namespace fawkes;
  * @author Mostafa Gomaa
  */
 /** Constructor*/
-WebSession::WebSession() : EventEmitter(), status_("N/A") {}
+WebSession::WebSession() : EventEmitter(), status_("N/A")
+{
+}
 
 /** Destructor */
-WebSession::~WebSession() {}
+WebSession::~WebSession()
+{
+}
 
 /** Set internal websocketpp connection handler
  * @param hdl websocket connection_hdl used to identify this session
  */
-void WebSession::set_connection_hdl(websocketpp::connection_hdl hdl) {
-  hdl_ = hdl;
+void
+WebSession::set_connection_hdl(websocketpp::connection_hdl hdl)
+{
+	hdl_ = hdl;
 }
 
 /** Set internal websocketpp endpoint
  * @param endpoint_ptr websocket endpoint
  */
-void WebSession::set_endpoint(std::shared_ptr<server> endpoint_ptr) {
-  endpoint_ptr_ = endpoint_ptr;
+void
+WebSession::set_endpoint(std::shared_ptr<server> endpoint_ptr)
+{
+	endpoint_ptr_ = endpoint_ptr;
 }
 
 /** Set internal session id
  * @param id to set
  */
-void WebSession::set_id(int id) { session_id_ = id; }
+void
+WebSession::set_id(int id)
+{
+	session_id_ = id;
+}
 
 /** Set internal session status
  * @param status to set
  */
-void WebSession::set_status(std::string status) { status_ = status; }
+void
+WebSession::set_status(std::string status)
+{
+	status_ = status;
+}
 
 /** Get internal id
  * @return id of the session
  */
-int WebSession::get_id() { return session_id_; }
+int
+WebSession::get_id()
+{
+	return session_id_;
+}
 
 /** Get internal session status
  * @return status string
  */
-std::string WebSession::get_status() { return status_; }
+std::string
+WebSession::get_status()
+{
+	return status_;
+}
 
 /** Get internal websocketpp connection handler
  * @return the websocekctpp::connection_hdl of the session
  */
-server::connection_ptr WebSession::get_connection_ptr() {
-  return endpoint_ptr_->get_con_from_hdl(hdl_);
+server::connection_ptr
+WebSession::get_connection_ptr()
+{
+	return endpoint_ptr_->get_con_from_hdl(hdl_);
 }
 
 /**Send WebSocket message to a session
@@ -84,20 +113,21 @@ server::connection_ptr WebSession::get_connection_ptr() {
  * message.
  * @return true on success
  */
-bool WebSession::send(std::string msg) {
+bool
+WebSession::send(std::string msg)
+{
+	// MutexLocker ml(mutex_);
 
-  // MutexLocker ml(mutex_);
+	websocketpp::lib::error_code ec;
 
-  websocketpp::lib::error_code ec;
+	// std::cout << ">TO WEB::sending message: " << std::endl;
+	endpoint_ptr_->send(hdl_, msg, websocketpp::frame::opcode::text, ec);
 
-  // std::cout << ">TO WEB::sending message: " << std::endl;
-  endpoint_ptr_->send(hdl_, msg, websocketpp::frame::opcode::text, ec);
-
-  if (ec) {
-    // std::cout << "> Error sending message: " << ec.message() << std::endl;
-    return false;
-  }
-  return true;
+	if (ec) {
+		// std::cout << "> Error sending message: " << ec.message() << std::endl;
+		return false;
+	}
+	return true;
 }
 
 /** This session has been closed from the server
@@ -105,23 +135,27 @@ bool WebSession::send(std::string msg) {
  * It Notifies anyone that registered for the session termination by directly
  * calling their resisted callback with the session ptr.
  */
-void WebSession::on_terminate() {
-  std::shared_ptr<WebSession> me = shared_from_this();
+void
+WebSession::on_terminate()
+{
+	std::shared_ptr<WebSession> me = shared_from_this();
 
-  me->emitt_event(EventType::TERMINATE);
+	me->emitt_event(EventType::TERMINATE);
 }
 
-void WebSession::emitt_event(EventType event_type) {
-  for (it_callables_ = callbacks_[event_type].begin();
-       it_callables_ != callbacks_[event_type].end();) {
-    (*it_callables_)->callback(event_type, shared_from_this());
+void
+WebSession::emitt_event(EventType event_type)
+{
+	for (it_callables_ = callbacks_[event_type].begin();
+	     it_callables_ != callbacks_[event_type].end();) {
+		(*it_callables_)->callback(event_type, shared_from_this());
 
-    // this is dangerous ..i am assuming the the callable obj is still there
-    // after the callback
-    if (event_type == EventType::TERMINATE) {
-      it_callables_ = callbacks_[event_type].erase(it_callables_);
-    } else {
-      it_callables_++;
-    }
-  }
+		// this is dangerous ..i am assuming the the callable obj is still there
+		// after the callback
+		if (event_type == EventType::TERMINATE) {
+			it_callables_ = callbacks_[event_type].erase(it_callables_);
+		} else {
+			it_callables_++;
+		}
+	}
 }

--- a/src/plugins/webtools-bridge/web_session.h
+++ b/src/plugins/webtools-bridge/web_session.h
@@ -20,15 +20,14 @@
 #ifndef _WEB_SESSION_H
 #define _WEB_SESSION_H
 
+#include "event_emitter.h"
+#include "event_type.h"
+
 #include <list>
 #include <map>
 #include <memory>
-
 #include <websocketpp/config/asio_no_tls.hpp>
 #include <websocketpp/server.hpp>
-
-#include "event_emitter.h"
-#include "event_type.h"
 
 namespace fawkes {
 class Mutex;
@@ -37,41 +36,40 @@ class Mutex;
 class WebSession;
 
 #ifndef _SERVER
-#define _SERVER
+#	define _SERVER
 typedef websocketpp::server<websocketpp::config::asio> server;
 #endif
 
-class WebSession : public EventEmitter,
-                   public std::enable_shared_from_this<WebSession> {
-
+class WebSession : public EventEmitter, public std::enable_shared_from_this<WebSession>
+{
 public:
-  WebSession();
-  ~WebSession();
+	WebSession();
+	~WebSession();
 
-  void set_connection_hdl(websocketpp::connection_hdl hdl);
-  void set_endpoint(std::shared_ptr<server> endpoint_ptr);
-  void set_id(int id);
-  void set_status(std::string status);
+	void set_connection_hdl(websocketpp::connection_hdl hdl);
+	void set_endpoint(std::shared_ptr<server> endpoint_ptr);
+	void set_id(int id);
+	void set_status(std::string status);
 
-  server::connection_ptr get_connection_ptr();
-  int get_id();
-  std::string get_status();
+	server::connection_ptr get_connection_ptr();
+	int                    get_id();
+	std::string            get_status();
 
-  bool send(std::string msg);
+	bool send(std::string msg);
 
-  void on_terminate(); // this will be called when session is closed from server
+	void on_terminate(); // this will be called when session is closed from server
 
-  void emitt_event(EventType event_type);
+	void emitt_event(EventType event_type);
 
 private:
-  websocketpp::connection_hdl hdl_;
-  std::shared_ptr<server> endpoint_ptr_;
+	websocketpp::connection_hdl hdl_;
+	std::shared_ptr<server>     endpoint_ptr_;
 
-  std::string session_name_;
-  std::string status_;
-  int session_id_;
+	std::string session_name_;
+	std::string status_;
+	int         session_id_;
 
-  fawkes::Mutex *mutex_;
+	fawkes::Mutex *mutex_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/websocket_server.cpp
+++ b/src/plugins/webtools-bridge/websocket_server.cpp
@@ -18,15 +18,16 @@
  */
 
 #include "websocket_server.h"
+
 #include "bridge_manager.h"
 #include "web_session.h"
-
-#include <exception>
 
 #include <core/exceptions/software.h>
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
 #include <logging/logger.h>
+
+#include <exception>
 
 using websocketpp::connection_hdl;
 using websocketpp::lib::bind;
@@ -49,167 +50,172 @@ using namespace fawkes;
  * @param logger Fawkes logger
  * @param bridge_manager entry point to dispatching requests
  */
-WebSocketServer::WebSocketServer(fawkes::Logger *logger,
+WebSocketServer::WebSocketServer(fawkes::Logger *               logger,
                                  std::shared_ptr<BridgeManager> bridge_manager)
-    : m_next_sessionid(1), finalized_(false) {
-  logger_ = logger;
-  bridge_manager_ = bridge_manager;
-  m_server = websocketpp::lib::make_shared<server>();
+: m_next_sessionid(1), finalized_(false)
+{
+	logger_         = logger;
+	bridge_manager_ = bridge_manager;
+	m_server        = websocketpp::lib::make_shared<server>();
 
-  m_server->init_asio();
-  m_server->set_open_handler(bind(&WebSocketServer::on_open, this, ::_1));
-  m_server->set_close_handler(bind(&WebSocketServer::on_close, this, ::_1));
-  m_server->set_validate_handler(
-      bind(&WebSocketServer::on_validate, this, ::_1));
-  m_server->clear_access_channels(websocketpp::log::alevel::all);
-  m_server->set_reuse_addr(true);
+	m_server->init_asio();
+	m_server->set_open_handler(bind(&WebSocketServer::on_open, this, ::_1));
+	m_server->set_close_handler(bind(&WebSocketServer::on_close, this, ::_1));
+	m_server->set_validate_handler(bind(&WebSocketServer::on_validate, this, ::_1));
+	m_server->clear_access_channels(websocketpp::log::alevel::all);
+	m_server->set_reuse_addr(true);
 
-  mutex_ = new fawkes::Mutex();
+	mutex_ = new fawkes::Mutex();
 }
 
 /** Destructor */
-WebSocketServer::~WebSocketServer() {
+WebSocketServer::~WebSocketServer()
+{
+	if (!finalized_) {
+		finalize();
+	}
 
-  if (!finalized_) {
-    finalize();
-  }
+	// TODO: What if the asio::run thread gets stuck while holding the mutex
+	//(in on_message of ex while processing  a request), am not sure if it could
+	// stop and join
+	if (!m_server->stopped()) {
+		m_server->stop();
+		usleep(100000);
+		logger_->log_info("WebServer", "Stopping Asio");
+	}
 
-  // TODO: What if the asio::run thread gets stuck while holding the mutex
-  //(in on_message of ex while processing  a request), am not sure if it could
-  // stop and join
-  if (!m_server->stopped()) {
-    m_server->stop();
-    usleep(100000);
-    logger_->log_info("WebServer", "Stopping Asio");
-  }
+	if (m_thread != NULL)
+		m_thread->join();
 
-  if (m_thread != NULL)
-    m_thread->join();
-
-  delete mutex_;
-  m_server.reset();
+	delete mutex_;
+	m_server.reset();
 }
 
 /** Start listening for connection of some port
  * @param port to listen to*/
-void WebSocketServer::run(uint16_t port) {
-  m_server->listen(port);
-  m_server->start_accept();
-  m_thread = websocketpp::lib::make_shared<websocketpp::lib::thread>(
-      &server::run, m_server);
+void
+WebSocketServer::run(uint16_t port)
+{
+	m_server->listen(port);
+	m_server->start_accept();
+	m_thread = websocketpp::lib::make_shared<websocketpp::lib::thread>(&server::run, m_server);
 }
 
 /** Finalize the server instance */
-void WebSocketServer::finalize() {
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return;
-  }
+void
+WebSocketServer::finalize()
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return;
+	}
 
-  logger_->log_info("WebServer:", " Finalizing");
+	logger_->log_info("WebServer:", " Finalizing");
 
-  websocketpp::lib::error_code ec;
+	websocketpp::lib::error_code ec;
 
-  for (std::map<connection_hdl, std::shared_ptr<WebSession>>::iterator it =
-           hdl_ids_.begin();
-       it != hdl_ids_.end();) {
-    m_server->close(it->first, websocketpp::close::status::going_away, "", ec);
-    it++;
-    // usleep(5000); // wait for session closing to terminate cleanl by handler.
-    // Or just count on the termination in the destrouctor
-    if (ec) {
-      logger_->log_info("WebServer:", " Error closing connection : : %s",
-                        ec.message().c_str());
-    }
-  }
+	for (std::map<connection_hdl, std::shared_ptr<WebSession>>::iterator it = hdl_ids_.begin();
+	     it != hdl_ids_.end();) {
+		m_server->close(it->first, websocketpp::close::status::going_away, "", ec);
+		it++;
+		// usleep(5000); // wait for session closing to terminate cleanl by handler.
+		// Or just count on the termination in the destrouctor
+		if (ec) {
+			logger_->log_info("WebServer:", " Error closing connection : : %s", ec.message().c_str());
+		}
+	}
 
-  while (!hdl_ids_.empty()) {
-    logger_->log_info("WebServer", "emptying hdls");
-    hdl_ids_.begin()->second->on_terminate(); // Should garanty the all sessions
-                                              // instanes went out of scope
-    hdl_ids_.erase(hdl_ids_.begin());
-  }
+	while (!hdl_ids_.empty()) {
+		logger_->log_info("WebServer", "emptying hdls");
+		hdl_ids_.begin()->second->on_terminate(); // Should garanty the all sessions
+		                                          // instanes went out of scope
+		hdl_ids_.erase(hdl_ids_.begin());
+	}
 
-  finalized_ = true;
+	finalized_ = true;
 }
 
 /** Called on when a connection is validated.
  * @param hdl websocket connection_hdl used to identify this session
  * @return true on succeeding
  */
-bool WebSocketServer::on_validate(connection_hdl hdl) {
+bool
+WebSocketServer::on_validate(connection_hdl hdl)
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return false;
+	}
 
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return false;
-  }
+	tmp_session_ = websocketpp::lib::make_shared<WebSession>();
+	tmp_session_->set_status("validating"); // todo::use status codes from websocketpp
 
-  tmp_session_ = websocketpp::lib::make_shared<WebSession>();
-  tmp_session_->set_status(
-      "validating"); // todo::use status codes from websocketpp
-
-  server::connection_ptr con = m_server->get_con_from_hdl(hdl);
-  return true;
+	server::connection_ptr con = m_server->get_con_from_hdl(hdl);
+	return true;
 }
 
 /** Called on establishment of a connection.
  * @param hdl websocket connection_hdl used to identify this session
  */
-void WebSocketServer::on_open(connection_hdl hdl) {
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return;
-  }
+void
+WebSocketServer::on_open(connection_hdl hdl)
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return;
+	}
 
-  tmp_session_->set_connection_hdl(hdl);
-  tmp_session_->set_endpoint(m_server);
-  tmp_session_->set_id(m_next_sessionid);
-  tmp_session_->set_status("open"); // todo::use status codes from websocketpp
+	tmp_session_->set_connection_hdl(hdl);
+	tmp_session_->set_endpoint(m_server);
+	tmp_session_->set_id(m_next_sessionid);
+	tmp_session_->set_status("open"); // todo::use status codes from websocketpp
 
-  hdl_ids_[hdl] = tmp_session_;
+	hdl_ids_[hdl] = tmp_session_;
 
-  m_server->get_con_from_hdl(hdl)->set_message_handler(
-      bind(&WebSocketServer::on_message, this, ::_1, ::_2));
+	m_server->get_con_from_hdl(hdl)->set_message_handler(
+	  bind(&WebSocketServer::on_message, this, ::_1, ::_2));
 
-  m_next_sessionid++;
-  // ForDebuging:: Print on http req
-  // for (std::map<std::string,std::string>::const_iterator i =
-  // tmp_session_->http_req.begin(); i != tmp_session_->http_req.end(); ++i)
-  // //std::cout<< i->first << "::::::" << i->second << std::endl;
+	m_next_sessionid++;
+	// ForDebuging:: Print on http req
+	// for (std::map<std::string,std::string>::const_iterator i =
+	// tmp_session_->http_req.begin(); i != tmp_session_->http_req.end(); ++i)
+	// //std::cout<< i->first << "::::::" << i->second << std::endl;
 
-  logger_->log_info("Webtools-Bridge:", "on open");
+	logger_->log_info("Webtools-Bridge:", "on open");
 }
 
 /** Called on closing of a connection.
  * @param hdl websocket connection_hdl used to identify this session
  */
-void WebSocketServer::on_close(connection_hdl hdl) {
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return;
-  }
+void
+WebSocketServer::on_close(connection_hdl hdl)
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return;
+	}
 
-  tmp_session_->set_status("close");
+	tmp_session_->set_status("close");
 
-  websocketpp::lib::error_code ec;
+	websocketpp::lib::error_code ec;
 
-  auto it = hdl_ids_.find(hdl);
+	auto it = hdl_ids_.find(hdl);
 
-  // TODO:: just do the termination if its there. do not throw and nothing
-  // otherwise
-  if (it == hdl_ids_.end()) {
-    // this connection is not in the list. This really shouldn't happen
-    // and probably means something else is wrong.
-    throw std::invalid_argument("No data available for session");
-  }
+	// TODO:: just do the termination if its there. do not throw and nothing
+	// otherwise
+	if (it == hdl_ids_.end()) {
+		// this connection is not in the list. This really shouldn't happen
+		// and probably means something else is wrong.
+		throw std::invalid_argument("No data available for session");
+	}
 
-  int session_id = it->second->get_id();
-  // TODO::replace by smarter registration mechanism
-  it->second->on_terminate();
+	int session_id = it->second->get_id();
+	// TODO::replace by smarter registration mechanism
+	it->second->on_terminate();
 
-  std::cout << "Closing connection  with sessionid " << session_id << std::endl;
+	std::cout << "Closing connection  with sessionid " << session_id << std::endl;
 
-  hdl_ids_.erase(hdl);
+	hdl_ids_.erase(hdl);
 }
 
 /** Finds the requesting sessions by its hdl.
@@ -218,23 +224,24 @@ void WebSocketServer::on_close(connection_hdl hdl) {
  * @param hdl websocket connection_hdl used to identify this session
  * @param web_msg ptr to the message
  */
-void WebSocketServer::on_message(
-    connection_hdl hdl,
-    websocketpp::server<websocketpp::config::asio>::message_ptr web_msg) {
-  MutexLocker ml(mutex_);
-  if (finalized_) {
-    return;
-  }
+void
+WebSocketServer::on_message(connection_hdl                                              hdl,
+                            websocketpp::server<websocketpp::config::asio>::message_ptr web_msg)
+{
+	MutexLocker ml(mutex_);
+	if (finalized_) {
+		return;
+	}
 
-  std::shared_ptr<WebSession> session = hdl_ids_[hdl];
+	std::shared_ptr<WebSession> session = hdl_ids_[hdl];
 
-  std::string jsonString = web_msg->get_payload();
+	std::string jsonString = web_msg->get_payload();
 
-  logger_->log_info("Webtools-Bridge", "Msg Received!");
+	logger_->log_info("Webtools-Bridge", "Msg Received!");
 
-  try {
-    bridge_manager_->incoming(jsonString, session);
-  } catch (fawkes::Exception &e) {
-    logger_->log_error("Webtools-Bridge", e);
-  }
+	try {
+		bridge_manager_->incoming(jsonString, session);
+	} catch (fawkes::Exception &e) {
+		logger_->log_error("Webtools-Bridge", e);
+	}
 }

--- a/src/plugins/webtools-bridge/websocket_server.h
+++ b/src/plugins/webtools-bridge/websocket_server.h
@@ -22,7 +22,6 @@
 
 #include <map>
 #include <memory>
-
 #include <websocketpp/common/thread.hpp>
 #include <websocketpp/config/asio_no_tls.hpp>
 #include <websocketpp/server.hpp>
@@ -36,45 +35,44 @@ class WebSession;
 class BridgeManager;
 
 #ifndef _SERVER
-#define _SERVER
+#	define _SERVER
 typedef websocketpp::server<websocketpp::config::asio> server;
 #endif
 
-class WebSocketServer {
+class WebSocketServer
+{
 public:
-  WebSocketServer(fawkes::Logger *logger,
-                  std::shared_ptr<BridgeManager> bridge_manager);
-  ~WebSocketServer();
+	WebSocketServer(fawkes::Logger *logger, std::shared_ptr<BridgeManager> bridge_manager);
+	~WebSocketServer();
 
-  void finalize();
+	void finalize();
 
-  bool on_validate(websocketpp::connection_hdl hdl);
-  void on_open(websocketpp::connection_hdl hdl);
-  void on_close(websocketpp::connection_hdl hdl);
-  void on_message(
-      websocketpp::connection_hdl hdl,
-      websocketpp::server<websocketpp::config::asio>::message_ptr web_msg);
+	bool on_validate(websocketpp::connection_hdl hdl);
+	void on_open(websocketpp::connection_hdl hdl);
+	void on_close(websocketpp::connection_hdl hdl);
+	void on_message(websocketpp::connection_hdl                                 hdl,
+	                websocketpp::server<websocketpp::config::asio>::message_ptr web_msg);
 
-  void run(uint16_t port);
+	void run(uint16_t port);
 
 private:
-  std::map<websocketpp::connection_hdl, std::shared_ptr<WebSession>,
-           std::owner_less<websocketpp::connection_hdl>>
-      hdl_ids_;
+	std::map<websocketpp::connection_hdl,
+	         std::shared_ptr<WebSession>,
+	         std::owner_less<websocketpp::connection_hdl>>
+	  hdl_ids_;
 
-  std::shared_ptr<websocketpp::lib::thread> m_thread;
-  std::shared_ptr<server> m_server;
-  std::shared_ptr<WebSession>
-      tmp_session_; // this only serve to collect the session data before
-                    // intializing the dispaticher
-  std::shared_ptr<BridgeManager> bridge_manager_;
+	std::shared_ptr<websocketpp::lib::thread> m_thread;
+	std::shared_ptr<server>                   m_server;
+	std::shared_ptr<WebSession> tmp_session_; // this only serve to collect the session data before
+	                                          // intializing the dispaticher
+	std::shared_ptr<BridgeManager> bridge_manager_;
 
-  fawkes::Logger *logger_;
-  fawkes::Mutex *mutex_;
+	fawkes::Logger *logger_;
+	fawkes::Mutex * mutex_;
 
-  unsigned int m_next_sessionid;
-  bool finalized_;
-  bool running_;
+	unsigned int m_next_sessionid;
+	bool         finalized_;
+	bool         running_;
 };
 
 #endif

--- a/src/plugins/webtools-bridge/webtools_bridge_plugin.cpp
+++ b/src/plugins/webtools-bridge/webtools_bridge_plugin.cpp
@@ -19,9 +19,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <core/plugin.h>
-
 #include "webtools_bridge_thread.h"
+
+#include <core/plugin.h>
 
 using namespace fawkes;
 
@@ -35,14 +35,16 @@ using namespace fawkes;
  *
  * @author Mostafa Gomaa
  */
-class WebtoolsBridgePlugin : public fawkes::Plugin {
+class WebtoolsBridgePlugin : public fawkes::Plugin
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param config Fawkes configuration
    */
-  WebtoolsBridgePlugin(Configuration *config) : Plugin(config) {
-    thread_list.push_back(new WebtoolsBridgeThread());
-  }
+	WebtoolsBridgePlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new WebtoolsBridgeThread());
+	}
 };
 
 PLUGIN_DESCRIPTION("webtools-bridge")

--- a/src/plugins/webtools-bridge/webtools_bridge_thread.cpp
+++ b/src/plugins/webtools-bridge/webtools_bridge_thread.cpp
@@ -21,16 +21,14 @@
 
 #include "webtools_bridge_thread.h"
 
-#include "bridge_manager.h"
-#include "websocket_server.h"
-
 #include "advertisment_capability_manager.h"
-#include "service_capability_manager.h"
-#include "subscription_capability_manager.h"
-
 #include "blackboard_processor.h"
+#include "bridge_manager.h"
 #include "clips_processor.h"
 #include "rosbridge_proxy_processor.h"
+#include "service_capability_manager.h"
+#include "subscription_capability_manager.h"
+#include "websocket_server.h"
 
 #include <string>
 
@@ -44,69 +42,77 @@ using namespace fawkes;
 
 /** Constructor. */
 WebtoolsBridgeThread::WebtoolsBridgeThread()
-    : Thread("BridgeThread", Thread::OPMODE_WAITFORWAKEUP),
-      BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE) {}
-
-WebtoolsBridgeThread::~WebtoolsBridgeThread() {}
-
-void WebtoolsBridgeThread::init() {
-  logger->log_info("Webtools-Bridge-thread", "initiating");
-
-  int rosbridge_port = config->get_int("/webtools-bridge/rosbridge-port");
-  bool in_simulation = config->get_bool("/clips-agent/rcll2016/enable-sim");
-
-  if (in_simulation) {
-    std::string server_bash =
-        "../src/plugins/webtools-bridge/./launch_server.bash -p " +
-        std::to_string(rosbridge_port);
-    if (system(server_bash.c_str()))
-      logger->log_error("Error running %s: %s", server_bash.c_str(),
-                        ::strerror(errno));
-    // Maybe wait a bit after starting the servers
-  }
-
-  bridge_manager_ = std::make_shared<BridgeManager>();
-
-  std::shared_ptr<SubscriptionCapabilityManager> subscription_cpm =
-      std::make_shared<SubscriptionCapabilityManager>();
-
-  std::shared_ptr<AdvertismentCapabilityManager> advertisment_cpm =
-      std::make_shared<AdvertismentCapabilityManager>();
-
-  std::shared_ptr<ServiceCapabilityManager> service_cpm =
-      std::make_shared<ServiceCapabilityManager>();
-
-  // register capability managers to the bridge under the operations they should
-  // handle
-  bridge_manager_->register_operation_handler("subscribe", subscription_cpm);
-  bridge_manager_->register_operation_handler("unsubscribe", subscription_cpm);
-
-  bridge_manager_->register_operation_handler("advertise", advertisment_cpm);
-  bridge_manager_->register_operation_handler("unadvertise", advertisment_cpm);
-  bridge_manager_->register_operation_handler("publish", advertisment_cpm);
-
-  bridge_manager_->register_operation_handler("call_service", service_cpm);
-
-  // register processors
-  bridge_manager_->register_processor(
-      std::make_shared<BridgeBlackBoardProcessor>("blackboard", logger, config,
-                                                  blackboard, clock));
-
-  bridge_manager_->register_processor(
-      std::make_shared<RosBridgeProxyProcessor>("/", logger, config, clock));
-
-  bridge_manager_->register_processor(std::make_shared<ClipsProcessor>(
-      "clips", logger, config, clock, clips_env_mgr));
-
-  try {
-    web_server_ =
-        websocketpp::lib::make_shared<WebSocketServer>(logger, bridge_manager_);
-    web_server_->run(config->get_int("/webtools-bridge/port"));
-  } catch (...) {
-    logger->log_warn(name(), " Wepsocekt Server crached");
-  }
+: Thread("BridgeThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE)
+{
 }
 
-void WebtoolsBridgeThread::finalize() {}
+WebtoolsBridgeThread::~WebtoolsBridgeThread()
+{
+}
 
-void WebtoolsBridgeThread::loop() {}
+void
+WebtoolsBridgeThread::init()
+{
+	logger->log_info("Webtools-Bridge-thread", "initiating");
+
+	int  rosbridge_port = config->get_int("/webtools-bridge/rosbridge-port");
+	bool in_simulation  = config->get_bool("/clips-agent/rcll2016/enable-sim");
+
+	if (in_simulation) {
+		std::string server_bash =
+		  "../src/plugins/webtools-bridge/./launch_server.bash -p " + std::to_string(rosbridge_port);
+		if (system(server_bash.c_str()))
+			logger->log_error("Error running %s: %s", server_bash.c_str(), ::strerror(errno));
+		// Maybe wait a bit after starting the servers
+	}
+
+	bridge_manager_ = std::make_shared<BridgeManager>();
+
+	std::shared_ptr<SubscriptionCapabilityManager> subscription_cpm =
+	  std::make_shared<SubscriptionCapabilityManager>();
+
+	std::shared_ptr<AdvertismentCapabilityManager> advertisment_cpm =
+	  std::make_shared<AdvertismentCapabilityManager>();
+
+	std::shared_ptr<ServiceCapabilityManager> service_cpm =
+	  std::make_shared<ServiceCapabilityManager>();
+
+	// register capability managers to the bridge under the operations they should
+	// handle
+	bridge_manager_->register_operation_handler("subscribe", subscription_cpm);
+	bridge_manager_->register_operation_handler("unsubscribe", subscription_cpm);
+
+	bridge_manager_->register_operation_handler("advertise", advertisment_cpm);
+	bridge_manager_->register_operation_handler("unadvertise", advertisment_cpm);
+	bridge_manager_->register_operation_handler("publish", advertisment_cpm);
+
+	bridge_manager_->register_operation_handler("call_service", service_cpm);
+
+	// register processors
+	bridge_manager_->register_processor(
+	  std::make_shared<BridgeBlackBoardProcessor>("blackboard", logger, config, blackboard, clock));
+
+	bridge_manager_->register_processor(
+	  std::make_shared<RosBridgeProxyProcessor>("/", logger, config, clock));
+
+	bridge_manager_->register_processor(
+	  std::make_shared<ClipsProcessor>("clips", logger, config, clock, clips_env_mgr));
+
+	try {
+		web_server_ = websocketpp::lib::make_shared<WebSocketServer>(logger, bridge_manager_);
+		web_server_->run(config->get_int("/webtools-bridge/port"));
+	} catch (...) {
+		logger->log_warn(name(), " Wepsocekt Server crached");
+	}
+}
+
+void
+WebtoolsBridgeThread::finalize()
+{
+}
+
+void
+WebtoolsBridgeThread::loop()
+{
+}

--- a/src/plugins/webtools-bridge/webtools_bridge_thread.h
+++ b/src/plugins/webtools-bridge/webtools_bridge_thread.h
@@ -47,18 +47,19 @@ class WebtoolsBridgeThread : public fawkes::Thread,
                              public fawkes::ConfigurableAspect,
                              public fawkes::BlackBoardAspect,
                              public fawkes::BlockedTimingAspect,
-                             public fawkes::CLIPSManagerAspect {
+                             public fawkes::CLIPSManagerAspect
+{
 public:
-  WebtoolsBridgeThread();
-  virtual ~WebtoolsBridgeThread();
+	WebtoolsBridgeThread();
+	virtual ~WebtoolsBridgeThread();
 
-  virtual void init();
-  virtual void loop();
-  virtual void finalize();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
 
 private:
-  std::shared_ptr<BridgeManager> bridge_manager_;
-  std::shared_ptr<WebSocketServer> web_server_;
+	std::shared_ptr<BridgeManager>   bridge_manager_;
+	std::shared_ptr<WebSocketServer> web_server_;
 };
 
 #endif

--- a/src/tools/gamectrl/gamectrl.cpp
+++ b/src/tools/gamectrl/gamectrl.cpp
@@ -21,12 +21,10 @@
  */
 
 #include <blackboard/remote.h>
-
 #include <core/threading/thread.h>
+#include <interfaces/SwitchInterface.h>
 #include <utils/system/argparser.h>
 #include <utils/system/signal.h>
-
-#include <interfaces/SwitchInterface.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -36,45 +34,48 @@
 
 using namespace fawkes;
 
-static void print_usage(const char *progname) {
-  printf("Usage: %s -r remote start|stop\n", progname);
+static void
+print_usage(const char *progname)
+{
+	printf("Usage: %s -r remote start|stop\n", progname);
 }
 
-int main(int argc, char **argv) {
-  ArgumentParser argp(argc, argv, "hr:");
+int
+main(int argc, char **argv)
+{
+	ArgumentParser argp(argc, argv, "hr:");
 
-  if (argp.has_arg("h") || argp.num_items() == 0) {
-    print_usage(argp.program_name());
-    exit(0);
-  }
+	if (argp.has_arg("h") || argp.num_items() == 0) {
+		print_usage(argp.program_name());
+		exit(0);
+	}
 
-  Thread::init_main();
+	Thread::init_main();
 
-  std::string host = "localhost";
-  unsigned short int port = 1910;
-  if (argp.has_arg("r")) {
-    argp.parse_hostport("r", host, port);
-  }
+	std::string        host = "localhost";
+	unsigned short int port = 1910;
+	if (argp.has_arg("r")) {
+		argp.parse_hostport("r", host, port);
+	}
 
-  BlackBoard *remote_bb = new RemoteBlackBoard(host.c_str(), port);
-  SwitchInterface *gamectrl_if =
-      remote_bb->open_for_writing<SwitchInterface>("Clips Agent Start");
+	BlackBoard *     remote_bb   = new RemoteBlackBoard(host.c_str(), port);
+	SwitchInterface *gamectrl_if = remote_bb->open_for_writing<SwitchInterface>("Clips Agent Start");
 
-  if (strcmp(argp.items()[0], "start") == 0) {
-    printf("Sending START to robot %s\n", host.c_str());
-    gamectrl_if->set_enabled(true);
-  } else if (strcmp(argp.items()[0], "start") == 0) {
-    printf("Sending STOP to robot %s\n", host.c_str());
-    gamectrl_if->set_enabled(false);
-  } else {
-    printf("Unknown command %s\n", argp.items()[0]);
-  }
-  gamectrl_if->write();
-  usleep(1000000);
-  remote_bb->close(gamectrl_if);
-  delete remote_bb;
+	if (strcmp(argp.items()[0], "start") == 0) {
+		printf("Sending START to robot %s\n", host.c_str());
+		gamectrl_if->set_enabled(true);
+	} else if (strcmp(argp.items()[0], "start") == 0) {
+		printf("Sending STOP to robot %s\n", host.c_str());
+		gamectrl_if->set_enabled(false);
+	} else {
+		printf("Unknown command %s\n", argp.items()[0]);
+	}
+	gamectrl_if->write();
+	usleep(1000000);
+	remote_bb->close(gamectrl_if);
+	delete remote_bb;
 
-  Thread::destroy_main();
+	Thread::destroy_main();
 
-  return 0;
+	return 0;
 }

--- a/src/tools/positionFaker/3dpositionFaker.cpp
+++ b/src/tools/positionFaker/3dpositionFaker.cpp
@@ -22,8 +22,11 @@
 
 #include <blackboard/remote.h>
 #include <core/threading/thread.h>
+#include <interfaces/Position3DInterface.h>
 #include <netcomm/fawkes/client.h>
 #include <netcomm/fawkes/client_handler.h>
+#include <readline/history.h>
+#include <readline/readline.h>
 #include <utils/system/argparser.h>
 #include <utils/system/signal.h>
 
@@ -36,221 +39,236 @@
 #include <string>
 #include <unistd.h>
 
-#include <readline/history.h>
-#include <readline/readline.h>
-
-#include <interfaces/Position3DInterface.h>
-
 using namespace fawkes;
 
-void print_usage(const char *program_name) {
-  printf("Usage: %s [-h] [-r host[:port]]\n"
-         " -h              This help message\n"
-         " -r host[:port]  Remote host (and optionally port) to connect to\n",
-         program_name);
+void
+print_usage(const char *program_name)
+{
+	printf("Usage: %s [-h] [-r host[:port]]\n"
+	       " -h              This help message\n"
+	       " -r host[:port]  Remote host (and optionally port) to connect to\n",
+	       program_name);
 }
 
-static int event_hook() { return 0; }
+static int
+event_hook()
+{
+	return 0;
+}
 
 /** Flite shell thread.
  * This thread opens a network connection to a host and uses a RemoteBlackBoard
  * connection to send commands to the flite-plugin
  * @author Tim Niemueller, Frederik Zwilling
  */
-class PositionFakerThread : public Thread, public FawkesNetworkClientHandler {
+class PositionFakerThread : public Thread, public FawkesNetworkClientHandler
+{
 public:
-  /** Constructor.
+	/** Constructor.
    * @param argp argument parser
    */
-  PositionFakerThread(ArgumentParser *argp)
-      : Thread("FliteShellThread", Thread::OPMODE_CONTINUOUS) {
-    this->argp = argp;
-    prompt = "-# ";
-    just_connected = true;
-    connection_died_recently = false;
+	PositionFakerThread(ArgumentParser *argp) : Thread("FliteShellThread", Thread::OPMODE_CONTINUOUS)
+	{
+		this->argp               = argp;
+		prompt                   = "-# ";
+		just_connected           = true;
+		connection_died_recently = false;
 
-    sif = NULL;
-    using_history();
-    // this is needed to get rl_done working
-    rl_event_hook = event_hook;
+		sif = NULL;
+		using_history();
+		// this is needed to get rl_done working
+		rl_event_hook = event_hook;
 
-    continuous = false;
+		continuous = false;
 
-    char *host = (char *)"localhost";
-    unsigned short int port = 1910;
-    bool free_host = argp->parse_hostport("r", &host, &port);
+		char *             host      = (char *)"localhost";
+		unsigned short int port      = 1910;
+		bool               free_host = argp->parse_hostport("r", &host, &port);
 
-    c = new FawkesNetworkClient(host, port);
+		c = new FawkesNetworkClient(host, port);
 
-    if (free_host)
-      free(host);
-    c->register_handler(this, FAWKES_CID_SKILLER_PLUGIN);
-    c->connect();
-  }
+		if (free_host)
+			free(host);
+		c->register_handler(this, FAWKES_CID_SKILLER_PLUGIN);
+		c->connect();
+	}
 
-  /** Destructor. */
-  ~PositionFakerThread() {
-    printf("Finalizing\n");
-    usleep(500000);
+	/** Destructor. */
+	~PositionFakerThread()
+	{
+		printf("Finalizing\n");
+		usleep(500000);
 
-    rbb->close(sif);
-    delete rbb;
-    rbb = NULL;
-    c->deregister_handler(FAWKES_CID_SKILLER_PLUGIN);
-    c->disconnect();
-    delete c;
-  }
+		rbb->close(sif);
+		delete rbb;
+		rbb = NULL;
+		c->deregister_handler(FAWKES_CID_SKILLER_PLUGIN);
+		c->disconnect();
+		delete c;
+	}
 
-  virtual void loop() {
-    if (c->connected()) {
-      if (just_connected) {
-        just_connected = false;
-        try {
-          rbb = new RemoteBlackBoard(c);
-          sif = rbb->open_for_writing<Position3DInterface>("Light");
-          poseInterface = rbb->open_for_writing<Position3DInterface>("Pose");
-          usleep(100000);
-        } catch (Exception &e) {
-          e.print_trace();
-          return;
-        }
-      }
+	virtual void
+	loop()
+	{
+		if (c->connected()) {
+			if (just_connected) {
+				just_connected = false;
+				try {
+					rbb           = new RemoteBlackBoard(c);
+					sif           = rbb->open_for_writing<Position3DInterface>("Light");
+					poseInterface = rbb->open_for_writing<Position3DInterface>("Pose");
+					usleep(100000);
+				} catch (Exception &e) {
+					e.print_trace();
+					return;
+				}
+			}
 
-      if (argp->num_items() > 0) {
-        std::string sks = "";
-        const std::vector<const char *> &items = argp->items();
+			if (argp->num_items() > 0) {
+				std::string                      sks   = "";
+				const std::vector<const char *> &items = argp->items();
 
-        std::vector<const char *>::const_iterator i = items.begin();
-        sks = *i;
-        ++i;
-        for (; i != items.end(); ++i) {
-          sks += " ";
-          sks += *i;
-        }
+				std::vector<const char *>::const_iterator i = items.begin();
+				sks                                         = *i;
+				++i;
+				for (; i != items.end(); ++i) {
+					sks += " ";
+					sks += *i;
+				}
 
-        usleep(100000);
-        exit();
-      } else {
-        char *lineX = NULL;
-        char *lineY = NULL;
-        char *lineXPos = NULL;
-        char *lineYPos = NULL;
+				usleep(100000);
+				exit();
+			} else {
+				char *lineX    = NULL;
+				char *lineY    = NULL;
+				char *lineXPos = NULL;
+				char *lineYPos = NULL;
 
-        printf("Enter Light x: ");
-        lineX = readline(prompt);
-        printf("Enter Light y: ");
-        lineY = readline(prompt);
-        printf("Enter Pose x: ");
-        lineXPos = readline(prompt);
-        printf("Enter Pose y: ");
-        lineYPos = readline(prompt);
-        if (lineX && lineY) {
-          if (strcmp(lineX, "") != 0) {
+				printf("Enter Light x: ");
+				lineX = readline(prompt);
+				printf("Enter Light y: ");
+				lineY = readline(prompt);
+				printf("Enter Pose x: ");
+				lineXPos = readline(prompt);
+				printf("Enter Pose y: ");
+				lineYPos = readline(prompt);
+				if (lineX && lineY) {
+					if (strcmp(lineX, "") != 0) {
+						std::stringstream sstr1;
+						std::stringstream sstr2;
+						std::stringstream sstr3;
+						std::stringstream sstr4;
+						double            x, y, xPos, yPos;
+						sstr1 << lineX;
+						sstr1 >> x;
+						sstr2 << lineY;
+						sstr2 >> y;
+						sstr3 << lineXPos;
+						sstr3 >> xPos;
+						sstr4 << lineYPos;
+						sstr4 >> yPos;
+						printf("Light: %f, %f \n", x, y);
+						printf("Pos: %f, %f \n", xPos, yPos);
 
-            std::stringstream sstr1;
-            std::stringstream sstr2;
-            std::stringstream sstr3;
-            std::stringstream sstr4;
-            double x, y, xPos, yPos;
-            sstr1 << lineX;
-            sstr1 >> x;
-            sstr2 << lineY;
-            sstr2 >> y;
-            sstr3 << lineXPos;
-            sstr3 >> xPos;
-            sstr4 << lineYPos;
-            sstr4 >> yPos;
-            printf("Light: %f, %f \n", x, y);
-            printf("Pos: %f, %f \n", xPos, yPos);
+						double translation[3];
+						translation[0] = x;
+						translation[1] = y;
+						translation[2] = 0.0;
+						double translationPos[3];
+						translationPos[0] = xPos;
+						translationPos[1] = yPos;
+						translationPos[2] = 0.0;
+						sif->set_translation(translation);
+						poseInterface->set_translation(translationPos);
+						sif->write();
+						poseInterface->write();
+					}
+				} else {
+					if (!connection_died_recently) {
+						exit();
+					}
+				}
+			}
+		} else {
+			if (connection_died_recently) {
+				connection_died_recently = false;
+				printf("Connection died\n");
+				c->disconnect();
+			}
+			try {
+				c->connect();
+			} catch (Exception &e) {
+				printf(".");
+				fflush(stdout);
+				sleep(1);
+			}
+		}
+	}
 
-            double translation[3];
-            translation[0] = x;
-            translation[1] = y;
-            translation[2] = 0.0;
-            double translationPos[3];
-            translationPos[0] = xPos;
-            translationPos[1] = yPos;
-            translationPos[2] = 0.0;
-            sif->set_translation(translation);
-            poseInterface->set_translation(translationPos);
-            sif->write();
-            poseInterface->write();
-          }
-        } else {
-          if (!connection_died_recently) {
-            exit();
-          }
-        }
-      }
-    } else {
-      if (connection_died_recently) {
-        connection_died_recently = false;
-        printf("Connection died\n");
-        c->disconnect();
-      }
-      try {
-        c->connect();
-      } catch (Exception &e) {
-        printf(".");
-        fflush(stdout);
-        sleep(1);
-      }
-    }
-  }
+	virtual void
+	deregistered(unsigned int id) throw()
+	{
+	}
 
-  virtual void deregistered(unsigned int id) throw() {}
+	virtual void
+	inbound_received(FawkesNetworkMessage *m, unsigned int id) throw()
+	{
+	}
 
-  virtual void inbound_received(FawkesNetworkMessage *m,
-                                unsigned int id) throw() {}
+	virtual void
+	connection_died(unsigned int id) throw()
+	{
+		prompt = "-# ";
 
-  virtual void connection_died(unsigned int id) throw() {
-    prompt = "-# ";
+		rbb->close(sif);
+		delete rbb;
+		rbb = NULL;
+		sif = NULL;
 
-    rbb->close(sif);
-    delete rbb;
-    rbb = NULL;
-    sif = NULL;
+		connection_died_recently = true;
 
-    connection_died_recently = true;
+		// fprintf(stdin, "\n");
+		// kill(SIGINT);
+		rl_done = 1;
+	}
 
-    // fprintf(stdin, "\n");
-    // kill(SIGINT);
-    rl_done = 1;
-  }
-
-  virtual void connection_established(unsigned int id) throw() {
-    printf("Connection established\n");
-    just_connected = true;
-    prompt = "+# ";
-  }
+	virtual void
+	connection_established(unsigned int id) throw()
+	{
+		printf("Connection established\n");
+		just_connected = true;
+		prompt         = "+# ";
+	}
 
 private:
-  ArgumentParser *argp;
-  FawkesNetworkClient *c;
-  BlackBoard *rbb;
-  Position3DInterface *sif, *poseInterface;
-  const char *prompt;
-  bool just_connected;
-  bool connection_died_recently;
+	ArgumentParser *     argp;
+	FawkesNetworkClient *c;
+	BlackBoard *         rbb;
+	Position3DInterface *sif, *poseInterface;
+	const char *         prompt;
+	bool                 just_connected;
+	bool                 connection_died_recently;
 
-  bool continuous;
+	bool continuous;
 };
 
 /** Config tool main.
  * @param argc argument count
  * @param argv arguments
  */
-int main(int argc, char **argv) {
-  ArgumentParser argp(argc, argv, "hr:");
+int
+main(int argc, char **argv)
+{
+	ArgumentParser argp(argc, argv, "hr:");
 
-  if (argp.has_arg("h")) {
-    print_usage(argv[0]);
-    exit(0);
-  }
+	if (argp.has_arg("h")) {
+		print_usage(argv[0]);
+		exit(0);
+	}
 
-  PositionFakerThread sst(&argp);
-  sst.start();
-  sst.join();
+	PositionFakerThread sst(&argp);
+	sst.start();
+	sst.join();
 
-  return 0;
+	return 0;
 }


### PR DESCRIPTION
So guess what, after putting our `.clang-format` into my IDE, I started wondering why it kept formatting things differently. Turns out that fawkes-robotino hasn't been using our format, but the default one. The differences are subtle enough to only become visible if tab sizes differ or your editor visualizes whitespace. Particularly all those nice smart tabs aren't in the default format.

I'm not saying we should actually merge this now, just putting this out there. Oh, and `fawkes/.clang-format` should of course be symlinked to `fawkes-robotino/.clang-format`. Or copied, or whatever ;-)