### PR TITLE
add host specific configs for realsense camera

### DIFF
--- a/cfg/conf.d/meta_plugins_laptop.yaml
+++ b/cfg/conf.d/meta_plugins_laptop.yaml
@@ -14,6 +14,8 @@ fawkes/meta_plugins:
     - m-fv
     - tag_vision
     - fvretriever
+  m-realsense:
+    - realsense
   m-clips:
     - clips
     - clips-motor-switch
@@ -40,7 +42,7 @@ fawkes/meta_plugins:
     - navgraph-generator
     - navgraph-generator-mps
     - skiller
-    - realsense
+    - m-realsense
     - conveyor-plane
     - conveyor-pose
     - ros-pcl

--- a/cfg/host_robotino-laptop-1.d/depth_cam.yaml
+++ b/cfg/host_robotino-laptop-1.d/depth_cam.yaml
@@ -12,16 +12,6 @@ conveyor_plane:
   realsense_switch: "realsense2"
 
 fawkes/meta_plugins:
-  m-skiller:
-    - ros
-    - m-fv-vision
-    - navgraph
-    - navgraph-generator
-    - navgraph-generator-mps
-    - skiller
+  m-realsense:
     - realsense2
-    - conveyor-plane
-    - conveyor-pose
-    - ros-pcl
-    - skiller-rest-api
 

--- a/cfg/host_robotino-laptop-2.d/depth_cam.yaml
+++ b/cfg/host_robotino-laptop-2.d/depth_cam.yaml
@@ -12,16 +12,6 @@ conveyor_plane:
   realsense_switch: "realsense2"
 
 fawkes/meta_plugins:
-  m-skiller:
-    - ros
-    - m-fv-vision
-    - navgraph
-    - navgraph-generator
-    - navgraph-generator-mps
-    - skiller
+  m-realsense:
     - realsense2
-    - conveyor-plane
-    - conveyor-pose
-    - ros-pcl
-    - skiller-rest-api
 

--- a/cfg/host_robotino-laptop-3.d/depth_cam.yaml
+++ b/cfg/host_robotino-laptop-3.d/depth_cam.yaml
@@ -12,16 +12,6 @@ conveyor_plane:
   realsense_switch: "realsense2"
 
 fawkes/meta_plugins:
-  m-skiller:
-    - ros
-    - m-fv-vision
-    - navgraph
-    - navgraph-generator
-    - navgraph-generator-mps
-    - skiller
+  m-realsense:
     - realsense2
-    - conveyor-plane
-    - conveyor-pose
-    - ros-pcl
-    - skiller-rest-api
 


### PR DESCRIPTION
Allows quick change of realsense1 to realsense2 

Not sure if the host specific configs should be named depth_cam.yaml?
Maybe we should change the name to realsense.yaml? 