### PR TITLE
Remove resource lock from bs and add resource lock of cc to FILL-CAP

### DIFF
--- a/src/clips-specs/rcll2018/goal-production.clp
+++ b/src/clips-specs/rcll2018/goal-production.clp
@@ -347,7 +347,7 @@
                         mps ?mps
                         cc ?cc
                 )
-                (required-resources ?mps)
+                (required-resources ?cc ?mps)
   ))
 )
 
@@ -447,7 +447,7 @@
                         wp ?wp
                         side ?side
                 )
-                (required-resources ?mps ?wp)
+                (required-resources ?wp)
   ))
 )
 


### PR DESCRIPTION
This PR removes the resource locks on the base station, because they have no internal state that would require to lock it as resource. Additionally the resource lock on the capcarrier is added to FILL-CAP goals as such goals change its position and cap status.