### PR TITLE
cx: disable bots via config value

### DIFF
--- a/cfg/conf.d/clips-executive.yaml
+++ b/cfg/conf.d/clips-executive.yaml
@@ -231,7 +231,7 @@ clips-executive:
 
           competitive-order-priority: DEFAULT
 
-          # Robots listed here will only formulate waiting goals in the
-          # production phase (allowed values: "R-1", "R-2" and "R-3")
+          # Bots that are enabled can formulate production goals,
+          # disabled bots only formulate wait goals
 
-          disabled-bots: []
+          enable-bot: true

--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -159,15 +159,10 @@
   (declare (salience ?*SALIENCE-GOAL-EXPAND*))
   (goal (id ?goal-id) (class PRODUCTION-MAINTAIN) (mode SELECTED))
   (not (goal (parent ?goal-id)))
-  (wm-fact (key config rcll disabled-bots) (values $?disabled))
-  (wm-fact (key domain fact self args? r ?robot))
+  (wm-fact (key config rcll enable-bot) (value ?enabled))
 =>
-  (if (member$ (str-cat ?robot) ?disabled)
+  (if ?enabled
     then
-      (goal-tree-assert-subtree ?goal-id
-        (goal-tree-assert-run-one PRODUCTION-SELECTOR
-            (goal-tree-assert-run-one NO-PROGRESS)))
-    else
       (goal-tree-assert-subtree ?goal-id
         (goal-tree-assert-run-one PRODUCTION-SELECTOR
           (goal-tree-assert-run-one URGENT)
@@ -178,6 +173,10 @@
               (goal-tree-assert-run-one CLEAR)
               (goal-tree-assert-run-one PREPARE-CAPS)
               (goal-tree-assert-run-one PREPARE-RINGS))
+            (goal-tree-assert-run-one NO-PROGRESS)))
+    else
+      (goal-tree-assert-subtree ?goal-id
+        (goal-tree-assert-run-one PRODUCTION-SELECTOR
             (goal-tree-assert-run-one NO-PROGRESS)))
   )
 )


### PR DESCRIPTION
This PR adds a configurable list where robot names can be written in order to disable them. Disabled bots still play the exploration phase but only formulate wait goals in the production phase.