### PR TITLE
cx: prevent formulating goals that mount caps on products with caps

### DIFF
--- a/src/clips-specs/rcll/goal-production.clp
+++ b/src/clips-specs/rcll/goal-production.clp
@@ -1126,6 +1126,7 @@
   ;WP CEs
   (wm-fact (key domain fact wp-base-color args? wp ?wp col ?base-color))
   (wm-fact (key domain fact wp-ring1-color args? wp ?wp col ?ring1-color))
+  (wm-fact (key domain fact wp-cap-color args? wp ?wp col CAP_NONE))
   ;MPS-RS CEs
   (wm-fact (key domain fact mps-type args? m ?rs t RS))
   (wm-fact (key domain fact mps-team args? m ?rs col ?team-color))
@@ -1189,6 +1190,7 @@
   (wm-fact (key domain fact wp-base-color args? wp ?wp col ?base-color))
   (wm-fact (key domain fact wp-ring1-color args? wp ?wp col ?ring1-color))
   (wm-fact (key domain fact wp-ring2-color args? wp ?wp col ?ring2-color))
+  (wm-fact (key domain fact wp-cap-color args? wp ?wp col CAP_NONE))
   ;MPS-RS CEs
   (wm-fact (key domain fact mps-type args? m ?rs t RS))
   (wm-fact (key domain fact mps-team args? m ?rs col ?team-color))
@@ -1254,6 +1256,7 @@
   (wm-fact (key domain fact wp-ring1-color args? wp ?wp col ?ring1-color))
   (wm-fact (key domain fact wp-ring2-color args? wp ?wp col ?ring2-color))
   (wm-fact (key domain fact wp-ring3-color args? wp ?wp col ?ring3-color))
+  (wm-fact (key domain fact wp-cap-color args? wp ?wp col CAP_NONE))
   ;MPS-RS CEs
   (wm-fact (key domain fact mps-type args? m ?rs t RS))
   (wm-fact (key domain fact mps-team args? m ?rs col ?team-color))


### PR DESCRIPTION
Found a fun bug, where robots try to mount a cap twice on a product:

The main reason why this did not cause troubles earlier is, because the
product remained at the cap station output until delivery, hence the
machine was never buffered with a new cap.
Now we bring products to the delivery station nearly, hence it can happen
that a finished product is at the DS while the respective cap station is
fed with a buffered cap again. This allows to mount the cap again if we
formulate PRODUCE-CX goals regardless of the current cap color on the
target workpiece.