### PR TITLE
Change handling of started goals after machine breaks in exec monitoring

### DIFF
--- a/src/clips-specs/rcll/execution-monitoring.clp
+++ b/src/clips-specs/rcll/execution-monitoring.clp
@@ -125,7 +125,6 @@
      (state FORMULATED|PENDING)
      (param-values $? ?mps $?)
      (action-name ?an))
-  (domain-atomic-precondition (operator ?an) (predicate mps-state) (param-values ?mps ?state))
   (not (wm-fact (key monitoring fail-goal args? g ?goal-id)))
   =>
   (assert (wm-fact (key monitoring fail-goal args? g ?goal-id) ))


### PR DESCRIPTION
This PR fixes #378. The modified rule did not fire since actions like wp-put were restructured, removing the mps-state precondition. 

Assuming all actions that require the mps as a parameter want to work with said mps, mark all such formulated and pending actions as failed, when the mps breaks.