### PR TITLE
Add workaround for stuck-on-launch headless simulation

### DIFF
--- a/etc/scripts/gazsim.bash
+++ b/etc/scripts/gazsim.bash
@@ -433,7 +433,25 @@ if [  $COMMAND  == start ]; then
 				if [ "$(command -v rcll-refbox-instruct)" == "" ]; then
 						echo "rcll-refbox-instruct not found, not built or old version?"
 				else
-						rcll-refbox-instruct -w
+                        (rcll-refbox-instruct -w) & pid=$!
+                        # in the background, sleep for 2 secs, kill, retry 
+                        run_wake=true
+                        retry_count=0
+                        while $run_wake
+                            do sleep 2
+                            if [ $retry_count -eq 10 ]
+                            then exit
+                                retry_count=$((retry_count+1))
+                            fi
+                            if ps -p $pid > /dev/null
+                            then kill -9 $pid 
+                                echo "Refbox wakeup stuck, retrying"
+                                (rcll-refbox-instruct -w) & pid=$!
+                            else 
+                                run_wake=false
+                                echo "Refbox alive"
+                            fi
+                        done
 						echo "Starting game (Phase: $START_GAME ${TEAM_CYAN:+Cyan: ${TEAM_CYAN}}${TEAM_MAGENTA:+ Magenta: ${TEAM_MAGENTA}})"
 						rcll-refbox-instruct -p SETUP -s RUNNING ${TEAM_CYAN:+-c ${TEAM_CYAN}}${TEAM_MAGENTA:+-m ${TEAM_MAGENTA}}
 						rcll-refbox-instruct -n $NUM_ROBOTINOS -W60 || (stop_simulation; exit 1)


### PR DESCRIPTION
This PR addresses robocup-logistics/rcll-refbox#87 by providing a functional workaround. 

The headless simulation (tmux based, as used in cx-simtest.bash), makes use of rcll-refbox-instruct to start the game. Due to a bug in `boost::asio::io_service`, it might get stuck without instructing the refbox. The following PR monitors the execution, retries after 2secs and repeats this for up to 10 times.