### PR TITLE
cx: remove fact pointer in error message

### DIFF
--- a/src/clips-specs/rcll-central/goals/central-run-all.clp
+++ b/src/clips-specs/rcll-central/goals/central-run-all.clp
@@ -91,7 +91,7 @@
 	?sg <- (goal (parent ?id) (type ACHIEVE) (mode FINISHED) (outcome FAILED))
 	=>
 	(modify ?gf (mode FINISHED) (outcome FAILED)
-	            (error SUB-GOAL-FAILED ?sg)
+	            (error SUB-GOAL-FAILED)
 	            (message (str-cat "Sub-goal '" (fact-slot-value ?sg id) "' of CENTRAL-RUN-ALL goal '" ?id "' has failed")))
 )
 


### PR DESCRIPTION
The fact pointer does not belong in a slot with allowed values symbol. While this is no inherent issue, this becomes problematic ones goal facts are translated to wm facts.