### PR TITLE
realsense2: add enable_depth config to disable point clouds

### DIFF
--- a/cfg/conf.d/realsense2.yaml
+++ b/cfg/conf.d/realsense2.yaml
@@ -23,6 +23,9 @@ realsense2:
   # messages. If false, switch messages will be ignored.
   use_switch: true
 
+  # If true, enable depth vision and publish point cloud
+  enable_depth: false
+
   # Desired Frame rate. Device will try deliver new frames in time.
   # Use 0 for don't care
   # Not all Frame rates supported on each device


### PR DESCRIPTION
This PR is needed to disable point clouds in the realsense2 plugin in fawkes core.