### PR TITLE
Allow the use of laser-pointclouds in ROS

### DIFF
--- a/cfg/conf.d/meta_plugins_base.yaml
+++ b/cfg/conf.d/meta_plugins_base.yaml
@@ -29,8 +29,8 @@ fawkes/meta_plugins:
   m-base-laser:
     - laser
     - laser-filter
-    - m-base-ros
     - laser-pointclouds
+    - m-base-ros
     - laser-cluster
     - laser-lines
   m-base-full:


### PR DESCRIPTION
When the meta-plugin `m-base-ros` is loaded _before_ `laser-pointclouds` then the plugin `ros-pcl` won't be able to propagate the available laser-pointclouds as they're fetched while running [`init()`](https://github.com/fawkesrobotics/fawkes/blob/a464ad8ef42fb06af9e0164fd549803aae00ae07/src/plugins/ros/pcl_thread.cpp#L57).