### PR TITLE
Remove unavailable machine facts 

### DIFF
--- a/src/clips-specs/rcll-central/refbox-worldmodel.clp
+++ b/src/clips-specs/rcll-central/refbox-worldmodel.clp
@@ -176,14 +176,24 @@
     )
   )
   ;remove machines that do not exist
-  (printout t "Available machines: " ?machines crlf)
   (do-for-all-facts ((?wm-fact wm-fact))
-      (and  (wm-key-prefix ?wm-fact:key (create$ domain fact mps-team))
-            (not (member$ (wm-key-arg ?wm-fact:key m) ?machines))
+      (or   (and  (wm-key-prefix ?wm-fact:key (create$ domain fact mps-team))
+              (not (member$ (wm-key-arg ?wm-fact:key m) ?machines))
+            )
+            (and  (wm-key-prefix ?wm-fact:key (create$ domain fact mps-side-free))
+              (not (member$ (wm-key-arg ?wm-fact:key m) ?machines))
+            )
+            (and  (wm-key-prefix ?wm-fact:key (create$ domain fact mps-state))
+              (not (member$ (wm-key-arg ?wm-fact:key m) ?machines))
+            )
+            (and  (wm-key-prefix ?wm-fact:key (create$ domain fact mps-type))
+              (not (member$ (wm-key-arg ?wm-fact:key m) ?machines))
+            )
       )
       (retract ?wm-fact)
   )
 )
+
 
 
 (defrule game-receive-field-layout-protobuf


### PR DESCRIPTION
Certain checks rely on all machines to be initialized, however in the RC21 challenges not all machines exist. Thus, remove the wm-facts from the non-existent machines to keep the checks satisfied. 