### PR TITLE
Fix laser filters for the 2019 hardware setup

### DIFF
--- a/cfg/conf.d/laser-filter.yaml
+++ b/cfg/conf.d/laser-filter.yaml
@@ -82,7 +82,7 @@ plugins/laser-filter:
       2-sector:
         # Ignore a defined range of beams (e.g. those hitting the robot itself)
         type: circle_sector
-        from: 255
+        from: 265
         to: 110
 
   filter-back-360:
@@ -100,7 +100,7 @@ plugins/laser-filter:
         # Ignore a defined range of beams (e.g. those hitting the robot itself)
         type: circle_sector
         from: 245
-        to: 135
+        to: 115
       3-projection:
         type: projection
         target_frame: !frame base_laser


### PR DESCRIPTION
In addition to https://github.com/carologistics/fawkes-robotino/pull/197 the laser filters were further increased due to additional laser beams hitting the robot.