### PR TITLE
cfg: enable C2 and C3, disable C1

### DIFF
--- a/cfg/conf.d/clips-executive.yaml
+++ b/cfg/conf.d/clips-executive.yaml
@@ -222,8 +222,8 @@ clips-executive:
           max-rotation: 1.0
           master: R-2
 
-          allowed-complexities: ["C0", "C1"]
-          exclusive-complexities: ["C2", "C3"]
+          allowed-complexities: ["C0", "C2", "C3"]
+          exclusive-complexities: []
 
           # Priority to pursue competitive orders.
           # HIGH: Produce it as fast as possible.


### PR DESCRIPTION
This is the strategy from the finals. Therefore it deserves a spot in the Master and the 2019 release.