### PR TITLE
Increase deceleration limits for robotino

### DIFF
--- a/cfg/conf.d/robotino.yaml
+++ b/cfg/conf.d/robotino.yaml
@@ -94,11 +94,11 @@ hardware/robotino:
 
     # Maximum acceleration and deceleration for translation, m/s^2
     trans-acceleration: 0.4
-    trans-deceleration: 1.0
+    trans-deceleration: 1.5
 
     # Maximum acceleration and deceleration for rotation, rad/s^2
     rot-acceleration: 1.6
-    rot-deceleration: 1.6
+    rot-deceleration: 3.2
 
   bumper:
     # Set to true to enable the emergency stop on bumper contact (provided


### PR DESCRIPTION
The deceleration limits for angular and translational velocities set up in the robotino plugin lead to some mechanical crashes during high velocities.
This setup was due to the heavy robotino head used in 2018. However, as we were able to reduce the weight of the robotino heads we can also stop faster.

The values were gathered empirically.