### PR TITLE
CX: small agent fixes around skiller simulation

### DIFF
--- a/cfg/conf.d/execution-time-estimator.yaml
+++ b/cfg/conf.d/execution-time-estimator.yaml
@@ -37,6 +37,14 @@ plugins/execution-time-estimator:
         name: discard
         exec-time: 8.25
       # shelf picks
+      00-check-wp-absent:
+        name: manipulate_wp
+        args: ["query=ABSENT"]
+        exec-time: 2.0
+      00-check-wp-present:
+        name: manipulate_wp
+        args: ["query=THERE"]
+        exec-time: 2.0
       01-get-shelf-new-left:
         name: maniuplate_wp
         args: ["side=SHELF-LEFT"]

--- a/cfg/conf.d/execution-time-estimator.yaml
+++ b/cfg/conf.d/execution-time-estimator.yaml
@@ -95,6 +95,7 @@ plugins/execution-time-estimator:
   # Estimates exec times of driving skills by taking distances from NavGraph
   # as reference.
   navgraph:
+    pose-update: true
     # misc options
     priority: 1
     speed: 0.5

--- a/etc/scripts/gazsim.bash
+++ b/etc/scripts/gazsim.bash
@@ -506,7 +506,7 @@ if [  $COMMAND  == start ]; then
     #start fawkes for robotinos
     for ((ROBO=$FIRST_ROBOTINO_NUMBER ; ROBO<$(($FIRST_ROBOTINO_NUMBER+$NUM_ROBOTINOS)) ;ROBO++))
     do
-	COMMANDS+=("bash -i -c \"export TAB_START_TIME=$(date +%s); $script_path/wait-at-first-start.bash 5; $startup_script_location -x fawkes -p 1132$ROBO -i robotino$ROBO $KEEP $CONF $ROS $ROS_LAUNCH_MAIN $ROS_LAUNCH_ROBOT $GDB $META_PLUGIN $DEBUG $DETAILED -f $FAWKES_BIN $SKIP_EXPLORATION $@\"")
+	COMMANDS+=("bash -i -c \"export TAB_START_TIME=$(date +%s); $script_path/wait-at-first-start.bash 1; $startup_script_location -x fawkes -p 1132$ROBO -i robotino$ROBO $KEEP $CONF $ROS $ROS_LAUNCH_MAIN $ROS_LAUNCH_ROBOT $GDB $META_PLUGIN $DEBUG $DETAILED -f $FAWKES_BIN $SKIP_EXPLORATION $@\"")
     DESCRIPTIONS+=("fawkes robot$ROBO")
 	FAWKES_USED=true
     done

--- a/src/clips-specs/rcll-central/domain.clp
+++ b/src/clips-specs/rcll-central/domain.clp
@@ -303,7 +303,7 @@
 		(if (and (= (length$ ?r-active) 2) (eq (nth$ 2 ?r-active) active)
 		                                   (eq ?cf:value TRUE))
 		  then
-		    (printout error ?r-active crlf)
+		    (printout t ?r-active crlf)
 		    (bind ?curr-robot (nth$ 1 ?r-active))
 		    (if (neq ?curr-robot laptop1) then
 		      (assert (wm-fact (key central agent robot args? r ?curr-robot))

--- a/src/clips-specs/rcll-central/execution-monitoring.clp
+++ b/src/clips-specs/rcll-central/execution-monitoring.clp
@@ -409,6 +409,7 @@
 						 (timeout-duration ?timeout&:(timeout ?now ?st ?timeout))
    						 (last-pose $?last-pose)
 						 (counter ?counter))
+  ?at <- (action-timer (plan-id ?plan-id) (status ?status) (action-id ?id) (timeout-duration ?at-timeout))
   =>
   (printout t "Checking progress of move action "  ?action-name  crlf)
 
@@ -421,6 +422,7 @@
   (if (> ?delta 0.5) then
   	(printout t "Robot " ?robot " made sufficient progress (" ?delta "m) on "  ?action-name  crlf)
 	(modify ?pt (counter 0) (last-pose ?pose) (start-time ?now))
+	(modify ?at (timeout-duration (+ ?at-timeout ?*MOVE-PROGRESS-TIMEOUT*)))
   else
 	(if (>= ?counter ?*MOVE-PROGRESS-COUNTER*) then
 	  (printout t "   Aborting action " ?action-name " on interface after stuck on small delta" ?skiller crlf)

--- a/src/clips-specs/rcll-central/goal-reasoner.clp
+++ b/src/clips-specs/rcll-central/goal-reasoner.clp
@@ -792,11 +792,11 @@
 (defrule goal-reasoner-evaluate-move-out-of-way-cleanup-wp
 " Sets a finished move-out-of-way or empty discard goal to formulated."
   (declare (salience ?*MONITORING-SALIENCE*))
-  ?g <- (goal (id ?goal-id) (class MOVE-OUT-OF-WAY|CLEANUP-WP) (mode FINISHED)
+  ?g <- (goal (id ?goal-id) (class ?class&MOVE-OUT-OF-WAY|CLEANUP-WP) (mode FINISHED)
               (outcome ?outcome) (verbosity ?v))
   ?gm <- (goal-meta (goal-id ?goal-id) (assigned-to ?robot&~nil) (retries ?retries))
   =>
-  (printout (log-debug ?v) "Evaluate move-out-of-way/empty discard goal " ?goal-id crlf)
+  (printout (log-debug ?v) "Evaluate " ?class " goal " ?goal-id crlf)
   (set-robot-to-waiting ?robot)
   (modify ?gm (retries (+ 1 ?retries)))
   (remove-robot-assignment-from-goal-meta ?g)

--- a/src/clips-specs/rcll-central/goal-reasoner.clp
+++ b/src/clips-specs/rcll-central/goal-reasoner.clp
@@ -741,6 +741,7 @@
              (category ?category&MAINTENANCE|MAINTENANCE-INSTRUCT) (retries ?retries))
   (test (neq ?class PAY-FOR-RINGS-WITH-CAP-CARRIER))
   =>
+  (modify ?gm (retries (+ 1 ?retries)))
   (if (not
           (eq ?category MAINTENANCE-INSTRUCT)
       )
@@ -750,7 +751,6 @@
   )
   (printout (log-debug ?v) "Goal " ?goal-id " EVALUATED, reformulate as the support WP was lost" crlf)
   (modify ?g (mode FORMULATED) (outcome UNKNOWN))
-  (modify ?gm (retries (+ 1 ?retries)))
 
   (goal-reasoner-retract-plan-action ?goal-id)
 )
@@ -763,10 +763,10 @@
   ?gm <- (goal-meta (goal-id ?goal-id) (assigned-to ?robot) (retries ?retries))
   =>
   (set-robot-to-waiting ?robot)
+  (modify ?gm (retries (+ 1 ?retries)))
   (remove-robot-assignment-from-goal-meta ?g)
   (printout (log-debug ?v) "Goal " ?goal-id " EVALUATED, reformulate and dispatch with classical drop discard" crlf)
   (modify ?g (mode FORMULATED) (outcome UNKNOWN))
-  (modify ?gm (retries (+ 1 ?retries)))
   (goal-reasoner-retract-plan-action ?goal-id)
 )
 
@@ -782,11 +782,10 @@
   ?gm <- (goal-meta (goal-id ?goal-id) (assigned-to ?robot) (retries ?retries))
   =>
   (set-robot-to-waiting ?robot)
+  (modify ?gm (retries (+ 1 ?retries)))
   (remove-robot-assignment-from-goal-meta ?g)
   (printout (log-debug ?v) "Goal " ?goal-id " EVALUATED, reformulate as only a " ?action " action failed" crlf)
   (modify ?g (mode FORMULATED) (outcome UNKNOWN))
-  (modify ?gm (retries (+ 1 ?retries)))
-
   (goal-reasoner-retract-plan-action ?goal-id)
 )
 
@@ -799,12 +798,12 @@
   =>
   (printout (log-debug ?v) "Evaluate move-out-of-way/empty discard goal " ?goal-id crlf)
   (set-robot-to-waiting ?robot)
+  (modify ?gm (retries (+ 1 ?retries)))
   (remove-robot-assignment-from-goal-meta ?g)
 
   ; delete plans of the goal
   (goal-reasoner-retract-plan-action ?goal-id)
   (modify ?g (mode FORMULATED) (outcome UNKNOWN) (is-executable FALSE))
-  (modify ?gm (retries (+ 1 ?retries)))
   (printout (log-debug ?v) "Goal " ?goal-id " FORMULATED" crlf)
 )
 

--- a/src/clips-specs/rcll-central/refbox-agent-task.clp
+++ b/src/clips-specs/rcll-central/refbox-agent-task.clp
@@ -185,7 +185,7 @@
     (param-values ?robot
                   ?wp
                   ?mps
-                  ?side)
+                  ?side $?)
     (state WAITING|RUNNING) (goal-id ?goal-id) (plan-id ?plan-id)
   )
   (wm-fact (key domain fact mps-state args? m ?mps s PROCESSED|READY-AT-OUTPUT|IDLE))
@@ -204,7 +204,7 @@
     (param-values ?robot
                   ?wp
                   ?mps
-                  ?shelf-spot)
+                  ?shelf-spot  $?)
     (state WAITING|RUNNING) (goal-id ?goal-id) (plan-id ?plan-id)
   )
   (not (refbox-agent-task (robot ?robot) (task-id ?seq)))
@@ -224,7 +224,7 @@
     (param-values ?robot
                   ?wp
                   ?mps
-                  ?side)
+                  ?side $?)
     (state WAITING|RUNNING) (goal-id ?goal-id) (plan-id ?plan-id)
   )
   (not (refbox-agent-task (robot ?robot) (task-id ?seq)))


### PR DESCRIPTION
This PR fixes and improves a few things:
 - iadds the workpiece checks to the static estimator that are reasonably fast, before they were treated as pick and put actions, hence took way too long time
 - updates the navgraph estimator to utilize the pose estimation feature
 - fixes a number of crashes due to operation on deleted facts, remove-robot-from-goal-meta is a dangerous helper function that probably should be removed in the future....
 - fixes agent task updates to accommodate for updated action parameters
 - starts the robots before the central agent to ensure a loaded navgraph generator beforehand.