### PR TITLE
rcll-central: fix condition for order tree creation when no active order

### DIFF
--- a/src/clips-specs/rcll-central/goal-production.clp
+++ b/src/clips-specs/rcll-central/goal-production.clp
@@ -813,8 +813,10 @@
         (wm-fact (key strategy meta selected-order args? cond possible) (value ?order-id))
         (not
             (and
-                (goal (id ?oid) (mode FORMULATED|SELECTED|EXPANDED|COMMITTED|DISPATCHED))
+                (goal (id ?oid) (mode FORMULATED|SELECTED|EXPANDED|COMMITTED|DISPATCHED)
+                            (sub-type SIMPLE) (parent ?o-parent))
                 (goal-meta (goal-id ?oid) (root-for-order ~nil))
+                (goal (id ?o-parent) (class MOVE-OUT-OF-WAY))
             )
         )
     )


### PR DESCRIPTION
When there is no active order, but there is a possible order that has
already expired, start the expired order in attempts to get more points
(this usually only happens at the end of a game). The previous
condition modelling this, failed to consider MOVE-OUT-OF-WAY goals
which would be active at that point.