### PR TITLE
cx: match goal id of plan-actions on retraction

### DIFF
--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -544,7 +544,7 @@
   (not (goal (id ?parent)))
 =>
   (delayed-do-for-all-facts ((?p plan)) (eq ?p:goal-id ?goal-id)
-    (delayed-do-for-all-facts ((?a plan-action)) (eq ?a:plan-id ?p:id)
+    (delayed-do-for-all-facts ((?a plan-action)) (and (eq ?a:plan-id ?p:id) (eq ?a:goal-id ?goal-id))
       (retract ?a)
     )
     (retract ?p)


### PR DESCRIPTION
On retraction of a goal, all plans and plan-actions of this goal are retracted. However, the plan-actions were only matched for the plan-id. Since the plan-id is the same for all goal of the same type (which should be changed at some point), the retraction could remove plan-actions of other goals of the same class as well.
This can be prohibited by matching the goal-id of the plan-action as well