### PR TITLE
Adapt laser filters to new front laser position

### DIFF
--- a/cfg/conf.d/laser-filter.yaml
+++ b/cfg/conf.d/laser-filter.yaml
@@ -82,8 +82,8 @@ plugins/laser-filter:
       2-sector:
         # Ignore a defined range of beams (e.g. those hitting the robot itself)
         type: circle_sector
-        from: 235
-        to: 125
+        from: 255
+        to: 110
 
   filter-back-360:
     active: true
@@ -134,8 +134,8 @@ plugins/laser-filter:
       2-sector:
         # Ignore a defined range of beams (e.g. those hitting the robot itself)
         type: circle_sector
-        from: 705
-        to: 375
+        from: 765
+        to: 335
 
   filter-back-1080:
     active: false


### PR DESCRIPTION
This PR updates the front laser filters to consider the new laser position which is now closer to the robot's middle point.
We have to widen the range due to more beams being blocked by the robot itself.