### PR TITLE
arduino: Make Makefile more verbose

### DIFF
--- a/src/plugins/arduino/Makefile
+++ b/src/plugins/arduino/Makefile
@@ -76,9 +76,11 @@ warning_tf:
 warning_arduino:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TYELLOW)Omitting flashing Arduino$(TNORMAL) (/dev/arduino not found)"
 flash_arduino:
-	$(SILENT)($(MAKE) -C $(BASEDIR)/src/plugins/arduino/ArduinoSketch safe_flash &> /dev/null) \
-	 	&& echo -e "$(INDENT_PRINT)--> $(TGREEN)Successfully flashed the arduino $(TNORMAL)"\
-	 	|| echo -e "$(INDENT_PRINT)--> $(TRED)Error while flashing the arduino $(TNORMAL)"
+	$(SILENT)($(MAKE) -C $(BASEDIR)/src/plugins/arduino/ArduinoSketch verify &> /dev/null) \
+		&& echo -e "$(INDENT_PRINT)--> $(TGREEN)No need to reflash arduino $(TNORMAL)"\
+		|| ( ($(MAKE) -C $(BASEDIR)/src/plugins/arduino/ArduinoSketch flash &> /dev/null) \
+			&& echo -e "$(INDENT_PRINT)--> $(TGREEN)Successfully reflashed arduino $(TNORMAL)" \
+			|| echo -e "$(INDENT_PRINT)--> $(TRED)Something went wrong while flashing the arduino $(TNORMAL)")
 endif
 
 


### PR DESCRIPTION
The Makefile always returned the message `Successfully flashed the arduino` if the arduino was connected and the Submakefile did not fail. However, this message is misleading as it was also returned if the arduino was only verified and a reflash was not necessary.

This PR changes this behaviour. If the arduino is already flashed with the current firmware, the message `No need to reflash the arduino` is emitted.