### PR TITLE
cx: sync the keep-mps-side-free fact

### DIFF
--- a/src/clips-specs/rcll/init-worldmodel.clp
+++ b/src/clips-specs/rcll/init-worldmodel.clp
@@ -58,6 +58,7 @@
   (wm-robmem-sync-enable "/domain/fact/quantity-delivered")
   (wm-robmem-sync-enable "/mps-handling/")
   (wm-robmem-sync-enable "/order/meta/wp-for-order")
+  (wm-robmem-sync-enable "/strategy/keep-mps-side-free")
   (wm-robmem-sync-enable "/exploration/fact/tag-vis")
   (wm-robmem-sync-enable "/exploration/fact/line-vis")
   (wm-robmem-sync-enable "/exploration/fact/time-searched")


### PR DESCRIPTION
This fact blocks the formulation of MOUNT-xxxx-RING goals that target a
RS input side, where the output is occupied by a product that needs the
same input next.
Only the robot that executes a PROCESS-MPS goal can assert this fact as
it is done as a pre-evaluation step. Therefore, this fact has to be
synced in order to properly prevent possible deadlocks at ring stations.