### PR TITLE
cx: let unlock actions succeed if mutex state is OPEN

### DIFF
--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -251,7 +251,7 @@
 " React to a successful unlock of an location by removing the corresponding location-locked domain-fact"
   (declare (salience ?*SALIENCE-GOAL-PRE-EVALUATE*))
   ?p <- (goal-reasoner-unlock-pending ?lock)
-  ?m <- (mutex (name ?lock) (request UNLOCK) (response UNLOCKED))
+  ?m <- (mutex (name ?lock) (request UNLOCK) (state OPEN))
   ?df <- (domain-fact (name location-locked) (param-values ?mps ?side))
   (test (not (eq FALSE (str-index (str-cat ?mps) (str-cat ?lock)))))
   (test (not (eq FALSE (str-index (str-cat ?side) (str-cat ?lock)))))
@@ -266,7 +266,7 @@
 " React to a successful unlock of a lock by removing the corresponding locked domain-fact"
   (declare (salience ?*SALIENCE-GOAL-PRE-EVALUATE*))
   ?p <- (goal-reasoner-unlock-pending ?lock)
-  ?m <- (mutex (name ?lock) (request UNLOCK) (response UNLOCKED))
+  ?m <- (mutex (name ?lock) (request UNLOCK) (state OPEN))
   ?df <- (domain-fact (name locked) (param-values ?lock))
   =>
   (modify ?m (request NONE) (response NONE))

--- a/src/clips-specs/rcll2018/lock-actions.clp
+++ b/src/clips-specs/rcll2018/lock-actions.clp
@@ -127,7 +127,7 @@
   ?pa <- (plan-action (id ?id) (action-name unlock) (state RUNNING)
                       (param-names $?param-names) (param-values $?param-values))
 	?mf <- (mutex (name ?name&:(eq ?name (plan-action-arg name ?param-names ?param-values)))
-								(request UNLOCK) (response UNLOCKED))
+								(state OPEN) (request UNLOCK))
 	=>
 	(printout t "Unlock of " ?name " successfull" crlf)
 	(modify ?pa (state EXECUTION-SUCCEEDED))
@@ -207,7 +207,7 @@
 (defrule lock-actions-unlock-location-done
   ?l <- (location-unlock-pending ?loc ?side)
   ?m <- (mutex (name ?lock-name&:(eq ?lock-name (sym-cat ?loc - ?side)))
-         (state OPEN) (request UNLOCK) (response UNLOCKED))
+         (state OPEN) (request UNLOCK))
   =>
   (do-for-fact ((?wm-fact wm-fact)) (eq ?wm-fact:key (create$ domain fact
                                         location-locked args? m ?loc s ?side))


### PR DESCRIPTION
Do not wait for the response but instead just check if the mutex is
OPEN. If so, let the action succeed.

This is analogous to fawkesrobotics/fawkes#134.