### PR TITLE
Higher acceleration limits for Robotino

### DIFF
--- a/cfg/conf.d/robotino.yaml
+++ b/cfg/conf.d/robotino.yaml
@@ -93,12 +93,12 @@ hardware/robotino:
       gear: 32.0
 
     # Maximum acceleration and deceleration for translation, m/s^2
-    trans-acceleration: 0.4
-    trans-deceleration: 1.0
+    trans-acceleration: 0.8
+    trans-deceleration: 1.5
 
     # Maximum acceleration and deceleration for rotation, rad/s^2
-    rot-acceleration: 1.6
-    rot-deceleration: 1.6
+    rot-acceleration: 2.5
+    rot-deceleration: 3.14
 
   bumper:
     # Set to true to enable the emergency stop on bumper contact (provided


### PR DESCRIPTION
As the head of the robotino is more lightweight than before we can again
setup a higher overall acceleration.