### PR TITLE
Revisit arduino calibration

### DIFF
--- a/src/plugins/arduino/ArduinoSketch/fawkes_plugin_comm.ino
+++ b/src/plugins/arduino/ArduinoSketch/fawkes_plugin_comm.ino
@@ -221,9 +221,12 @@ void calibrate()
   bool x_done = false, y_done = false, z_done = false;
   do { //repeat calibration as long as not successfull
     motor_X.enableOutputs();
+    noInterrupts();
     if(!x_done) motor_X.move(20000L);
     if(!y_done) motor_Y.move(20000L);
     if(!z_done) motor_Z.move(20000L);
+    movement_done_flag = false;
+    interrupts();
     // due to high step count, reaching end stops is guaranteed!
     set_status(STATUS_MOVING); // status is always only changed on no interrupt code level, hence no race condition occurs here
     // This while loop controls permanently the state of the respective end stops and handles crashing into them


### PR DESCRIPTION
When calibrating the axes, all axes move to their end stop, until reaching it. Already before the decision was made to retry calibration for a specific axis, if the respective end stop is not reached in a generous amount of steps. For slow stepping speeds this worked fine, however, for faster stepping speeds the end stop was not recognized anymore in calibration, if the first calibration run failed.

The reason for this bug was a race condition, leading to the `calibrate` function thinking that the movement was already done and consequently triggering a new calibration run.