### PR TITLE
skills: check which subskill failed and set error field

### DIFF
--- a/src/lua/skills/robotino/bring_product_to.lua
+++ b/src/lua/skills/robotino/bring_product_to.lua
@@ -94,6 +94,13 @@ function DRIVE_TO_MACHINE_POINT:init()
    end
 end
 
+function DRIVE_TO_MACHINE_POINT:exit()
+  local dtmp_fsm = skillenv.get_skill_fsm("drive_to_machine_point")
+  if dtmp_fsm.current == dtmp_fsm.states[dtmp_fsm.fail_state] then
+    self.fsm:set_error("Drive To Machine Point Failed")
+  end
+end
+
 function CONVEYOR_ALIGN:init()
     if (self.fsm.vars.slide == nil) then
       self.args["conveyor_align"].disable_realsense_afterwards = false
@@ -104,9 +111,23 @@ function CONVEYOR_ALIGN:init()
     self.args["conveyor_align"].slide = self.fsm.vars.slide
 end
 
+function CONVEYOR_ALIGN:exit()
+  local cv_fsm = skillenv.get_skill_fsm("conveyor_align")
+  if cv_fsm.current == cv_fsm.states[cv_fsm.fail_state] then
+    self.fsm:set_error("Conveyor Align Failed")
+  end
+end
 
 function PRODUCT_PUT:init()
   self.args["product_put"].place = self.fsm.vars.place
   self.args["product_put"].slide = self.fsm.vars.slide
   self.args["product_put"].side = self.fsm.vars.side
 end
+
+function PRODUCT_PUT:exit()
+  local pp_fsm = skillenv.get_skill_fsm("product_put")
+  if pp_fsm.current == pp_fsm.states[pp_fsm.fail_state] then
+    self.fsm:set_error("Product Put Failed")
+  end
+end
+

--- a/src/lua/skills/robotino/get_product_from.lua
+++ b/src/lua/skills/robotino/get_product_from.lua
@@ -101,8 +101,36 @@ function DRIVE_TO_MACHINE_POINT:init()
    end
 end
 
+function DRIVE_TO_MACHINE_POINT:exit()
+  local dtmp_fsm = skillenv.get_skill_fsm("drive_to_machine_point")
+  if dtmp_fsm.current == dtmp_fsm.states[dtmp_fsm.fail_state] then
+    self.fsm:set_error("Drive To Machine Point Failed")
+  end
+end
+
+function PRODUCT_PICK:init()
+  self.args["product_pick"].place = self.fsm.vars.place
+  self.args["product_pick"].side = self.fsm.vars.side
+  self.args["product_pick"].slide = self.fsm.vars.slide
+  self.args["product_pick"].shelf = self.fsm.vars.shelf
+end
+
+function PRODUCT_PICK:exit()
+  local pp_fsm = skillenv.get_skill_fsm("product_pick")
+  if pp_fsm.current == pp_fsm.states[pp_fsm.fail_state] then
+    self.fsm:set_error("Product Pick Failed")
+  end
+end
+
 function SHELF_PICK:init()
   self.args["shelf_pick"].slot = self.fsm.vars.shelf
+end
+
+function SHELF_PICK:exit()
+  local sp_fsm = skillenv.get_skill_fsm("shelf_pick")
+  if sp_fsm.current == sp_fsm.states[sp_fsm.fail_state] then
+    self.fsm:set_error("Shelf Pick Failed")
+  end
 end
 
 function CONVEYOR_ALIGN:init()
@@ -120,4 +148,11 @@ function CONVEYOR_ALIGN:init()
      self.args["conveyor_align"].slide = self.fsm.vars.slide
    end
 
+end
+
+function CONVEYOR_ALIGN:exit()
+  local cv_fsm = skillenv.get_skill_fsm("conveyor_align")
+  if cv_fsm.current == cv_fsm.states[cv_fsm.fail_state] then
+    self.fsm:set_error("Conveyor Align Failed")
+  end
 end


### PR DESCRIPTION
When exiting a SkillJumpState, check the state of the subskill.
If it is failed, set the error of the current skill to something that
indicates the failed subskill. This is then published via the SkillerInterface,
enabling the agent to check the reason for an action failure.