### PR TITLE
rcll-central: Bind BS-INSTRUCT-DESPENSE to correct goal for wait-for-wp action

### DIFF
--- a/src/clips-specs/rcll-central/goal-executability.clp
+++ b/src/clips-specs/rcll-central/goal-executability.clp
@@ -713,6 +713,7 @@ The workpiece remains in the output of the used ring station after
 	(plan-action (action-name wait-for-wp) (param-values ?robot ?mps ?side)
 	             (goal-id ?oid) (state PENDING|RUNNING)
 	             (precondition ?precondition-id))
+	(goal (id ?oid) (params $? wp ?wp $?))
 	(goal-meta (goal-id ?oid) (order-id ?order-id))
 	(not (goal (class INSTRUCT-BS-DISPENSE-BASE) (mode SELECTED|DISPATCHED|COMMITTED|EXPANDED)))
 	=>


### PR DESCRIPTION
Previously it could occur that the wrong BS Instruct goal was executed w.r.t. the goal that was executing a wait-for-wp action leading to mismatches and potential game breaking behavior.