### PR TITLE
Fix misaligned box filter messages

### DIFF
--- a/src/plugins/mps-laser-gen/mps-laser-gen_thread.cpp
+++ b/src/plugins/mps-laser-gen/mps-laser-gen_thread.cpp
@@ -159,10 +159,10 @@ MPSLaserGenThread::loop()
 				mps.corners[2] = (rot * mps.corners[2]) + mps.center;
 				mps.corners[3] = (rot * mps.corners[3]) + mps.center;
 
-				float dists[4]  = {mps.corners[0].norm(),
-                          mps.corners[1].norm(),
-                          mps.corners[2].norm(),
-                          mps.corners[3].norm()};
+				float dists[4] = {mps.corners[0].norm(),
+			                          mps.corners[1].norm(),
+			                          mps.corners[2].norm(),
+			                          mps.corners[3].norm()};
 				mps.closest_idx = 0;
 				for (unsigned int i = 1; i < 4; ++i) {
 					if (dists[i] < dists[mps.closest_idx])


### PR DESCRIPTION
The messages set for the `box_filter` were misaligned and hence caused the `box_filter` to not properly filter out the machines.
It is required to differentiate the view on the particular machine for the two use cases:
 * Use absolute coordinates of the MPS for the `box_filter`
 * Use sensor-relative coordinates to generate the actual MPS laser