### PR TITLE
Set a proper error message on invalid target

### DIFF
--- a/src/lua/skills/robotino/goto.lua
+++ b/src/lua/skills/robotino/goto.lua
@@ -165,6 +165,7 @@ function INIT:init()
 
       else
         self.fsm.vars.target_valid = false
+        self.fsm.error = "target invalid"
       end
     end
   else


### PR DESCRIPTION
This simply fills the `error` field of `fsm` in case the desired target is invalid.