### PR TITLE
Fix exp-stop rule by only checking if we found all machines from our team

### DIFF
--- a/src/clips-specs/rcll-central/exploration.clp
+++ b/src/clips-specs/rcll-central/exploration.clp
@@ -502,7 +502,8 @@
 
 (defrule exp-stop-when-all-found
 	?exp-active <- (wm-fact (key exploration active) (type BOOL) (value TRUE))
-	(not (and (wm-fact (key domain fact mps-type args? m ?target-mps $?))
+	(wm-fact (key refbox team-color) (value ?color))
+	(not (and (wm-fact (key domain fact mps-team args? m ?target-mps col ?color))
 	          (not (domain-fact (name zone-content)
 	                            (param-values ?zz ?target-mps))
 	)))


### PR DESCRIPTION
mps-type facts exist for all machines (including those of the other team), thus this rule never fired.