### PR TITLE
Add Realsense Switch Param to Conveyor Pose Config

### DIFF
--- a/cfg/conf.d/conveyor_pose.yaml
+++ b/cfg/conf.d/conveyor_pose.yaml
@@ -9,6 +9,10 @@ plugins/conveyor_pose:
   # - the switch if is ignored, the plugin is always running
   debug: false
 
+  # sets the switch interface the plugin is waiting for before
+  # starting the plugin
+  realsense_switch: "realsense"
+
   # forces ConveyorPosePlugin to think its MPS_TARGET is a shelf
   # This works only in debug mode, as its usage is intended to simplify
   # debugging of shelf specific code


### PR DESCRIPTION
The Realsense Switch param was not defined in the config.
In the Conveyor pose get_config_or_default with "realsense" is used.
Since we now have 2 different realsense Interfaces this parameter should be inside the config file