### PR TITLE
rework domain for central agent

### DIFF
--- a/src/clips-specs/rcll-central/domain.pddl
+++ b/src/clips-specs/rcll-central/domain.pddl
@@ -86,7 +86,6 @@
 	(cs-prepared-for ?m - mps ?op - cs-operation)
 	(cs-buffered ?m - mps ?col - cap-color)
 	(cs-color ?m - mps ?col - cap-color)
-	(cs-free ?m - mps)
 	(ss-prepared-for ?m - mps ?op - ss-operation ?wp - workpiece ?shelf - ss-shelf ?slot - ss-slot)
 	(rs-prepared-color ?m - mps ?col - ring-color)
 	(rs-ring-spec ?m - mps ?r - ring-color ?rn - ring-num)


### PR DESCRIPTION
This PR adapts the PDDL domain description used in the decentralized agents for use in the new centralized agents, by removing actions and predicates that are no longer relevant. It also includes some housekeeping (formatting of the entire file, removal of unused actions, ...). 

- Base domain description on version from tviehmann/storage-station-full for future proofing
- Fix formatting
- Remove self predicate (no self in a centralized agent)
- Remove request actions (will be modelled differently)
- Remove old and unused actions and predicates. 