### PR TITLE
YOLO: fix bounding box projection

### DIFF
--- a/src/plugins/object-tracking/object_tracking_thread.cpp
+++ b/src/plugins/object-tracking/object_tracking_thread.cpp
@@ -798,31 +798,29 @@ ObjectTrackingThread::compute_3d_point(std::array<float, 4> bounding_box,
 		return;
 	}
 
+	float object_width = object_widths_[(int)current_object_type_];
+	float angle;
 	if (current_object_type_ == ObjectTrackingInterface::WORKPIECE) {
-		//workpieces have an equal width from all angles
-		//distance towards this perception + additional adjustments through angle
-		float dist = object_widths_[(int)current_object_type_] / (dx_right - dx_left);
+		//workpiece angles depend only on the camera view and not the mps
+		angle = atan((dx_right + dx_left) / 2);
+	} else {
+		angle = mps_angle;
+	}
 
-		//compute base middle point with deltas and distance
-		// using the bottom point + wp_height/2
-		point[0] = dist;
-		point[1] = (dx_left + dx_right) * dist / 2;
-		point[2] = dy_top * dist + puck_height_ / 2;
+	//distance towards object center point
+	float dist = ((cos(angle) + sin(angle) * dx_left) * object_width) / (dx_right - dx_left)
+	             + sin(angle) * object_width / 2;
 
+	//compute middle point with deltas and distance
+	point[0] = dist;
+	point[1] = (dx_left + dx_right) * dist / 2;
+
+	if (current_object_type_ == ObjectTrackingInterface::WORKPIECE) {
+		//compute base middle point using the bottom point + wp_height/2
+		point[2]             = dy_top * dist + puck_height_ / 2;
 		wp_additional_height = max(puck_height_ / 2, dy_bottom * dist - point[2]);
 	} else {
-		//percieved object width from angle
-		float object_width = cos(mps_angle) * object_widths_[(int)current_object_type_];
-
-		//distance towards this perception + additional adjustments through angle
-		float dist = object_width / (dx_right - dx_left)
-		             + sin(abs(mps_angle)) * object_widths_[(int)current_object_type_] / 2;
-
-		//compute middle point with deltas and distance
-		point[0] = dist;
-		point[1] = (dx_left + dx_right) * dist / 2;
-		point[2] = dy_center * dist;
-
+		point[2]             = dy_center * dist;
 		wp_additional_height = 0;
 	}
 }


### PR DESCRIPTION
There was a bug in the projection from YOLO bounding box to 3D position which caused workpieces to be projected closer in direction of the camera the further the object was away from the image middle.