### PR TITLE
cfg: add gazsim-tag-vision to meta config

### DIFF
--- a/cfg/conf.d/meta_plugins_gazebo.yaml
+++ b/cfg/conf.d/meta_plugins_gazebo.yaml
@@ -12,7 +12,7 @@ fawkes/meta_plugins:
     - laser-cluster
     - gazsim-timesource
     - gazsim-gripper
-    - gazsim-conveyor
+    - gazsim-meta-robotino-vision-high-level
     - laser_front_dist
     - webview
   gazsim-meta-robotino-ros:
@@ -44,6 +44,7 @@ fawkes/meta_plugins:
     - gazsim-vis-localization
     - skiller
   gazsim-meta-robotino-vision-high-level:
+    - gazsim-conveyor
     - gazsim-tag-vision
   gazsim-meta-robotino-vision-low-level:
     - fvbase


### PR DESCRIPTION
Adds missing gazsim-tag-vision plugin back to gazebo meta plugins