### PR TITLE
unclutter tag-vision index interface

### DIFF
--- a/src/plugins/tag_vision/tag_position_interface_helper.h
+++ b/src/plugins/tag_vision/tag_position_interface_helper.h
@@ -38,7 +38,7 @@
 
 #define EMPTY_INTERFACE_MARKER_ID 0
 #define CHILD_FRAME "/tag_"
-#define INTERFACE_UNSEEN_BOUND -100
+#define INTERFACE_UNSEEN_BOUND -5
 
 class TagPositionInterfaceHelper {
   enum ROT { X = 0, Y = 1, Z = 2, W = 3 };


### PR DESCRIPTION
As seen at the GO 2019, the pruning threshold of -1000 for the `tag-vision/info` interface is much too low. This PR drastically increases it to -5 so that invisible tags get pruned much faster. The underlying problem is that new tags are discarded if there is no unused interface to store them. That might also be fixed generally, but ensuring that there's always an unused interface is just as good a solution. We can reasonably expect that there aren't more than 16 tags visible at any given time IFF we prune reasonably fast.