### PR TITLE
Drive back after putting a workpiece on the machine

### DIFF
--- a/src/lua/skills/robotino/product_pick.lua
+++ b/src/lua/skills/robotino/product_pick.lua
@@ -49,7 +49,7 @@ local conveyor_gripper_down_z = -0.027  -- distance to move gripper down after d
 local conveyor_gripper_back_x = -0.03 -- distance to move gripper back after closing gripper
 local conveyor_gripper_up_z = 0.025   -- distance to move gripper up after closing gripper
 
-local drive_back_x = -0.1      -- distance to drive back after closing the gripper
+local drive_back_x = -0.2      -- distance to drive back after closing the gripper
 
 local gripper_pose_offset_x = 0.013   -- conveyor pose offset in x direction
 local gripper_pose_offset_y = 0.00   -- conveyor_pose offset in y direction

--- a/src/lua/skills/robotino/product_put.lua
+++ b/src/lua/skills/robotino/product_put.lua
@@ -59,7 +59,7 @@ local slide_gripper_down_z = -0.04    -- distance to move gripper down after dri
 local slide_gripper_back_x = -0.01 -- distance to move gripper back after opening the gripper if the target is slide
 local slide_gripper_up_z = 0.01    --distance to move gripper up after opening the gripper if the target is slide
 
-local drive_back_x = -0.1      -- distance to drive back after closing the gripper
+local drive_back_x = -0.2      -- distance to drive back after closing the gripper
 
 function pose_not_exist()
   local target_pos = { x = gripper_pose_offset_x,


### PR DESCRIPTION
Avoid collisions with the machine by first backing off before finishing the skill. We used to do this, but apparently this was accidentally removed in commit c432271.

Also increase the distance to move back from 0.1m to 0.2m. This further reduces the collisions with machines, at least in simulation.