### PR TITLE
buildsys: override format target as well

### DIFF
--- a/etc/buildsys/override.mk
+++ b/etc/buildsys/override.mk
@@ -3,3 +3,6 @@ check:
 check: quickdoc $(if $(subst 0,,$(YAMLLINT)),yamllint) license-check
 	$(SILENT)touch $(BASEDIR)/.check_stamp
 
+.PHONY: format-check-branch
+format-check-branch:
+	$(SILENT)true


### PR DESCRIPTION
For some unclear reason, the format-check-branch target is still
called later by 'make check', even if the check target is overridden.
Override the format-check-branch target itself seems to disable it for
good.