### PR TITLE
cx: remove whtespace errors and fix pddl domain

### DIFF
--- a/src/clips-specs/rcll/action-selection.clp
+++ b/src/clips-specs/rcll/action-selection.clp
@@ -77,7 +77,7 @@
 	?p <- (plan (id EXPLORATION-PLAN) (goal-id ?goal-id))
 	?pa <- (plan-action (plan-id EXPLORATION-PLAN) (goal-id ?goal-id) (id ?id)
 			(action-name move-node) (param-values ?r ?node) (state FAILED))
-        (not (plan-action (plan-id EXPLORATION-PLAN) (goal-id ?goal-id) (id ?id2&:(> ?id2 ?id)) 
+        (not (plan-action (plan-id EXPLORATION-PLAN) (goal-id ?goal-id) (id ?id2&:(> ?id2 ?id))
 			(action-name move-node) (param-values ?r ?node2) (state FAILED)))
 	(Position3DInterface (id "Pose") (translation $?r-pose))
 	(navgraph-node (name ?node) (pos $?node-pos))

--- a/src/clips-specs/rcll/domain.pddl
+++ b/src/clips-specs/rcll/domain.pddl
@@ -219,7 +219,7 @@
 	(:action rs-mount-ring1
 		:parameters (?m - mps ?wp - workpiece ?col - ring-color ?rs-before - ring-num ?rs-after - ring-num ?r-req - ring-num)
 		:precondition (and (mps-type ?m RS) (or (mps-state ?m PROCESSING) (mps-state ?m READY-AT-OUTPUT)) (locked ?m)
-										(wp-at ?wp ?m INPUT) (not (mps-side-free ?m INPUT)) 
+										(wp-at ?wp ?m INPUT) (not (mps-side-free ?m INPUT))
                     (mps-side-free ?m OUTPUT)
 										(wp-usable ?wp)
 										(wp-ring1-color ?wp RING_NONE)
@@ -282,7 +282,7 @@
 			 				?ring-pos - ring-num ?col1 - ring-color ?col2 - ring-color ?col3 - ring-color
 							?r-req - ring-num)
 		:precondition (self ?r)
-		:effect (self ?r)	
+		:effect (self ?r)
 	)
 
 	; The following is the generic move version.

--- a/src/clips-specs/rcll/exploration.clp
+++ b/src/clips-specs/rcll/exploration.clp
@@ -392,7 +392,7 @@
 
 
 (defrule exp-exploration-ends-cleanup
-" As soon as the game phase switches to production, set the exploration goal to finished 
+" As soon as the game phase switches to production, set the exploration goal to finished
   and reset the velocity
 
 "

--- a/src/clips-specs/rcll/fixed-sequence.clp
+++ b/src/clips-specs/rcll/fixed-sequence.clp
@@ -900,14 +900,14 @@
   (assert
     (plan (id WAIT-FOR-MPS-PROCESS-PLAN) (goal-id ?goal-id))
   )
-  (if (eq ?pos ?mps-other) then 
+  (if (eq ?pos ?mps-other) then
     (assert
       (plan-action (id 1) (plan-id WAIT-FOR-MPS-PROCESS-PLAN) (goal-id ?goal-id)
                         (action-name wait)
                         (param-values ?robot ?pos))
     )
   else
-    (assert 
+    (assert
       (plan-action (id 1) (plan-id WAIT-FOR-MPS-PROCESS-PLAN) (goal-id ?goal-id)
                         (action-name go-wait)
                         (param-values ?robot ?mps-other ?side-other ?pos))

--- a/src/clips-specs/rcll/goal-reasoner.clp
+++ b/src/clips-specs/rcll/goal-reasoner.clp
@@ -98,7 +98,7 @@
               (eq ?goal-class MOUNT-FIRST-RING)
               (eq ?goal-class MOUNT-NEXT-RING)
               (eq ?goal-class DELIVER)
-              (eq ?goal-class RESET-MPS) 
+              (eq ?goal-class RESET-MPS)
               (eq ?goal-class WAIT)
               (eq ?goal-class GO-WAIT)
               (eq ?goal-class WAIT-FOR-MPS-PROCESS)))

--- a/src/clips-specs/rcll/rcll-domain.clp
+++ b/src/clips-specs/rcll/rcll-domain.clp
@@ -22,6 +22,6 @@
     (domain-effect
       (part-of visit) (predicate visited) (param-names to))
   )
-  
+
   (path-load "rcll/refbox.clp")
 )

--- a/src/clips-specs/rcll/refbox-comm-init.clp
+++ b/src/clips-specs/rcll/refbox-comm-init.clp
@@ -24,7 +24,7 @@
   "Initialization of refbox related facts."
   (executive-init)
   =>
-  (assert 
+  (assert
     (wm-fact (id "/refbox/team-color") )
     (wm-fact (id "/refbox/points/magenta") (type UINT) (value 0) )
     (wm-fact (id "/refbox/points/cyan") (type UINT) (value 0) )
@@ -33,7 +33,7 @@
     (wm-fact (id "/game/state")  (value WAIT_START) )
     (wm-fact (id "/refbox/game-time")  (type UINT) (is-list TRUE) (values 0 0))
     (wm-fact (key refbox beacon seq) (type UINT) (value 1))
-  )  
+  )
 )
 
 (defrule refbox-comm-enable-public

--- a/src/clips-specs/rcll/refbox-worldmodel.clp
+++ b/src/clips-specs/rcll/refbox-worldmodel.clp
@@ -26,7 +26,7 @@
   =>
   (bind ?beacon-name (pb-field-value ?p "peer_name"))
   (printout debug "Beacon Recieved from " ?beacon-name crlf)
-  (retract ?pf) 
+  (retract ?pf)
 )
 
 
@@ -105,7 +105,7 @@
           (loop-for-count (?c (+ 1 ?rings-count) 3) do
             (assert (wm-fact (key domain fact (sym-cat order- ring ?c -color) args? ord ?order-id col RING_NONE) (type BOOL) (value TRUE) ))
           )
-          (assert 
+          (assert
             (wm-fact (key domain fact order-complexity args? ord ?order-id comp ?complexity) (type BOOL) (value TRUE) )
             (wm-fact (key domain fact order-base-color args? ord ?order-id col ?base) (type BOOL) (value TRUE) )
             (wm-fact (key domain fact order-cap-color  args? ord ?order-id col ?cap) (type BOOL) (value TRUE) )
@@ -150,7 +150,7 @@
     (bind ?m-type (sym-cat (pb-field-value ?m "type")))
     (bind ?m-team (sym-cat (pb-field-value ?m "team_color")))
     (bind ?m-state (sym-cat (pb-field-value ?m "state")))
-    (if (not (any-factp ((?wm-fact wm-fact)) 
+    (if (not (any-factp ((?wm-fact wm-fact))
               (and  (wm-key-prefix ?wm-fact:key (create$ domain fact mps-state))
                     (eq ?m-name (wm-key-arg ?wm-fact:key m)))))
       then
@@ -164,12 +164,12 @@
         )
       )
     )
-   (do-for-fact ((?wm-fact wm-fact)) 
-                  (and  (wm-key-prefix ?wm-fact:key (create$ domain fact mps-state)) 
+   (do-for-fact ((?wm-fact wm-fact))
+                  (and  (wm-key-prefix ?wm-fact:key (create$ domain fact mps-state))
                         (eq ?m-name (wm-key-arg ?wm-fact:key m))
                         (neq ?m-state (wm-key-arg ?wm-fact:key s)))
       (retract ?wm-fact)
-      (assert (wm-fact (key domain fact mps-state args? m ?m-name s ?m-state) (type BOOL) (value TRUE))) 
+      (assert (wm-fact (key domain fact mps-state args? m ?m-name s ?m-state) (type BOOL) (value TRUE)))
     )
    )
 )


### PR DESCRIPTION
This PR should be addressed once all recent agent PRs are processed.
I want to get rid of all the anoying trailing whitespaces, fix some pddl errors and afterwards reformat the whole domain file as its indentation is a hot mess.