### PR TITLE
cx: assert spot free on shelf wp-get-shelf

### DIFF
--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -455,6 +455,7 @@
   =>
   (printout t "Goal " ?goal-id " has been failed because of wp-get-shelf and is evaluated" crlf)
   (assert (wm-fact (key monitoring cleanup-wp args? wp ?wp)))
+  (assert (wm-fact (key domain fact spot-free args? m ?mps spot ?spot)))
   (modify ?g (mode EVALUATED))
 )
 


### PR DESCRIPTION
On a failed wp-get-shelf, we assume that the workpiece is lost and dont try the same spot another time. However, a free shelf spot has to have a spot-free fact, which was not asserted. Therefore the refill shelf action later times out, because it has spot-free as precondition