### PR TITLE
cx: flush domain-facts on worldmodel flush

### DIFF
--- a/src/clips-specs/rcll2018/domain.clp
+++ b/src/clips-specs/rcll2018/domain.clp
@@ -75,6 +75,9 @@
 	=>
 	(printout warn "Flushing worldmodel!" crlf)
 	(wm-robmem-flush)
+	(do-for-all-facts ((?df domain-fact)) TRUE
+	  (retract ?df)
+	)
 	(assert (domain-wm-flushed))
 )
 


### PR DESCRIPTION
In the case of a second setup phase, the agent would have flushed
the robot memory but kept all domain fact. Since the delete trigger
of the robot memory flush may take a while to arrive, the world model
initialization would only have asserted missing domain-facts, which
would lead to the deletion of all domain-facts by the delayed trigger