### PR TITLE
scripts: fix broken */lib* check in GAZEBO_PLUGIN_PATH

### DIFF
--- a/etc/scripts/gazsim.bash
+++ b/etc/scripts/gazsim.bash
@@ -336,7 +336,7 @@ if [  $COMMAND  == start ]; then
 	echo "FAWKES_DIR is not set"
 	exit 1
     fi
-    if $START_GAZEBO && ! [[ $GAZEBO_PLUGIN_PATH == *lib/gazebo* ]]
+    if $START_GAZEBO && ! [[ $GAZEBO_PLUGIN_PATH == *gazebo-rcll* ]]
     then
 	echo "Missing path to Gazebo Plugins in GAZEBO_PLUGIN_PATH";
 	exit 1


### PR DESCRIPTION
With the change to cmake in gazebo-rcll, the gazebo plugin path changed and now does not contain `lib` anymore.
Instead, check for occurrences of `gazebo-rcll`.