### PR TITLE
cx-central: Add rule to restart prepare action timer when mps is down

### DIFF
--- a/src/clips-specs/rcll-central/refbox-actions.clp
+++ b/src/clips-specs/rcll-central/refbox-actions.clp
@@ -11,7 +11,7 @@
   ?*BEACON-PERIOD* = 1.0
   ?*PREPARE-PERIOD* = 1.0
   ?*ABORT-PREPARE-PERIOD* = 30.0
-
+  ?*ABORT-PREPARE-DOWN-REST* = 1.0
 )
 
 (defrule action-send-beacon-signal


### PR DESCRIPTION
When an MPS is down (e.g. because of maintenance), a prepare plan-action cannot
be sent and the failing action will cause the workpiece to be blocking the input.
This rule captures such situations and resets the timer a given period before the timeout.