### PR TITLE
Allow host specific pushable config files

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -5,7 +5,9 @@
 include:
   # reads files ending in .yaml from modules.d config subdir
   - !ignore-missing conf.d/
-  # reads host-specific config files from host.d subdir
+  # Reads host-specific config files from host_$host.d subdir
+  # $host is replaced by the hostname, thus robotino-(laptop/base)-(1/2/3)
+  # e.g. host_robotino-laptop-1.d
   - !ignore-missing host_$host.d/
   # Reads first host specific config file, this file is treated as normal
   # config file by the fawkes framework


### PR DESCRIPTION
In several occasions it would be useful to push host specific host.yaml files.
Until now, this was not possible as the host specific config file was named equally for all hosts.

This PR bases on PR [#107](https://github.com/fawkesrobotics/fawkes/pull/107) of the core repo, which introduces the necessary changes to load pushable host specific config files. This PR itself only modifies the main config file to actually load the host specific config file. 

CAREFUL!: This should not be merged before PR [#107](https://github.com/fawkesrobotics/fawkes/pull/107) of the core repo is merged, as it will otherwise lead to using `host_<>.yaml` as host specific config file.