### PR TITLE
cx: switch bs and cs priority for getting wps for slides

### DIFF
--- a/src/clips-specs/rcll2018/goal-production.clp
+++ b/src/clips-specs/rcll2018/goal-production.clp
@@ -34,8 +34,8 @@
   ?*PRIORITY-CLEAR-CS* = 70
   ?*PRIORITY-CLEAR-RS* = 55
   ?*PRIORITY-PREFILL-CS* = 50 ;This priority can be increased by +1
-  ?*PRIORITY-PREFILL-RS* = 40 ;This priority can be increased by up to +4
-  ?*PRIORITY-PREFILL-RS-WITH-FRESH-BASE* = 30
+  ?*PRIORITY-PREFILL-RS-WITH-FRESH-BASE* = 40
+  ?*PRIORITY-PREFILL-RS* = 30 ;This priority can be increased by up to +4
   ?*PRIORITY-ADD-ADDITIONAL-RING-WAITING* = 20
   ?*PRIORITY-DISCARD-UNKNOWN* = 10
   ?*PRIORITY-WAIT* = 2


### PR DESCRIPTION
The agent used to get workpieces from the shelf to fill the RS slides if there is nothing else to do. Only if both cap stations are not usable, the agent would get a base from the base station to fill a ring station. 

However, as we saw at the German Open this leads to a high workload a the cap stations which delayed the production of actual orders. Thus, this PR switches the priority of getting a workpiece from the shelf and from the base station