### PR TITLE
cx: fix spelling mistake in action-selection rule

### DIFF
--- a/src/clips-specs/rcll/action-selection.clp
+++ b/src/clips-specs/rcll/action-selection.clp
@@ -22,7 +22,7 @@
 	(modify ?g (mode FINISHED) (outcome COMPLETED))
 )
 
-(defrule action-seleection-explorezone-unlock
+(defrule action-selection-explorezone-unlock
   (declare (salience 1))
 	(goal (id ?goal-id) (class EXPLORATION) (mode DISPATCHED))
 	?p <- (plan (id EXPLORE-ZONE) (goal-id ?goal-id))


### PR DESCRIPTION
delete one 'e' of seleection in action-selection-explorezone-unlock rule