### PR TITLE
CX: small fix in ring station deadlock check

### DIFF
--- a/src/clips-specs/rcll/goal-production.clp
+++ b/src/clips-specs/rcll/goal-production.clp
@@ -1005,14 +1005,6 @@
 )
 
 
-;TODO: Do we need this?
-(deffunction trac-ring-mount-time (?complexity ?rings)
-  "Determine time to mount the remaining rings plus cap"
-  (bind ?max-rings (eval (sub-string 2 3 (str-cat ?complexity))))
-  (return (+ (* (- ?max-rings ?rings) ?*PRODUCE-RING-AHEAD-TIME*) ?*PRODUCE-CAP-AHEAD-TIME*))
-)
-
-
 (defrule goal-production-create-mount-next-ring
 " Mount the next ring on a CX product:
    - Take the started workpiece from the ring station output.


### PR DESCRIPTION
Found a small bug that i introduced in #263. A variable name that was slightly off broke the addiditional deadlock check in the formulation of `MOUNT-FIRST-RING` goals.

Also i saw a piece of dead code that was bugging me for the last 2 years, so i decided to finally remove it.