### PR TITLE
add delay before next retry config value for old realsense

### DIFF
--- a/cfg/conf.d/realsense.yaml
+++ b/cfg/conf.d/realsense.yaml
@@ -12,8 +12,8 @@ realsense:
 
   # restart device after num retries
   restart_after_num_errors: 20
-  # wait time before ppolling new images
-  delay_between_pol_errors: 0.5
+  # wait time before polling new images
+  delay_between_poll_errors: 0.5
 
   # Section to set the Realsense device options
   device_options:


### PR DESCRIPTION
adds delay value that reduces polling frequency if an error occured. 
This was merged in common current but not in master