### PR TITLE
rcll-central: Add execution monitoring for wp-put-slide-cc

### DIFF
--- a/src/clips-specs/rcll-central/execution-monitoring.clp
+++ b/src/clips-specs/rcll-central/execution-monitoring.clp
@@ -370,11 +370,8 @@
          )
   (domain-atomic-precondition (operator wp-put-slide-cc) (grounded-with ?action-id) (is-satisfied FALSE))
   (wm-fact (key domain fact rs-filled-with args? m ?rs n ?rs-num&:(not (eq ?rs-num ?rs-before))))
-  (wm-fact (key domain fact rs-inc args? summand ?rs-before sum ?rs-after))
+  (wm-fact (key domain fact rs-inc args? summand ?rs-num sum ?rs-num-after))
   =>
-  (if (and (eq ?rs-num ONE) (eq ?rs-after ONE))
-    then
-	(printout t "rs-before is unequal to rs-filled-with" crlf)
-	(modify ?pa (param-values ?robot ?wp ?rs ?rs-num TWO))
-  )
+  (printout t "execuction monitoring wp-put-slide-cc: rs-before is unequal to rs-filled-with" crlf)
+  (modify ?pa (param-values ?robot ?wp ?rs ?rs-num ?rs-num-after))
 )


### PR DESCRIPTION
- Check if rs filled with is equal to rs-before of wp-put-slide-cc
  if not the action parameters are adapted