### PR TITLE
skills: switch laser-lines on/off

### DIFF
--- a/src/lua/skills/robotino/bring_product_to.lua
+++ b/src/lua/skills/robotino/bring_product_to.lua
@@ -27,6 +27,7 @@ name               = "bring_product_to"
 fsm                = SkillHSM:new{name=name, start="INIT", debug=true}
 depends_skills     = {"product_put", "drive_to_machine_point", "conveyor_align"}
 depends_interfaces = {
+   {v = "laserline_switch", type = "SwitchInterface", id="laser-lines"},
 }
 
 documentation      = [==[ 
@@ -109,4 +110,12 @@ function PRODUCT_PUT:init()
   self.args["product_put"].place = self.fsm.vars.place
   self.args["product_put"].slide = self.fsm.vars.slide
   self.args["product_put"].side = self.fsm.vars.side
+end
+
+function FINAL:init()
+  laserline_switch:msgq_enqueue(laserline_switch.DisableSwitchMessage:new())
+end
+
+function FAILED:init()
+  laserline_switch:msgq_enqueue(laserline_switch.DisableSwitchMessage:new())
 end

--- a/src/lua/skills/robotino/conveyor_align.lua
+++ b/src/lua/skills/robotino/conveyor_align.lua
@@ -27,6 +27,7 @@ depends_interfaces = {
    {v = "motor", type = "MotorInterface", id="Robotino" },
    {v = "if_conveyor_pose", type = "ConveyorPoseInterface", id="conveyor_pose/status"},
    {v = "if_plane_switch", type = "SwitchInterface", id="conveyor_plane/switch"},
+   {v = "laserline_switch", type = "SwitchInterface", id="laser-lines"},
 }
 
 documentation      = [==[aligns the robot orthogonal to the conveyor by using the
@@ -177,6 +178,8 @@ fsm:add_transitions{
 }
 
 function INIT:init()
+   laserline_switch:msgq_enqueue(laserline_switch.EnableSwitchMessage:new())
+
    enable_conveyor_plane(true)
    local parse_result = pam.parse_to_type_target(if_conveyor_pose,self.fsm.vars.place,self.fsm.vars.side,self.fsm.vars.shelf,self.fsm.vars.slide)
    self.fsm.vars.mps_type = parse_result.mps_type

--- a/src/lua/skills/robotino/drive_to_machine_point.lua
+++ b/src/lua/skills/robotino/drive_to_machine_point.lua
@@ -62,8 +62,8 @@ depends_interfaces = {
    {v = "tag_14", type = "Position3DInterface", id="/tag-vision/14"},
    {v = "tag_15", type = "Position3DInterface", id="/tag-vision/15"},
    {v = "tag_info", type = "TagVisionInterface", id="/tag-vision/info"},
-   {v = "navi", type = "NavigatorInterface", id="Navigator"}
-
+   {v = "navi", type = "NavigatorInterface", id="Navigator"},
+   {v = "laserline_switch", type = "SwitchInterface", id="laser-lines"},
 }
 
 documentation      = [==[Drive to point with colisoin avoidance and approach a point relative to the laser line.
@@ -241,6 +241,8 @@ fsm:add_transitions{
 }
 
 function INIT:init()
+  laserline_switch:msgq_enqueue(laserline_switch.EnableSwitchMessage:new())
+
   self.fsm.vars.lines = {}
   self.fsm.vars.lines[line1:id()] = line1
   self.fsm.vars.lines[line2:id()] = line2

--- a/src/lua/skills/robotino/get_product_from.lua
+++ b/src/lua/skills/robotino/get_product_from.lua
@@ -27,6 +27,7 @@ name               = "get_product_from"
 fsm                = SkillHSM:new{name=name, start="INIT", debug=true}
 depends_skills     = {"product_pick", "drive_to_machine_point", "conveyor_align","shelf_pick"}
 depends_interfaces = {
+   {v = "laserline_switch", type = "SwitchInterface", id="laser-lines"},
 }
 
 documentation      = [==[
@@ -120,4 +121,12 @@ function CONVEYOR_ALIGN:init()
      self.args["conveyor_align"].slide = self.fsm.vars.slide
    end
 
+end
+
+function FINAL:init()
+  laserline_switch:msgq_enqueue(laserline_switch.DisableSwitchMessage:new())
+end
+
+function FAILED:init()
+  laserline_switch:msgq_enqueue(laserline_switch.DisableSwitchMessage:new())
 end

--- a/src/lua/skills/robotino/mps_align.lua
+++ b/src/lua/skills/robotino/mps_align.lua
@@ -64,6 +64,7 @@ depends_interfaces = {
    {v = "tag_14", type = "Position3DInterface", id="/tag-vision/14"},
    {v = "tag_15", type = "Position3DInterface", id="/tag-vision/15"},
    {v = "tag_info", type = "TagVisionInterface", id="/tag-vision/info"},
+   {v = "laserline_switch", type = "SwitchInterface", id="laser-lines"},
 }
 
 documentation      = [==[Align precisely at the given coordinates, relative to the center of an MPS
@@ -176,6 +177,8 @@ fsm:add_transitions{
 }
 
 function INIT:init()
+   laserline_switch:msgq_enqueue(laserline_switch.EnableSwitchMessage:new())
+
    self.fsm.vars.y   = self.fsm.vars.y   or 0
    self.fsm.vars.ori = self.fsm.vars.ori or 0
 


### PR DESCRIPTION
All skills that use laser-lines switch them on at the beginning, but
only `bring_product_to` and `get_product_from` disable them at the end.

The exploration should be unaffected as long as the laser-lines are switched on at startup (as per `laser-lines.yaml`). Has been tested in `common/current`.