### PR TITLE
Revert team-name in agent.yaml. define as cx/rcll config

### DIFF
--- a/cfg/gazsim-configurations/default/host_robotino_1.yaml
+++ b/cfg/gazsim-configurations/default/host_robotino_1.yaml
@@ -10,7 +10,6 @@ fawkes:
   agent:
     name: Icks
     number: 1
-    team: Carologistics
 
 network:
   fawkes:

--- a/cfg/gazsim-configurations/default/host_robotino_2.yaml
+++ b/cfg/gazsim-configurations/default/host_robotino_2.yaml
@@ -10,7 +10,6 @@ fawkes:
   agent:
     name: Upsilan
     number: 2
-    team: Carologistics
 
 network:
   fawkes:

--- a/cfg/gazsim-configurations/default/host_robotino_3.yaml
+++ b/cfg/gazsim-configurations/default/host_robotino_3.yaml
@@ -10,7 +10,6 @@ fawkes:
   agent:
     name: Set
     number: 3
-    team: Carologistics
 
 network:
   fawkes:

--- a/src/clips-specs/rcll/refbox-actions.clp
+++ b/src/clips-specs/rcll/refbox-actions.clp
@@ -21,7 +21,7 @@
                       (action-name send-beacon) (executable TRUE)
                       (param-names $?param-names)
                       (param-values $?param-values))
-  (wm-fact (key config agent team)  (value ?team-name) )
+  (wm-fact (key config rcll team-name)  (value ?team-name) )
   (wm-fact (key config agent name)  (value ?robot-name) )
   (wm-fact (key config agent number)  (value ?robot-number) )
   (wm-fact (id "/refbox/team-color") (value ?team-color&:(neq ?team-color nil)))

--- a/src/clips-specs/rcll/refbox-worldmodel.clp
+++ b/src/clips-specs/rcll/refbox-worldmodel.clp
@@ -38,7 +38,7 @@
   ?pm <- (wm-fact (id "/refbox/points/magenta"))
   ?pc <- (wm-fact (id "/refbox/points/cyan"))
   ?tc <- (wm-fact (id "/refbox/team-color")  (value ?team-color) )
-  (wm-fact (key config agent team)  (value ?team-name) )
+  (wm-fact (key config rcll team-name)  (value ?team-name) )
   =>
   (retract ?pf ?gt ?pm ?pc)
   (bind ?new-state (pb-field-value ?p "state"))


### PR DESCRIPTION
The team-name is more related to agent implementation than the
agent itself. This also avoids the redundancy in having to specify the
team for every host. It is also easier to see in relation to the Redbox
configs declared in the cx.yaml

This commit reverts part of the changes introduced by 5fd913a63

This caused the issue that we had were not able to connect to the Redbox irl at the beginning of this season