### PR TITLE
Arduino: Use endstop

### DIFF
--- a/src/plugins/arduino/ArduinoSketch/fawkes_plugin_comm.ino
+++ b/src/plugins/arduino/ArduinoSketch/fawkes_plugin_comm.ino
@@ -434,14 +434,8 @@ void read_package() {
         }
         break;
       case CMD_CLOSE:
-        check_gripper_status();
-        if(open_gripper){
-          open_gripper = false;
-          set_new_rel_pos(-a_toggle_steps,motor_A);
-        } else {
-          send_status();
-          send_status();
-        }
+        open_gripper = false;
+        set_new_rel_pos(-a_toggle_steps,motor_A);
         break;
       case CMD_STATUS_REQ:
         send_status();


### PR DESCRIPTION
In the arduino firmware the endstop was not used anymore. Instead, the gripper was assumed to be open in the beginning, and could only be toggled. This means, that absolutely no feedback was used.

As example: When the gripper was assumed to be open, only the command CLOSE had effect, the OPEN command was just ignored.

Unfortunately, the gripper finger's movement was not as reliable as anticipated. Sometimes, the fingers would not open eventhough the command OPEN was sent, and the closed state was assumed. Consequently, opening the gripper fingers afterwards was not possible anymore without virtually closing the before.

This PR introduces changes to use the endstop of the gripper fingers again. If the endstop is pressed, the gripper fingers are safely assumed to be open and the OPEN command is ignore, while the CLOSE command is executed.
When the endstop is not triggered, both commands are executed, as one can not safely assume the gripper to be open or closed.