### PR TITLE
Update back laser position

### DIFF
--- a/cfg/conf.d/static_transforms.yaml
+++ b/cfg/conf.d/static_transforms.yaml
@@ -28,9 +28,9 @@ plugins/static-transforms:
     back_laser:
       frame: !frame base_link
       child_frame: !frame back_laser
-      trans_x: -0.145
+      trans_x: -0.11
       trans_y: 0.0
-      trans_z: 0.315
+      trans_z: 0.32
       rot_roll: 0.0
       rot_pitch: 2.94
       rot_yaw: 0.0


### PR DESCRIPTION
With the new mounting of the back laser we have to setup a new default position in the `static_transforms`.