### PR TITLE
Arduino Firmware: Make check for the gripper status better

### DIFF
--- a/src/plugins/arduino/ArduinoSketch/fawkes_plugin_comm.ino
+++ b/src/plugins/arduino/ArduinoSketch/fawkes_plugin_comm.ino
@@ -197,7 +197,8 @@ void set_status(int status_) {
 bool assumed_gripper_state;
 
 // @Return True if gripper is assumed to be open
-bool get_gripper_assumed_state(bool is_open_command) {
+// This helper function is necessary to set the assumed_gripper_state initially
+bool get_assumed_gripper_state(bool is_open_command) {
   static bool initialized = false;
   if(!initialized){
     initialized = true;
@@ -377,7 +378,7 @@ void read_package() {
         cur_cmd == CMD_SET_ACCEL) {
       if(sscanf (buffer_ + (cur_i_cmd + 1),"%ld",&new_value)<=0){buf_i_ = 0; return;} // flush and return if parsing error
     }
-    bool assumed_state;
+    bool assumed_gripper_state_local; // this is used to store the assumed gripper state locally, to reduce calls to the function get_assumed_gripper_state
     switch (cur_cmd) {
       case CMD_X_NEW_POS:
         set_new_pos(-new_value, motor_X);
@@ -440,8 +441,8 @@ void read_package() {
         break;
       case CMD_OPEN:
         check_gripper_endstop();
-        assumed_state = get_gripper_assumed_state(true);
-        if(!assumed_state && open_gripper || !open_gripper)
+        assumed_gripper_state_local = get_assumed_gripper_state(true);
+        if(!assumed_gripper_state_local && open_gripper || !open_gripper)
         { // we do it
           set_new_rel_pos(-a_toggle_steps,motor_A);
           assumed_gripper_state = true;
@@ -452,8 +453,8 @@ void read_package() {
         break;
       case CMD_CLOSE:
         check_gripper_endstop();
-        assumed_state = get_gripper_assumed_state(false);
-        if(assumed_state)
+        assumed_gripper_state_local = get_assumed_gripper_state(false);
+        if(assumed_gripper_state_local)
         { // we do it
           set_new_rel_pos(a_toggle_steps,motor_A);
           assumed_gripper_state = false;


### PR DESCRIPTION
The decision whether the open/close command should be followed is not an
easy one.
If for example, the gripper is open and the gripper is opened again, the
belt slips, which lead to mechanical erosion and makes future gripping
less reliable.

This commit introduces the usage of an assumed state of the gripper, as
well as the not so reliable end stop state.

The following cases are possible:

| assumed state | end stop  | reactions  |
|---|---|---|
| open         | open   |    no open  @ open cmd |
|            |        |               close    @ close cmd |
| closed      |  open   |    open     @ open cmd |
  | |      |                        no close @ close cmd |
| open        |  closed  |   open     @ open cmd |
 | |        |                close    @ close cmd |
| closed     |     closed |    open     @ open cmd |
  | |         |              no close @ close cmd |