### PR TITLE
cx: reset mps after failed exog action only if not already broken

### DIFF
--- a/src/clips-specs/rcll2018/goal-reasoner.clp
+++ b/src/clips-specs/rcll2018/goal-reasoner.clp
@@ -431,6 +431,7 @@
                (state FAILED))
   (domain-object (name ?mps) (type mps))
   ?g <- (goal (id ?goal-id) (mode FINISHED) (outcome FAILED))
+  (domain-fact (name mps-state) (param-values ?mps ~BROKEN))
   (not (wm-fact (key evaluated reset-mps args? m ?mps)))
   =>
   (assert


### PR DESCRIPTION
After a failed exogenous action we want to reset the mps. But exogenous actions also fail if the mps gets broken because of a wrong prepare. In this case we dont want to reset the mps another time