### PR TITLE
CX: Add Block and Clean-Up Requests

### DIFF
--- a/src/clips-specs/rcll-central/goal-executability.clp
+++ b/src/clips-specs/rcll-central/goal-executability.clp
@@ -241,6 +241,12 @@
 		(goal (class MOUNT-CAP) (id ?oid&~?goal-id) (mode ~FORMULATED) (params $? target-mps ?target-mps $?))
 		(goal-meta (goal-id ?oid) (assigned-to ~nil))
 	))
+
+	;consider block requests of orders with higher complexity
+	(not (and
+		(wm-fact (key request block args? mps ?target-mps wp ?other-wp&:(neq ?other-wp ?wp) com ?other-com ord ?other-order) (values ACTIVE $?))
+		(test (> (com-to-int ?other-com) (com-to-int ?order-complexity)))
+	))
 	=>
 	(printout t "Goal MOUNT-CAP executable for " ?robot crlf)
 	(modify ?g (is-executable TRUE))
@@ -280,6 +286,7 @@
 	         (wm-fact (key domain fact wp-at args? wp ?wp m ?wp-loc side ?wp-side)))
 	    (wm-fact (key domain fact holding args? r ?robot wp ?wp)))
 	(wm-fact (key order meta wp-for-order args? wp ?wp ord ?order))
+	(wm-fact (key domain fact order-complexity args? ord ?order com ?com))
 	(domain-fact (name zone-content) (param-values ?zz1 ?target-mps))
 	(domain-fact (name zone-content) (param-values ?zz2 ?wp-loc))
 
@@ -287,6 +294,12 @@
   	(wm-fact (key refbox game-time) (values $?game-time))
 	(wm-fact (key refbox order ?order delivery-begin) (type UINT)
 	        (value ?begin&:(< ?begin (+ (nth$ 1 ?game-time) ?*DELIVER-AHEAD-TIME*))))
+
+	;consider block requests of orders with higher complexity
+	(not (and
+		(wm-fact (key request block args? mps ?ds wp ?other-wp&:(neq ?other-wp ?wp) com ?other-com ord ?other-order) (values ACTIVE $?))
+		(test (> (com-to-int ?other-com) (com-to-int ?com)))
+	))
 	=>
 	(printout t "Goal DELIVER executable for " ?robot crlf)
 	(modify ?g (is-executable TRUE))
@@ -350,6 +363,8 @@
 	         (wm-fact (key domain fact wp-at args? wp ?wp m ?wp-loc side ?wp-side)))
 	    (wm-fact (key domain fact holding args? r ?robot wp ?wp)))
 	(domain-fact (name zone-content) (param-values ?zz ?wp-loc))
+	;consider block requests
+	(not (wm-fact (key request block args? mps ?ds wp ?other-wp&:(neq ?other-wp ?wp) $?) (values ACTIVE $?)))
 	=>
 	(printout t "Goal DISCARD executable for " ?robot crlf)
 	(modify ?g (is-executable TRUE))
@@ -420,6 +435,8 @@
 	(domain-fact (name zone-content) (param-values ?zz2 ?target-mps))
 	;the BS is not in use
 	(not (wm-fact (key mps meta bs-in-use args? bs ?wp-loc $?)))
+	;consider block requests
+	(not (wm-fact (key request block args? mps ?ds wp ?other-wp&:(neq ?other-wp ?wp) $?) (values ACTIVE $?)))
 	=>
 	(printout t "Goal " PAY-FOR-RINGS-WITH-BASE " executable" crlf)
 	(modify ?g (is-executable TRUE))
@@ -485,6 +502,9 @@
 	)
 	(domain-fact (name zone-content) (param-values ?zz1 ?target-mps))
 	(domain-fact (name zone-content) (param-values ?zz2 ?wp-loc))
+
+	;consider block requests
+	(not (wm-fact (key request block args? mps ?target-mps wp ?other-wp&:(neq ?other-wp ?wp) $?) (values ACTIVE $?)))
 	=>
 	(bind ?wp-side nil)
 	(do-for-fact ((?wp-at wm-fact))
@@ -652,6 +672,12 @@ The workpiece remains in the output of the used ring station after
 
 	; Goal CEs
 	(not (goal (class MOUNT-RING) (mode SELECTED|EXPANDED|COMMITTED|DISPATCHED) (params $? target-mps ?target-mps $?)))
+
+	;consider block requests of orders with higher complexity
+	(not (and
+		(wm-fact (key request block args? mps ?target-mps wp ?other-wp&:(neq ?other-wp ?wp) com ?other-com ord ?other-order) (values ACTIVE $?))
+		(test (> (com-to-int ?other-com) (com-to-int ?complexity)))
+	))
 	=>
 	(printout t "Goal MOUNT-RING executable for " ?robot crlf)
 	(modify ?g (is-executable TRUE))

--- a/src/clips-specs/rcll-central/goal-requests.clp
+++ b/src/clips-specs/rcll-central/goal-requests.clp
@@ -320,18 +320,38 @@
 
 
 ; -------------------- Block Requests ------------------------
+(defrule goal-request-deactivate-block
+  " If there is a block request and it either timed out or the WP was moved to
+    the DS, deactivate the block request.
+  "
+  (wm-fact (key refbox game-time) (values ?now $?))
+  ?br <- (wm-fact (key request block args? mps ?ds wp ?wp com ?com ord ?order) (values ACTIVE ?st ?duration))
+
+  (or
+    (wm-fact (key domain fact wp-at args? wp ?wp m ?ds side INPUT)) ;wp arrived at DS
+    (test (> (- ?now ?st) ?duration))
+    (not (wm-fact (key domain fact wp-usable args? wp ?wp))) ;the wp was flushed away or consumed
+  )
+  =>
+  (modify ?br (values INACTIVE))
+)
+
 (defrule goal-request-block-ds-almost-finished-product
   " If there is a product that is soon going to be completed,
     issue a request to keep the the delivery station free, if possible.
   "
   ;get wp and order information
   (domain-object (name ?wp) (type workpiece))
-  (wm-fact (key wp meta next-step args? wp ?wp) (value DELIVER))
-  (wm-fact (key wp meta next-machine args? wp ?wp) (value ?ds))
+  (wm-fact (key domain fact mps-type args? m ?ds t DS))
+  (or
+    (wm-fact (key wp meta next-step args? wp ?wp) (value DELIVER))
+    (wm-fact (key wp meta next-machine args? wp ?wp) (value ?ds))
+  )
   (wm-fact (key order meta wp-for-order args? wp ?wp ord ?order))
-  (wm-fact (key domain fact order-complexity args? ord ?order comp ?com))
+  (wm-fact (key domain fact order-complexity args? ord ?order com ?com))
 
   ;either the wp is already at the output of a machine or the output is clear
+  (wm-fact (key domain fact mps-type args? m ?cs t CS))
   (or
     (wm-fact (key domain fact wp-at args? wp ?wp m ?cs side OUTPUT))
     (and
@@ -339,26 +359,10 @@
       (not (wm-fact (key domain fact wp-at args? wp ?any-wp m ?cs side OUTPUT)))
     )
   )
-  (wm-fact (key refbox game-time) (values $?now))
+  (wm-fact (key refbox game-time) (values ?now $?))
   (not (wm-fact (key request block args? mps ?ds wp ?wp com ?com ord ?order) (values $?)))
   =>
-  (assert (wm-fact (key request block args? mps ?ds wp ?wp com ?com ord ?order) (values ACTIVE ?now)))
-)
-
-(defrule goal-request-deactivate-block-ds
-  " If there is a block request and it either timed out or the WP was moved to
-    the DS, deactivate the block request.
-  "
-  (wm-fact (key refbox game-time) (values $?now))
-  ?br <- (wm-fact (key request block args? mps ?ds wp ?wp com ?com ord ?order) (values ACTIVE $?st))
-
-  (or
-    (wm-fact (key domain fact wp-at args? wp ?wp m ?ds side INPUT)) ;wp arrived at DS
-    (test (timeout ?now ?st ?*BLOCK-DURATION-DS*)) ;timeout occured
-    (not (wm-fact (key domain fact wp-usable args? wp ?wp))) ;the wp was flushed away or consumed
-  )
-  =>
-  (modify ?br (values INACTIVE))
+  (assert (wm-fact (key request block args? mps ?ds wp ?wp com ?com ord ?order) (values ACTIVE ?now ?*BLOCK-DURATION-DS*)))
 )
 
 (defrule goal-request-block-rs-almost-finished-product
@@ -371,33 +375,17 @@
   (wm-fact (key wp meta next-machine args? wp ?wp) (value ?rs))
   (wm-fact (key wp meta prev-machine args? wp ?wp) (value ?prev-mps))
   (wm-fact (key order meta wp-for-order args? wp ?wp ord ?order))
-  (wm-fact (key domain fact order-complexity args? ord ?order comp ?com))
+  (wm-fact (key domain fact order-complexity args? ord ?order com ?com))
 
   ;the wp is already at the output of the previous machine
   (wm-fact (key domain fact wp-at args? wp ?wp m ?prev-mps side OUTPUT))
   ;the input side of the target RS is free
   (not (wm-fact (key domain fact wp-at args? wp ?any-wp m ?rs side INPUT)))
 
-  (wm-fact (key refbox game-time) (values $?now))
-  (not (wm-fact (key request block args? mps ?rs wp ?wp com ?com ord ?order) (values ? ?ring $?)))
+  (wm-fact (key refbox game-time) (values ?now $?))
+  (not (wm-fact (key request block args? mps ?rs wp ?wp com ?com ord ?order) (values $? ?ring)))
   =>
-  (assert (wm-fact (key request block args? mps ?rs wp ?wp com ?com ord ?order) (values ACTIVE ?ring ?now)))
-)
-
-(defrule goal-request-deactivate-block-rs
-  " If there is a block request and it either timed out or the WP was moved to
-    the target RS, deactivate the block request.
-  "
-  (wm-fact (key refbox game-time) (values $?now))
-  ?br <- (wm-fact (key request block args? mps ?rs wp ?wp com ?com ord ?order) (values ACTIVE ?ring $?st))
-
-  (or
-    (wm-fact (key domain fact wp-at args? wp ?wp m ?rs side INPUT)) ;wp arrived at RS
-    (test (timeout ?now ?st ?*BLOCK-DURATION-RS*)) ;timeout occured
-    (not (wm-fact (key domain fact wp-usable args? wp ?wp))) ;the wp was flushed away or consumed
-  )
-  =>
-  (modify ?br (values INACTIVE))
+  (assert (wm-fact (key request block args? mps ?rs wp ?wp com ?com ord ?order) (values ACTIVE ?now ?*BLOCK-DURATION-RS* ?ring )))
 )
 
 (defrule goal-request-block-cs-almost-finished-product
@@ -410,7 +398,7 @@
   (wm-fact (key wp meta next-machine args? wp ?wp) (value ?cs))
   (wm-fact (key wp meta prev-machine args? wp ?wp) (value ?prev-mps))
   (wm-fact (key order meta wp-for-order args? wp ?wp ord ?order))
-  (wm-fact (key domain fact order-complexity args? ord ?order comp ?com))
+  (wm-fact (key domain fact order-complexity args? ord ?order com ?com))
 
   ;the wp is already at the output of the previous machine
   (wm-fact (key domain fact wp-at args? wp ?wp m ?prev-mps side OUTPUT))
@@ -418,24 +406,8 @@
   (not (wm-fact (key domain fact wp-at args? wp ?any-wp m ?cs side INPUT)))
   (wm-fact (key domain fact cs-buffered args? m ?cs col ?any-cap-color))
 
-  (wm-fact (key refbox game-time) (values $?now))
+  (wm-fact (key refbox game-time) (values ?now $?))
   (not (wm-fact (key request block args? mps ?cs wp ?wp com ?com ord ?order) (values $?)))
   =>
-  (assert (wm-fact (key request block args? mps ?cs wp ?wp com ?com ord ?order) (values ACTIVE ?now)))
-)
-
-(defrule goal-request-deactivate-block-cs
-  " If there is a block request and it either timed out or the WP was moved to
-    the DS, deactivate the block request.
-  "
-  (wm-fact (key refbox game-time) (values $?now))
-  ?br <- (wm-fact (key request block args? mps ?cs wp ?wp com ?com ord ?order) (values ACTIVE $?st))
-
-  (or
-    (wm-fact (key domain fact wp-at args? wp ?wp m ?cs side INPUT)) ;wp arrived at CS
-    (test (timeout ?now ?st ?*BLOCK-DURATION-CS*)) ;timeout occured
-    (not (wm-fact (key domain fact wp-usable args? wp ?wp))) ;the wp was flushed away or consumed
-  )
-  =>
-  (modify ?br (values INACTIVE))
+  (assert (wm-fact (key request block args? mps ?cs wp ?wp com ?com ord ?order) (values ACTIVE ?now ?*BLOCK-DURATION-CS*)))
 )

--- a/src/clips-specs/rcll-central/production-strategy.clp
+++ b/src/clips-specs/rcll-central/production-strategy.clp
@@ -533,6 +533,7 @@
 "
   (declare (salience ?*SALIENCE-PRODUCTION-STRATEGY*))
   (wm-fact (key order meta wp-for-order args? wp ?wp ord ?order))
+  (wm-fact (key domain fact wp-at args? wp ?wp m ? side OUTPUT))
   ; WP CEs
   (wm-fact (key domain fact wp-ring1-color args? wp ?wp col ?wp-col-r1))
   (wm-fact (key domain fact wp-ring2-color args? wp ?wp col ?wp-col-r2))

--- a/src/clips-specs/rcll-central/production-strategy.clp
+++ b/src/clips-specs/rcll-central/production-strategy.clp
@@ -554,6 +554,7 @@
   (wm-fact (key domain fact rs-ring-spec args? m ?rs2 r ?col-r2 $?))
   (wm-fact (key domain fact rs-ring-spec args? m ?rs3 r ?col-r3 $?))
   (wm-fact (key refbox team-color) (value ?team-color))
+  (wm-fact (key domain fact mps-type args? m ?ds t DS))
   ; WP Meta CEs
   ?ns <- (wm-fact (key wp meta points-current args? wp ?wp) (value ?p-curr))
   ?wm <- (wm-fact (key wp meta next-step args? wp ?wp)
@@ -587,11 +588,6 @@
                (not (eq ?curr-step DELIVER)))
 ))
 =>
-  (bind ?ds MOCKUP-DS)
-  (do-for-fact ((?wf wm-fact)) (wm-key-prefix ?wf:key (create$ domain fact mps-type))
-    (eq DS (wm-key-arg ?wf:key t))
-    (bind ?ds (wm-key-arg ?wf:key m))
-  )
   (bind ?new-step DELIVER)
   (bind ?new-machine ?ds)
   (if (not (eq ?wp-col-r1 ?col-r1))

--- a/src/clips-specs/rcll-central/refbox-agent-task.clp
+++ b/src/clips-specs/rcll-central/refbox-agent-task.clp
@@ -186,7 +186,7 @@
                   ?wp
                   ?mps
                   ?side $?)
-    (state WAITING|RUNNING) (goal-id ?goal-id) (plan-id ?plan-id)
+    (state RUNNING|WAITING) (goal-id ?goal-id) (plan-id ?plan-id)
   )
   (wm-fact (key domain fact mps-state args? m ?mps s PROCESSED|READY-AT-OUTPUT|IDLE))
   (not (refbox-agent-task (robot ?robot) (task-id ?seq)))
@@ -204,8 +204,8 @@
     (param-values ?robot
                   ?wp
                   ?mps
-                  ?shelf-spot  $?)
-    (state WAITING|RUNNING) (goal-id ?goal-id) (plan-id ?plan-id)
+                  ?shelf-spot $?)
+    (state RUNNING|WAITING) (goal-id ?goal-id) (plan-id ?plan-id)
   )
   (not (refbox-agent-task (robot ?robot) (task-id ?seq)))
   =>
@@ -225,7 +225,7 @@
                   ?wp
                   ?mps
                   ?side $?)
-    (state WAITING|RUNNING) (goal-id ?goal-id) (plan-id ?plan-id)
+    (state RUNNING|WAITING) (goal-id ?goal-id) (plan-id ?plan-id)
   )
   (not (refbox-agent-task (robot ?robot) (task-id ?seq)))
   =>

--- a/src/clips-specs/rcll-central/utils.clp
+++ b/src/clips-specs/rcll-central/utils.clp
@@ -149,6 +149,10 @@
 	)
 )
 
+(deffunction com-to-int (?complexity)
+  (return (integer (string-to-field (sub-string 2 2 ?complexity))))
+)
+
 (deffunction random-id ()
   "Return a random task id"
   (return (random 0 1000000000))

--- a/src/clips-specs/rcll-central/utils.clp
+++ b/src/clips-specs/rcll-central/utils.clp
@@ -1155,6 +1155,19 @@
   (return 0)
 )
 
+(deffunction compute-rs-total-payments (?rs)
+  (bind ?filled-with 0)
+  (do-for-fact ((?df domain-fact)) (and (eq ?df:name rs-filled-with) (member$ ?rs ?df:param-values))
+    (bind ?filled-with (sym-to-int (nth$ 2 ?df:param-values)))
+  )
+  (bind ?open-payments 0)
+  (do-for-all-facts ((?g goal)) (and (or (eq ?g:class PAY-FOR-RINGS-WITH-BASE) (eq ?g:class PAY-FOR-RINGS-WITH-CAP-CARRIER)) (neq ?g:mode RETRACTED) (member$ ?g:params ?rs))
+    (bind ?open-payments (+ 1 ?open-payments))
+  )
+  (return (+ ?filled-with ?open-payments))
+)
+
+
 (deffunction values-from-name-value-list ($?args)
 " @param $?args a list containing name value pairs. E.g. (m C-CS1 s IDLE)
 


### PR DESCRIPTION
Add two new kinds of requests to the request dynamic:
- block requests introduce a formal mechanism to block certain machines so that they can be reserved for tasks with preferential treatment
- clean-up requests introduce a unified way to deal with workpieces that should be removed from their current position