### PR TITLE
cfg: add moving average config value

### DIFF
--- a/cfg/conf.d/robotino.yaml
+++ b/cfg/conf.d/robotino.yaml
@@ -168,3 +168,9 @@ hardware/robotino:
     # Currently not implemented
     # current-max: 1
     # current-max-time: 400
+
+
+  digital:
+    # Number of samples used for moving average
+    # of the digital_in filter
+    moving_average: 10


### PR DESCRIPTION
Adds a config value to determine the number of samples used for the moving average on the digital_in input. This is used for the puck check