### PR TITLE
skills: ignore puck check

### DIFF
--- a/src/lua/skills/robotino/product_pick.lua
+++ b/src/lua/skills/robotino/product_pick.lua
@@ -70,7 +70,8 @@ function is_grabbed()
  if robotino_sensor:is_digital_in(0) == false and robotino_sensor:is_digital_in(1) == true then -- white cable on DI1 and black on DI2
     return true
  else
-    return false
+   -- Ignore puck laser, until realsense is disabled by default 
+   return true
  end
 end
 

--- a/src/lua/skills/robotino/product_put.lua
+++ b/src/lua/skills/robotino/product_put.lua
@@ -71,7 +71,8 @@ function is_grabbed()
  if robotino_sensor:is_digital_in(0) == false and robotino_sensor:is_digital_in(1) == true then -- white cable on DI1 and black on DI2
     return true
  else
-    return false
+   -- Ignore until realsense is switched of by default 
+   return true
  end
 end
 


### PR DESCRIPTION
We have a puck check that makes use of a distance sensor at the gripper. However, currently the realsense is not disabled by default and the reflections of the infrared rays interfere with the lightsensor, drawing its results unusable.

Ignore the result of the puck check for now