### PR TITLE
cx: make clear-mps goals urgent

### DIFF
--- a/src/clips-specs/rcll2018/goal-production.clp
+++ b/src/clips-specs/rcll2018/goal-production.clp
@@ -449,7 +449,7 @@
 (defrule goal-production-create-clear-bs
   "Remove a workpiece from the base station."
   (declare (salience ?*SALIENCE-GOAL-FORMULATE*))
-  (goal (id ?production-id) (class CLEAR) (mode FORMULATED))
+  (goal (id ?production-id) (class URGENT) (mode FORMULATED))
   (wm-fact (key refbox team-color) (value ?team-color))
   ;Robot CEs
   (wm-fact (key domain fact self args? r ?robot))


### PR DESCRIPTION
To avoid deadlocks if production goals are formulated that use the base
station, we have to clear the bs with higher priority than any
production goal. This resolves #286 