### PR TITLE
cx: exog on processing

### DIFF
--- a/src/clips-specs/rcll2018/domain.pddl
+++ b/src/clips-specs/rcll2018/domain.pddl
@@ -144,7 +144,7 @@
 
 	(:action bs-dispense
 		:parameters (?r - robot ?m - mps ?side - mps-side ?wp - workpiece ?basecol - base-color)
-		:precondition (and (mps-type ?m BS) (mps-state ?m READY-AT-OUTPUT)
+		:precondition (and (mps-type ?m BS) (or (mps-state ?m PROCESSING) (mps-state ?m READY-AT-OUTPUT))
                        (locked ?m) (bs-prepared-color ?m ?basecol)
                        (bs-prepared-side ?m ?side)
 											 (wp-base-color ?wp BASE_NONE) (wp-unused ?wp)
@@ -160,7 +160,7 @@
 
 	(:action cs-mount-cap
 		:parameters (?m - mps ?wp - workpiece ?capcol - cap-color)
-		:precondition (and (mps-type ?m CS) (mps-state ?m READY-AT-OUTPUT) (locked ?m)
+		:precondition (and (mps-type ?m CS) (or (mps-state ?m PROCESSING) (mps-state ?m READY-AT-OUTPUT)) (locked ?m)
 										(cs-buffered ?m ?capcol) (cs-prepared-for ?m MOUNT_CAP)
 										(wp-usable ?wp) (wp-at ?wp ?m INPUT)
 										(not (mps-side-free ?m INPUT))
@@ -184,7 +184,7 @@
 
 	(:action cs-retrieve-cap
 		:parameters (?m - mps ?cc - cap-carrier ?capcol - cap-color)
-		:precondition (and (mps-type ?m CS) (mps-state ?m READY-AT-OUTPUT)
+		:precondition (and (mps-type ?m CS) (or (mps-state ?m PROCESSING) (mps-state ?m READY-AT-OUTPUT))
                        (locked ?m) (cs-prepared-for ?m RETRIEVE_CAP)
 										(wp-at ?cc ?m INPUT) (not (mps-side-free ?m INPUT)) (mps-side-free ?m OUTPUT)
 										(wp-cap-color ?cc ?capcol))
@@ -214,7 +214,7 @@
 
 	(:action rs-mount-ring1
 		:parameters (?m - mps ?wp - workpiece ?col - ring-color ?rs-before - ring-num ?rs-after - ring-num ?r-req - ring-num)
-		:precondition (and (mps-type ?m RS) (mps-state ?m READY-AT-OUTPUT) (locked ?m)
+		:precondition (and (mps-type ?m RS) (or (mps-state ?m PROCESSING) (mps-state ?m READY-AT-OUTPUT)) (locked ?m)
 										(wp-at ?wp ?m INPUT) (not (mps-side-free ?m INPUT)) 
                     (mps-side-free ?m OUTPUT)
 										(wp-usable ?wp)
@@ -234,7 +234,7 @@
 	(:action rs-mount-ring2
 		:parameters (?m - mps ?wp - workpiece ?col - ring-color ?col1 - ring-color
 					?rs-before - ring-num ?rs-after - ring-num ?r-req - ring-num)
-		:precondition (and (mps-type ?m RS) (mps-state ?m READY-AT-OUTPUT)
+		:precondition (and (mps-type ?m RS) (or (mps-state ?m PROCESSING) (mps-state ?m READY-AT-OUTPUT))
                     (locked ?m)
 										(wp-at ?wp ?m INPUT) (not (mps-side-free ?m INPUT)) (wp-usable ?wp)
 										(mps-side-free ?m OUTPUT)
@@ -255,7 +255,7 @@
 	(:action rs-mount-ring3
 		:parameters (?m - mps ?wp - workpiece ?col - ring-color ?col1 - ring-color ?col2 - ring-color
 							?rs-before - ring-num ?rs-after - ring-num ?r-req - ring-num)
-		:precondition (and (mps-type ?m RS) (mps-state ?m READY-AT-OUTPUT) (locked ?m)
+		:precondition (and (mps-type ?m RS) (or (mps-state ?m PROCESSING) (mps-state ?m READY-AT-OUTPUT)) (locked ?m)
 										(wp-at ?wp ?m INPUT) (not (mps-side-free ?m INPUT)) (wp-usable ?wp)
 										(mps-side-free ?m OUTPUT)
 										(wp-ring1-color ?wp ?col1)


### PR DESCRIPTION
The READY-AT-OUTPUT precondition of the exogenous actions is used to determine, that the mps actually finished its processing and the workpiece is already at the output.
By changing the precondition to be satsified already on the PROCESSING state, this is still given since the mps is processing and the effects are going to be applied. This will lead to an earlier execution of the exogenous action and therefore safe time.

We still have to keep the READY-AT-OUTPUT state, since the PROCESSING state is only temporarily and may be missed 