### PR TITLE
Calibrating the gripper after putting a product

### DIFF
--- a/src/lua/skills/robotino/product_put.lua
+++ b/src/lua/skills/robotino/product_put.lua
@@ -128,10 +128,10 @@ fsm:define_states{ export_to=_M,
   {"MOVE_GRIPPER_FORWARD", SkillJumpState, skills={{gripper_commands}}, final_to="OPEN_GRIPPER",fail_to="FAILED"},
   {"OPEN_GRIPPER", SkillJumpState, skills={{gripper_commands}}, final_to="MOVE_GRIPPER_BACK", fail_to="FAILED"},
   {"MOVE_GRIPPER_BACK", SkillJumpState, skills={{gripper_commands}}, final_to = "CLOSE_GRIPPER", fail_to="FAILED"},
-  {"CLOSE_GRIPPER", SkillJumpState, skills={{gripper_commands}}, final_to="DRIVE_BACK", fail_to="FAILED"},
-  {"DRIVE_BACK", SkillJumpState, skills={{motor_move}}, final_to="CALIBRATE_GRIPPER", fail_to="FAILED"},
+  {"CLOSE_GRIPPER", SkillJumpState, skills={{gripper_commands}}, final_to="CALIBRATE_GRIPPER", fail_to="FAILED"},
   {"CALIBRATE_GRIPPER", SkillJumpState, skills={{gripper_commands}}, final_to="GRIPPER_HOME", fail_to="FAILED"},
-  {"GRIPPER_HOME", SkillJumpState, skills={{gripper_commands}}, final_to="FINAL", fail_to="FAILED"}
+  {"GRIPPER_HOME", SkillJumpState, skills={{gripper_commands}}, final_to="DRIVE_BACK", fail_to="FAILED"}
+  {"DRIVE_BACK", SkillJumpState, skills={{motor_move}}, final_to="FINAL", fail_to="FAILED"},
 }
 
 fsm:add_transitions{


### PR DESCRIPTION
This calibrates and homes the gripper in `product_put`. It accounts for lost steps while putting a product as mentioned in #104.
Time is not lost, as all the movements will be done while the bot is moving to its next task.
