### PR TITLE
Payment tracking and payment distribution

### DIFF
--- a/src/clips-specs/rcll-central/execution-monitoring.clp
+++ b/src/clips-specs/rcll-central/execution-monitoring.clp
@@ -443,11 +443,11 @@
 (deffunction distribute-payments
 	(?root-id)
 ; Distributing the payments of a failed PRODUCE-ORDER goal
-;1 get finished payments for mps
+;1 get payments for mps
 	(bind ?paid (create$))
 	(bind ?paid-at (create$))
 	(bind ?order-id (fact-slot-value (nth$ 1 (find-fact ((?meta goal-meta))(eq ?meta:goal-id ?root-id))) order-id))
-	(do-for-all-facts ((?wm-fact wm-fact)) (and (wm-key-prefix ?wm-fact:key (create$ mps finished payments order))
+	(do-for-all-facts ((?wm-fact wm-fact)) (and (wm-key-prefix ?wm-fact:key (create$ mps state payments order))
 																							(eq ?order-id (wm-key-arg ?wm-fact:key ord)))
 		(if (neq 0 ?wm-fact:value) then
 			(bind ?paid (insert$ ?paid 1 ?wm-fact:value))
@@ -460,7 +460,7 @@
 																			(member$ (nth$ 8 ?gf:params) ?paid-at)
 																			(neq ?order-id (fact-slot-value (nth$ 1 (find-fact ((?m goal-meta)) (eq ?gf:id ?m:goal-id))) order-id))
 																			(neq 0 (length$ ?paid)))
-				;3 finish goal and reduce amout of finished payments for given
+				;3 finish goal and reduce amout of  payments
 		(modify ?gf (mode FINISHED)(outcome COMPLETED))
 		(bind ?i 0)
 		(if (eq (nth$ 8 ?gf:params) (nth$ 1 ?paid-at)) then

--- a/src/clips-specs/rcll-central/goal-reasoner.clp
+++ b/src/clips-specs/rcll-central/goal-reasoner.clp
@@ -494,7 +494,7 @@
 	            (verbosity ?v) (params $? ?mn $? ?rc))
 	(goal-meta (goal-id ?goal-id) (assigned-to ?robot)(order-id ?order-id))
   ?wmf-order <- (wm-fact (key mps workload order args? m ?mn ord ?order-id))
-  ?pay-order <- (wm-fact (key mps finished payments order args? m ?mn ord ?order-id))
+  ?pay-order <- (wm-fact (key mps state payments order args? m ?mn ord ?order-id))
 =>
 	(set-robot-to-waiting ?robot)
 	(printout (log-debug ?v) "Goal " ?goal-id " EVALUATED" ?mn  crlf)

--- a/src/clips-specs/rcll-central/production-strategy.clp
+++ b/src/clips-specs/rcll-central/production-strategy.clp
@@ -121,7 +121,7 @@
 =>
   (modify ?update-fact (value TRUE))
   (bind ?wl workload)
-  (bind ?pm (create$ finished payments))
+  (bind ?pm (create$ state payments))
   (delayed-do-for-all-facts ((?mps-type domain-fact)) (eq (nth$ 2 ?mps-type:param-values) RS)
     (bind ?payment-sum (calculate-order-payments-sum ?order (nth$ 1 ?mps-type:param-values)))
     (production-strategy-assert-workload-or-payment-for-machine ?wl ?order (nth$ 1 ?mps-type:param-values)


### PR DESCRIPTION
This PR added payment tracking in form of the existing workload facts.
 Furthermore the payment distribution was added which is supposed to be called after a wp is lost, to distribute the already transacted payments to other goaltrees