### PR TITLE
CX: do not fail instruct goals for lost WPs

### DIFF
--- a/src/clips-specs/rcll-central/goal-reasoner.clp
+++ b/src/clips-specs/rcll-central/goal-reasoner.clp
@@ -699,10 +699,7 @@
     (and
       (eq ?goal:id ?goal-meta:goal-id)
       (eq ?goal-meta:order-id ?order-id)
-      (or
-        (eq ?category PRODUCTION)
-        (eq ?category PRODUCTION-INSTRUCT)
-      )
+      (eq ?category PRODUCTION)
       (member$ ?goal:mode (create$ FORMULATED SELECTED EXPANDED COMMITTED))
     )
     (modify ?goal (mode FINISHED) (outcome FAILED) (error WP-LOST))
@@ -714,10 +711,7 @@
     (and
       (eq ?goal:id ?goal-meta:goal-id)
       (eq ?goal-meta:order-id ?order-id)
-      (or
-        (eq ?category PRODUCTION)
-        (eq ?category PRODUCTION-INSTRUCT)
-      )
+      (eq ?category PRODUCTION)
       (member$ ?goal:mode (create$ DISPACTHED))
       (eq ?goal:outcome UNKNOWN)
     )


### PR DESCRIPTION
Failing instruct goals might lead to irrecoverable behavior as dynamic assignment might mean we use buffer goals and payment goals from other orders. Meanwhile leaving those goals should just mean that they won't be executed.