### PR TITLE
remove laptop setup for robot 1 from off-field2

### DIFF
--- a/cfg/host_off-field2.d/bbsync.yaml
+++ b/cfg/host_off-field2.d/bbsync.yaml
@@ -47,15 +47,6 @@ fawkes/bbsync:
   peers:
     robotino-base/active: false
 
-    laptop1:
-      #active: true (set via the off-field startup)
-      host: robotino-laptop-1
-      port: !tcp-port 1910
-      reading:
-        navgraph-generator-mps: NavGraphWithMPSGeneratorInterface::/navgraph-generator-mps=/laptop1/navgraph-generator-mps
-        navgraph-generator: NavGraphGeneratorInterface::/navgraph-generator=/laptop1/navgraph-generator
-        navigator: NavigatorInterface::Navigator=/laptop1/Navigator
-
     robot1:
       #active: true (set via the off-field startup)
       host: robotino-base-1

--- a/etc/scripts/off_field_central_agent_start.bash
+++ b/etc/scripts/off_field_central_agent_start.bash
@@ -42,17 +42,11 @@ for CURR_ROBO in $ALL_ROBOTS
 		fi
 	done
 	if [[ -z "$IS_ACTIVE" ]]; then
-		if (( $CURR_ROBO == 1)); then
-			echo "  laptop1/active: false" >> $CFG_DIR/startup_generated.yaml
-		fi
 		echo "  robot$CURR_ROBO/active: false" >> $CFG_DIR/startup_generated.yaml
 	fi
 done
 for ACTIVE_ROBO in $ACTIVE_ROBOTS
 	do
-		if (( $ACTIVE_ROBO == 1)); then
-			echo "  laptop1/active: true" >> $CFG_DIR/startup_generated.yaml
-		fi
 		echo "  robot$ACTIVE_ROBO/active: true" >> $CFG_DIR/startup_generated.yaml
 	done
 


### PR DESCRIPTION
The laptop setup is obsolete as the robotino of robot 1 got a new head which fixed the hardware issues that required the laptop setup.