### PR TITLE
rcll-central: do not buffer if other buffer goal is active on same mps

### DIFF
--- a/src/clips-specs/rcll-central/goal-executability.clp
+++ b/src/clips-specs/rcll-central/goal-executability.clp
@@ -132,6 +132,11 @@
 	                    cap-color ?cap-color
 	            )
 	            (is-executable FALSE))
+	(not (goal (class BUFFER-CAP)
+	            (mode SELECTED|EXPANDED|COMMITTED|DISPATCHED)
+	            (params target-mps ?mps
+	                    cap-color ?cap-color
+	            )))
 	(goal-meta (goal-id ?id) (assigned-to ?robot&~nil))
 	(wm-fact (key refbox team-color) (value ?team-color))
 	; Robot CEs


### PR DESCRIPTION
This PR was used since last year and fixes an issue where 2 different buffer-cap goals are dispatched for the same at once.