### PR TITLE
arduino: refactor Makefile, check for libudev

### DIFF
--- a/src/plugins/arduino/Makefile
+++ b/src/plugins/arduino/Makefile
@@ -20,7 +20,6 @@ include $(BUILDSYSDIR)/pcl.mk
 include $(BUILDSYSDIR)/ros.mk
 include $(BUILDCONFDIR)/tf/tf.mk
 
-HAVE_arduino = $(shell [ -a /dev/arduino ]; echo $$?)
 
 PRESUBDIRS = interfaces
 
@@ -37,52 +36,57 @@ LDFLAGS += $(LDFLAGS_TF)
 
 OBJS_all      = $(OBJS_arduino)
 PLUGINS_all   = $(PLUGINDIR)/arduino.$(SOEXT)
-PLUGINS_build = $(PLUGINS_all)
 
-ifeq ($(HAVE_CPP11),1)
-  CFLAGS += $(CFLAGS_CPP11)
+HAVE_ARDUINO = $(shell if [[ -a /dev/arduino ]]; then echo 1 ; else echo 0; fi)
+HAVE_UDEV=$(if $(shell $(PKGCONFIG) --exists libudev; echo $${?/1/}),1,0)
+
+ifeq ($(HAVE_CPP11)$(HAVE_TF)$(HAVE_UDEV),111)
+  CFLAGS_UDEV=$(shell $(PKGCONFIG) --cflags libudev)
+  LDFLAGS_UDEV=$(shell $(PKGCONFIG) --libs libudev)
+  CFLAGS += $(CFLAGS_CPP11) $(CFLAGS_TF) $(CFLAGS_UDEV)
+  LDFLAGS += $(LDFLAGS_CPP11) $(LDFLAGS_TF) $(LDFLAGS_UDEV)
+  PLUGINS_build = $(PLUGINS_all)
 else
   ifneq ($(HAVE_CPP11),1)
     WARN_TARGETS += warning_cpp11
   endif
-endif
-
-ifeq ($(HAVE_TF),1)
-  CFLAGS += $(CFLAGS_TF)
-  LDFLAGS += $(LDFLAGS_TF)
-else
   ifneq ($(HAVE_TF),1)
     WARN_TARGETS += warning_tf
   endif
+  ifneq ($(HAVE_UDEV),1)
+    WARN_TARGETS += warning_udev
+  endif
 endif
 
-ifneq ($(HAVE_arduino),0) # arduino not found
-	WARN_TARGETS += warning_arduino
-else 
-  ifeq ($(HAVE_arduino),0) #arduino was found
+ifeq ($(HAVE_ARDUINO),1)
 all: flash_arduino
-  endif
+else
+  WARN_TARGETS += warning_arduino
+all: $(WARN_TARGETS)
 endif
 
-ifeq ($(OBJSSUBMAKE),1)
-  ifneq ($(WARN_TARGETS),)
-all: $(WARN_TARGETS)
-  endif
-.PHONY: warning_tf warning_cpp11 warning_arduino flash_arduino
-warning_cpp11:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TYELLOW)Omitting Arduino commnunication support$(TNORMAL) (C++11 support required)"
-warning_tf:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TYELLOW)Omitting Arduino commnunication support$(TNORMAL) (tf required)"
-warning_arduino:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TYELLOW)Omitting flashing Arduino$(TNORMAL) (/dev/arduino not found)"
 flash_arduino:
 	$(SILENT)($(MAKE) -C $(BASEDIR)/src/plugins/arduino/ArduinoSketch verify &> /dev/null) \
 		&& echo -e "$(INDENT_PRINT)--> $(TGREEN)No need to reflash arduino $(TNORMAL)"\
 		|| ( ($(MAKE) -C $(BASEDIR)/src/plugins/arduino/ArduinoSketch flash &> /dev/null) \
 			&& echo -e "$(INDENT_PRINT)--> $(TGREEN)Successfully reflashed arduino $(TNORMAL)" \
-			|| echo -e "$(INDENT_PRINT)--> $(TRED)Something went wrong while flashing the arduino $(TNORMAL)")
-endif
+			|| echo -e "$(INDENT_PRINT)--> $(TRED)Something went wrong while flashing the arduino $(TNORMAL)"; exit 1)
 
+ifeq ($(OBJSSUBMAKE),1)
+  ifneq ($(WARN_TARGETS),)
+all: $(WARN_TARGETS)
+  endif
+
+.PHONY: $(WARN_TARGETS)
+warning_cpp11:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TYELLOW)Omitting Arduino commnunication support$(TNORMAL) (C++11 support required)"
+warning_tf:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TYELLOW)Omitting Arduino commnunication support$(TNORMAL) (tf required)"
+warning_arduino:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TYELLOW)Not flashing arduino$(TNORMAL) (/dev/arduino not found)"
+warning_udev:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TYELLOW)Omitting Arduino commnunication support$(TNORMAL) (libudev not found)"
+endif
 
 
 include $(BUILDSYSDIR)/base.mk


### PR DESCRIPTION
Do not build the plugin if libudev could not be found. Also clean up the
Makefile:
- Only build the plugin if all dependencies have been found
- Fix the definition of HAVE_ARDUINO (invert 0/1)
- Fail if flashing the arduino fails