### PR TITLE
cx: increase order delivered counter in deliver goal evaluation

### DIFF
--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -326,6 +326,18 @@
   (modify ?g (mode EVALUATED))
 )
 
+(defrule goal-reasoner-evaluate-completed-deliver
+" Enhance the order-delivered fact of the order of a successful deliver goal
+"
+  ?g <- (goal (id ?goal-id) (class DELIVER) (mode FINISHED) (outcome COMPLETED)
+              (params $? ?order $?))
+  (wm-fact (id "/refbox/team-color") (value ?team-color&:(neq ?team-color nil)))
+  ?od <- (wm-fact (key refbox order ?order quantity-delivered ?team-color) (value ?val))
+  =>
+  (modify ?od (value (+ ?val 1)))
+  (modify ?g (mode EVALUATED))
+)
+
 
 (defrule goal-reasoner-evaluate-completed-produce-c0-and-mount-first-ring
 " Bind a workpiece to the order it belongs to.

--- a/src/clips-specs/rcll2018/refbox-worldmodel.clp
+++ b/src/clips-specs/rcll2018/refbox-worldmodel.clp
@@ -123,18 +123,9 @@
           (printout t "Added order " ?id " with " (pb-field-value ?o "cap_color") crlf)
       else
           (if (eq ?team-color CYAN) then
-            (bind ?qd (pb-field-value ?o "quantity_delivered_cyan"))
             (bind ?qd-them (pb-field-value ?o "quantity_delivered_magenta"))
           else
-            (bind ?qd (pb-field-value ?o "quantity_delivered_magenta"))
             (bind ?qd-them (pb-field-value ?o "quantity_delivered_cyan"))
-          )
-          (do-for-fact ((?old-qd wm-fact))
-            (and (wm-key-prefix ?old-qd:key
-                   (create$ refbox order ?order-id
-                    quantity-delivered ?team-color))
-                 (neq ?old-qd:value ?qd))
-              (modify ?old-qd (value ?qd))
           )
           (do-for-fact ((?old-qd-them wm-fact))
             (and (wm-key-prefix ?old-qd-them:key


### PR DESCRIPTION
we used to increase the quantity delivered counter on refbox messages after a order was confirmed. If the referee is slow or the order gets confirmed only at the end of a game, the agent was able to start the order again.

Rather than waiting for the refbox, we want to trust our own agent more and increase the quantity delivered counter as soon as we finished a deliver goal for an order.

This fixes #223 