### PR TITLE
CX: reverse goal tree retraction order

### DIFF
--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -90,6 +90,7 @@
   (return (or (eq ?goal-class GET-BASE-TO-FILL-RS)
               (eq ?goal-class GET-SHELF-TO-FILL-RS)
               (eq ?goal-class FILL-CAP)
+              (eq ?goal-class CLEAR-MPS)
               (eq ?goal-class DISCARD-UNKNOWN)
               (eq ?goal-class PRODUCE-C0)
               (eq ?goal-class PRODUCE-CX)


### PR DESCRIPTION
This PR ensures, that all goals are properly deleted before a new production cycle starts. It resolves #280
Edit: This also fixes the bug that CLEAR-MPS was not properly listed as production tree goal 