### PR TITLE
buildsys: override 'check' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ include $(BASEDIR)/etc/buildsys/config.mk
 include $(BUILDSYSDIR)/rules.mk
 include $(BUILDSYSDIR)/root/root.mk
 include $(BUILDSYSDIR)/root/linkscripts.mk
+include $(BASEDIR)/etc/buildsys/override.mk
 
 src: fawkes
 

--- a/etc/buildsys/override.mk
+++ b/etc/buildsys/override.mk
@@ -1,0 +1,5 @@
+.PHONY: check
+check:
+check: quickdoc $(if $(subst 0,,$(YAMLLINT)),yamllint) license-check
+	$(SILENT)touch $(BASEDIR)/.check_stamp
+


### PR DESCRIPTION
This removes the format check from 'make check' by adding an override.mk
that redefines the 'check' target.