### PR TITLE
CX: reject goals that potentially delay the production of complex products

### DIFF
--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -532,9 +532,13 @@
   (declare (salience ?*SALIENCE-GOAL-REJECT*))
   (domain-obj-is-of-type ?mps mps)
   (goal (id ?goal) (parent ?parent) (type ACHIEVE)
-              (sub-type SIMPLE) (class PRODUCE-CX|MOUNT-NEXT-RING|MOUNT-FIRST-RING)
-              (required-resources $? ?mps $?) (mode FORMULATED))
-  ?g <- (goal (id ?o-goal&~?goal) (class ~PRODUCE-CX&~MOUNT-NEXT-RING&~MOUNT-FIRST-RING)
+        (sub-type SIMPLE) (class PRODUCE-CX
+                                |MOUNT-NEXT-RING
+                                |MOUNT-FIRST-RING)
+        (required-resources $? ?mps $?) (mode FORMULATED))
+  ?g <- (goal (id ?o-goal&~?goal) (class ~PRODUCE-CX
+                                        &~MOUNT-NEXT-RING
+                                        &~MOUNT-FIRST-RING)
               (sub-type SIMPLE) (parent ?o-parent) (mode FORMULATED)
               (required-resources $? ?mps $?))
   (goal (id ?o-parent) (class ~URGENT))


### PR DESCRIPTION
This PR adds a rule that, given a formulated goal that performs a production step of a complex product, rejects all other (non urgent) formulated goals that require a resource that is also needed for said production step.

I think this is a good idea in general, however it is debatable whether we determine the important production steps by
1. the goal class of the leaf goals,
2. the class of some ancestor in the tree
3. dynmaic decisions based on points (current value of the product, expected value in the future/on delivery...).
4. Something else i have not thought of yet

Option 1 is how it is currently done, the second option would require changes to the production tree as currently C0 and CX related goals share the same parents. Option 3 is not possible yet but is probably required in the long run.  Between 1. and 2. it boils down to the question whether the atomic production steps or the goal tree structure is more likely to be subject of future changes. However since 3. would invalidate 2. again (because dynamic decisions may be independent of the complexity) i guess the current solution is fine for now and should be revisited once we can make more elaborate decisions based on production points.