### PR TITLE
cx: check existence of mps-side-free before asserting

### DIFF
--- a/src/clips-specs/rcll2018/execution-monitoring.clp
+++ b/src/clips-specs/rcll2018/execution-monitoring.clp
@@ -172,8 +172,17 @@
                                               (wm-key-prefix ?wf:key (create$ domain fact wp-at)))
            (assert (wm-fact (key monitoring cleanup-wp args? wp (wm-key-arg ?wf:key wp))))
   )
-  (assert (wm-fact (key domain fact mps-side-free args? m ?mps side INPUT))
-          (wm-fact (key domain fact mps-side-free args? m ?mps side OUTPUT))
+  (if (not (any-factp ((?wf wm-fact)) (and (wm-key-prefix ?wf:key (create$ domain fact mps-side-free))
+                                           (eq (wm-key-arg ?wf:key m) ?mps)
+                                           (eq (wm-key-arg ?wf:key side) INPUT))))
+      then
+    (assert (wm-fact (key domain fact mps-side-free args? m ?mps side INPUT)))
+  )
+  (if (not (any-factp ((?wf wm-fact)) (and (wm-key-prefix ?wf:key (create$ domain fact mps-side-free))
+                                           (eq (wm-key-arg ?wf:key m) ?mps)
+                                           (eq (wm-key-arg ?wf:key side) OUTPUT))))
+      then
+    (assert (wm-fact (key domain fact mps-side-free args? m ?mps side OUTPUT)))
   )
 )
 


### PR DESCRIPTION
On a broken machine, both mps-side-free predicates have to be added. These used to be asserted, regardless whether they existed beforehand or not. This caused some problems by creating two equal facts. This PR fixes this, by checking if the mps-side-free fact exists