### PR TITLE
goto: fix place to zone regex

### DIFF
--- a/src/lua/skills/robotino/goto.lua
+++ b/src/lua/skills/robotino/goto.lua
@@ -128,7 +128,7 @@ function INIT:init()
     if string.match(self.fsm.vars.place, "%bWAIT") then 
        self.fsm.vars.waiting_pos = true
     end
-    if string.match(self.fsm.vars.place, "[MC][-]Z[1-7][1-8]") then
+    if string.match(self.fsm.vars.place, "^[MC][-]Z[1-7][1-8]$") then
       -- place argument is a zone, e.g. M-Z21
       self.fsm.vars.zone = self.fsm.vars.place
       self.fsm.vars.x = tonumber(string.sub(self.fsm.vars.place, 4, 4)) - 0.5


### PR DESCRIPTION
When the place was assumed to be a zone, the skill did not properly
check whether the zone might actually be a navgraph place.
This is fixed by making sure the regex only matches if the setup place
only starts and ends with a proper zone name (e.g. M-Z21).
Otherwise a place named "WAIT-C-Z23" would match the regex leading to a
skill failure.