### PR TITLE
rcll-central: fix rebase issue missing closing bracket

### DIFF
--- a/src/clips-specs/rcll-central/execution-monitoring.clp
+++ b/src/clips-specs/rcll-central/execution-monitoring.clp
@@ -468,6 +468,7 @@
   =>
   (modify ?at (time ?now))
   (printout t "Action prepare-" ?mps " timer extended due to down machine" crlf)
+)
 
 ; ----------------------- RESTORE FROM BACKUP -------------------------------
 


### PR DESCRIPTION
A bracket was missing after rebase, this minor PR fixes the issue. 