### PR TITLE
marker_writer: no warning for free non heap obj

### DIFF
--- a/src/plugins/marker_writer/marker_writer_thread.cpp
+++ b/src/plugins/marker_writer/marker_writer_thread.cpp
@@ -75,9 +75,6 @@ MarkerWriterThread::finalize()
 	}
 	pub_->shutdown();
 	delete pub_;
-	for (Position3DInterface *pos_if : pos_ifs_) {
-		delete pos_if;
-	}
 }
 
 void


### PR DESCRIPTION
Fawkes does not build under Fedora 34 on either the base or laptop due to this warning.

Not sure whether disabling the warning is the correct way, but I couldn't find a definitive fix on google.