### PR TITLE
Add missing includes in webtools-bridge

### DIFF
--- a/src/plugins/webtools-bridge/advertisment_capability.h
+++ b/src/plugins/webtools-bridge/advertisment_capability.h
@@ -27,6 +27,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <string>
 
 namespace fawkes {
 class Mutex;

--- a/src/plugins/webtools-bridge/subscription_capability.h
+++ b/src/plugins/webtools-bridge/subscription_capability.h
@@ -27,6 +27,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <string>
 
 namespace fawkes {
 class Clock;


### PR DESCRIPTION
This PR fixes build failures of the `webtools-bridge`. In particular the build fails with errors looking as follows:
```
[...]
/home/nlimpert/dev/fawkes-robotino/src/plugins/webtools-bridge/advertisment_capability.h:133:15: error: field ‘id’ has incomplete type  std::string’ {aka ‘std::__cxx11::basic_string<char>’}
  133 |   std::string id; /**< id given to request. Unique across a single
[...]
```

The same applies to `subscribtion_capbality.h`.