### PR TITLE
rcll-central: use upper-case for insertion zone names

### DIFF
--- a/src/clips-specs/rcll-central/fixed-sequence.clp
+++ b/src/clips-specs/rcll-central/fixed-sequence.clp
@@ -626,10 +626,10 @@
 	(wm-fact (key refbox team-color) (value ?team-color))
 	(wm-fact (key config rcll challenge-flip-insertion) (value ?flip))
 	=>
-	(bind ?dropzone M-ins-out)
+	(bind ?dropzone M-INS-OUT)
 	(if (or (and (eq ?team-color CYAN) (neq ?flip TRUE))
 	        (and (eq ?team-color MAGENTA) (eq ?flip TRUE))) then
-		(bind ?dropzone C-ins-out)
+		(bind ?dropzone C-INS-OUT)
 	)
 
 	(plan-assert-sequential (sym-cat DELIVER-RC21-PLAN- (gensym*)) ?goal-id ?robot


### PR DESCRIPTION
The mapping of movement skills shift those to upper-case anyways. To
avoid confusion, stick to the name from the beginning.

See also https://github.com/carologistics/fawkes-robotino/pull/519.