### PR TITLE
Tune discard skill

### DIFF
--- a/src/lua/skills/robotino/discard.lua
+++ b/src/lua/skills/robotino/discard.lua
@@ -33,7 +33,7 @@ documentation      = [==[
 Skill to safely discard a workpiece
 ]==]
 
-local MOVE_X = 0.025
+local MOVE_X = 0.05
 
 -- Initialize as skill module
 skillenv.skill_module(_M)
@@ -54,7 +54,7 @@ fsm:add_transitions{
 function INIT:init()
   -- Override values if host specific config value is set
   if config:exists("/arduino/y_max") then
-      self.fsm.vars.y_max = config:get_float("/arduino/y_max")
+      self.fsm.vars.y_max = config:get_float("/arduino/y_max")/2
   else
       self.fsm.vars.y_max = 0.038
   end


### PR DESCRIPTION
To discard a workpiece the gripper would drive its max distance in X and Y direction, and open its fingers.
To comply with rcll rules, the gripper must not reach outside the Robotino's table more than 5cm.
With this PR the Y-axis moves in its max position and the X-axis now only moves 2,5cm forward. This discards the workpiece just shy of the table's edge. The movement in Y direction is necessary to prevent the workpiece from falling into the Robotino's base.