### PR TITLE
cx: add FILL-RS goal to production leaf goals

### DIFF
--- a/src/clips-specs/rcll/goal-reasoner.clp
+++ b/src/clips-specs/rcll/goal-reasoner.clp
@@ -89,6 +89,7 @@
 (deffunction production-leaf-goal (?goal-class)
   (return (or (eq ?goal-class GET-BASE-TO-FILL-RS)
               (eq ?goal-class GET-SHELF-TO-FILL-RS)
+              (eq ?goal-class FILL-RS)
               (eq ?goal-class FILL-CAP)
               (eq ?goal-class CLEAR-MPS)
               (eq ?goal-class DISCARD-UNKNOWN)


### PR DESCRIPTION
This PR fixes situations where the agent gets stuck because it formulates a
`FILL-RS` goal without executing it (e.g. because the ring stations are both unavailable).

The issue is, that during goal clean up we rely on the production-goal function. The clean up rule that reviled the missing `FILL-RS` entry states that if one production goal is dispatched, then all other production goals can be retracted.

A better long term solution to this would be to refactor the production-goal function, e.g. by identifying a tree by its root node and recursively climb up from sub goals to determine the belonging tree.
AFAIK @morxa and @Sagre both already made some drafts for this.