### PR TITLE
rcll-central: Fixed create-move-out-of-way

### DIFF
--- a/src/clips-specs/rcll-central/goal-production.clp
+++ b/src/clips-specs/rcll-central/goal-production.clp
@@ -535,22 +535,6 @@
 	(return ?goal)
 )
 
-
-<<<<<<< HEAD
-(deffunction goal-production-assert-move-out-of-way
-  (?location)
-  (bind ?goal (assert (goal (class MOVE-OUT-OF-WAY)
-              (id (sym-cat MOVE-OUT-OF-WAY- (gensym*)))
-              (sub-type SIMPLE)
-              (verbosity NOISY) (is-executable FALSE)
-              (meta-template goal-meta)
-              (params target-pos (translate-location-map-to-grid ?location) location ?location)
-  )))
-  (return ?goal)
-)
-
-=======
->>>>>>> 932146e92 (rcll-central: removed unused function and redundant match)
 (deffunction goal-production-assign-order-and-prio-to-goal (?goal ?order-id ?prio)
   (bind ?goal-id (fact-slot-value ?goal id))
   (modify ?goal (priority ?prio))


### PR DESCRIPTION
This PR changed the arbitrary waiting zones to the actual waiting zones, which are generated after the exploration.