### PR TITLE
cx: stop wait actions from reacting on wrong timers

### DIFF
--- a/src/clips-specs/rcll-central/wait-actions.clp
+++ b/src/clips-specs/rcll-central/wait-actions.clp
@@ -36,7 +36,7 @@
   ?pa <- (plan-action (id ?action-id) (plan-id ?plan-id) (goal-id ?goal-id)
                       (action-name wait) (state RUNNING))
   (time $?now)
-  ?timer <- (timer (name ?name &: (sym-cat ?goal-id - ?plan-id - ?action-id))
+  ?timer <- (timer (name ?name &:(eq ?name (sym-cat ?goal-id - ?plan-id - ?action-id)))
                    (time $?t&:(timeout ?now ?t ?*WAIT-DURATION*)))
   =>
   (printout info "Finished waiting" crlf)
@@ -47,7 +47,7 @@
 (defrule action-fail-execute-wait-action
   ?pa <- (plan-action (id ?action-id) (plan-id ?plan-id) (goal-id ?goal-id)
                       (action-name wait) (state RUNNING) (executable TRUE))
-  (not (timer (name ?name &: (sym-cat ?goal-id - ?plan-id - ?action-id))))
+  (not (timer (name ?name &:(eq ?name (sym-cat ?goal-id - ?plan-id - ?action-id)))))
   =>
   (printout warn "Failed to wait, timer for action id " ?action-id
                  ", plan-id " ?plan-id ", goal-id " ?goal-id " does not exist"

--- a/src/clips-specs/rcll/wait-actions.clp
+++ b/src/clips-specs/rcll/wait-actions.clp
@@ -36,7 +36,7 @@
   ?pa <- (plan-action (id ?action-id) (plan-id ?plan-id) (goal-id ?goal-id)
                       (action-name wait) (state RUNNING) (executable TRUE))
   (time $?now)
-  ?timer <- (timer (name ?name &: (sym-cat ?goal-id - ?plan-id - ?action-id))
+  ?timer <- (timer (name ?name &:(eq ?name (sym-cat ?goal-id - ?plan-id - ?action-id)))
                    (time $?t&:(timeout ?now ?t ?*WAIT-DURATION*)))
   =>
   (printout info "Finished waiting" crlf)
@@ -47,7 +47,7 @@
 (defrule action-fail-execute-wait-action
   ?pa <- (plan-action (id ?action-id) (plan-id ?plan-id) (goal-id ?goal-id)
                       (action-name wait) (state RUNNING) (executable TRUE))
-  (not (timer (name ?name &: (sym-cat ?goal-id - ?plan-id - ?action-id))))
+  (not (timer (name ?name &:(eq ?name (sym-cat ?goal-id - ?plan-id - ?action-id)))))
   =>
   (printout warn "Failed to wait, timer for action id " ?action-id
                  ", plan-id " ?plan-id ", goal-id " ?goal-id " does not exist"


### PR DESCRIPTION
I found a funny little bug, where a wait action deleted a timer of a `prepare-cs`. One of those "how did this ever work" type of things i guess, as it has been around for ages and in both the central and decentral agent...