### PR TITLE
plugins: use bb refresh instead of change notification

### DIFF
--- a/src/plugins/navgraph-generator-mps/navgraph_generator_mps_thread.cpp
+++ b/src/plugins/navgraph-generator-mps/navgraph_generator_mps_thread.cpp
@@ -759,7 +759,7 @@ NavGraphGeneratorMPSThread::generate_navgraph()
 }
 
 void
-NavGraphGeneratorMPSThread::bb_interface_data_changed(Interface *interface) throw()
+NavGraphGeneratorMPSThread::bb_interface_data_refreshed(Interface *interface) throw()
 {
 	navgen_if_->read();
 	if (navgen_if_->msgid() == compute_msgid_ && navgen_if_->is_final()) {

--- a/src/plugins/navgraph-generator-mps/navgraph_generator_mps_thread.h
+++ b/src/plugins/navgraph-generator-mps/navgraph_generator_mps_thread.h
@@ -70,7 +70,7 @@ private:
 	void                                               generate_navgraph();
 	fawkes::NavGraphGeneratorInterface::ConnectionMode mps_node_insmode(std::string name);
 
-	virtual void bb_interface_data_changed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
 
 private:
 	std::string                                   cfg_global_frame_;

--- a/src/plugins/navgraph_broker/navgraph_broker_thread.cpp
+++ b/src/plugins/navgraph_broker/navgraph_broker_thread.cpp
@@ -379,7 +379,7 @@ NavgraphBrokerThread::send_msg()
 }
 
 void
-NavgraphBrokerThread::bb_interface_data_changed(fawkes::Interface *interface) throw()
+NavgraphBrokerThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
 {
 	path_if_->read();
 	std::vector<std::string> path = get_path_from_interface_as_vector();

--- a/src/plugins/navgraph_broker/navgraph_broker_thread.h
+++ b/src/plugins/navgraph_broker/navgraph_broker_thread.h
@@ -74,7 +74,7 @@ public:
 	virtual void finalize();
 
 	// For BlackBoardInterfaceListener
-	virtual void bb_interface_data_changed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/skiller_motor_state/skiller_motor_state_thread.cpp
+++ b/src/plugins/skiller_motor_state/skiller_motor_state_thread.cpp
@@ -268,7 +268,7 @@ SkillerMotorStateThread::interruptable_timeout(fawkes::Time *wait_until)
 }
 
 void
-SkillerMotorStateThread::bb_interface_data_changed(fawkes::Interface *interface) throw()
+SkillerMotorStateThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
 {
 	if (*interface == *skiller_if_) {
 		fawkes::MutexLocker scoped_timeout_mutex(timeout_wait_mutex_);

--- a/src/plugins/skiller_motor_state/skiller_motor_state_thread.h
+++ b/src/plugins/skiller_motor_state/skiller_motor_state_thread.h
@@ -83,7 +83,7 @@ private:
 	fawkes::Mutex         timeout_wait_mutex_;
 	fawkes::WaitCondition timeout_wait_condition_;
 
-	virtual void bb_interface_data_changed(fawkes::Interface *interface) throw() override;
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw() override;
 
 	std::atomic<bool> motor_if_changed_flag_;
 	std::atomic<bool> skiller_if_changed_flag_;

--- a/src/plugins/webtools-bridge/blackboard_processor.cpp
+++ b/src/plugins/webtools-bridge/blackboard_processor.cpp
@@ -495,7 +495,7 @@ BlackBoardSubscription::serialize(std::string op, std::string topic_name, std::s
  * @param interface The interface to listen too
  */
 void
-BlackBoardSubscription::bb_interface_data_changed(fawkes::Interface *interface) throw()
+BlackBoardSubscription::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
 {
 	if (!is_active()) {
 		// this should not happen. listener should be deregistered in

--- a/src/plugins/webtools-bridge/blackboard_processor.h
+++ b/src/plugins/webtools-bridge/blackboard_processor.h
@@ -66,7 +66,7 @@ public:
 	void        finalize_impl();
 	std::string serialize(std::string op, std::string topic, std::string id);
 
-	void bb_interface_data_changed(fawkes::Interface *interface) throw();
+	void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
 
 private:
 	fawkes::BlackBoard *blackboard_; /**< Fawkes blackboard */


### PR DESCRIPTION
depends on https://github.com/fawkesrobotics/fawkes/pull/236. When that is merged, this should go in as well, but it's not strictly necessary.