### PR TITLE
Arduino: Repeat calibration if failed

### DIFF
--- a/src/plugins/arduino/ArduinoSketch/fawkes_plugin_comm.ino
+++ b/src/plugins/arduino/ArduinoSketch/fawkes_plugin_comm.ino
@@ -210,13 +210,12 @@ void double_calibrate()
 
 void calibrate()
 {
-  bool x_done, y_done, z_done;
+  bool x_done = false, y_done = false, z_done = false;
   do { //repeat calibration as long as not successfull
-    x_done = y_done = z_done = false;
     motor_X.enableOutputs();
-    motor_X.move(10000L);
-    motor_Y.move(10000L);
-    motor_Z.move(10000L);
+    if(!x_done) motor_X.move(10000L);
+    if(!y_done) motor_Y.move(10000L);
+    if(!z_done) motor_Z.move(10000L);
     // due to high step count, reaching end stops is guaranteed!
     set_status(STATUS_MOVING); // status is always only changed on no interrupt code level, hence no race condition occurs here
     // This while loop controls permanently the state of the respective end stops and handles crashing into them


### PR DESCRIPTION
Sometimes, gripper calibration can fail due to stalling of the motor or even moving into the wrong direction. (see [#14 (hardware)](https://github.com/carologistics/hardware/issues/14))

This PR includes changes to repeat the calibration automatically when the end stops were not reached in the maximum amount of steps needed to move the axis along its complete range.