### PR TITLE
Allow move to current location

### DIFF
--- a/src/clips-specs/rcll-central/execution-monitoring.clp
+++ b/src/clips-specs/rcll-central/execution-monitoring.clp
@@ -344,7 +344,7 @@
 ; ----------------------- HANDLE SAME SIDE MOVE -------------------------------
 
 (defrule execution-monitoring-handle-same-side-move
-" Resetting the timeout-timer if a move action is pending while waiting for its target mps-side to be approachable.
+" Allows move to current location by setting mps mps-side to be approachable.
 "
   (declare (salience ?*MONITORING-SALIENCE*))
   (plan-action 


### PR DESCRIPTION
This PR fixes a bug where move is stuck in pending if start and target locations are the same.
This case is catched in the execution-monitoring and sets mps mps-side approachable.