### PR TITLE
CX prepare action fixes: finish on processed and fail on broken

### DIFF
--- a/src/clips-specs/rcll2018/refbox-actions.clp
+++ b/src/clips-specs/rcll2018/refbox-actions.clp
@@ -233,6 +233,20 @@
 	(modify ?pa (state EXECUTION-FAILED))
 )
 
+(defrule refbox-action-prepare-mps-abort-on-broken
+  "Abort preparing if the mps got broken"
+  ?pa <- (plan-action (plan-id ?plan-id) (id ?id) (state RUNNING)
+                          (action-name prepare-bs|prepare-cs|prepare-ds|prepare-rs))
+  ?at <- (timer (name prepare-mps-abort-timer))
+  ?st <- (timer (name prepare-mps-send-timer))
+  ?md <- (metadata-prepare-mps ?mps $?date)
+  (wm-fact (key domain fact mps-state args? m ?mps s BROKEN))
+  =>
+  (printout t "Action Prepare " ?mps " is Aborted because mps is broken" crlf)
+  (retract ?st ?md ?at)
+  (modify ?pa (state EXECUTION-FAILED))
+)
+
 (defrule refbox-action-prepare-mps-abort
 	"Abort preparing and fail the action if took too long"
 	(time $?now)


### PR DESCRIPTION
The prepare action used to final only on processing,ready-at-output and prepared. However, with the current changes of the refbox and mps software, the bs jumps quit fast from prepared to processed, which led to the BS recieving to many prepare messages and thus breaks.

This PR let the prepare action also final on PROCESSED.
On the way, if the station switches to BROKEN, we want to abort the prepare action directly