### PR TITLE
object-tracking: use time stamp of image

### DIFF
--- a/src/plugins/object-tracking/object_tracking_thread.cpp
+++ b/src/plugins/object-tracking/object_tracking_thread.cpp
@@ -374,7 +374,7 @@ ObjectTrackingThread::loop()
 		//read from sharedMemoryBuffer and convert into Mat
 		image = Mat(camera_height_, camera_width_, CV_8UC3, shm_buffer_->buffer()).clone();
 		cv::cvtColor(image, image, cv::COLOR_RGB2BGR);
-		capture_time = fawkes::Time(0.0);
+		capture_time = shm_buffer_->capture_time();
 	}
 
 	if (rotate_image_)
@@ -493,7 +493,15 @@ ObjectTrackingThread::loop()
 		cur_object_pos_cam.setX(cur_object_pos[0]);
 		cur_object_pos_cam.setY(cur_object_pos[1]);
 		cur_object_pos_cam.setZ(cur_object_pos[2]);
-		tf_listener->transform_point(target_frame_, cur_object_pos_cam, cur_object_pos_target);
+
+		try {
+			tf_listener->transform_point(target_frame_, cur_object_pos_cam, cur_object_pos_target);
+		} catch (tf::ExtrapolationException &e) {
+			logger->log_info(name(), "Extrapolation error: %s", e.what());
+			capture_time             = fawkes::Time(0.0);
+			cur_object_pos_cam.stamp = capture_time;
+			tf_listener->transform_point(target_frame_, cur_object_pos_cam, cur_object_pos_target);
+		}
 
 		//update object pos transform
 		tf::Quaternion       q(0.0, 0.0, 0.0);
@@ -581,7 +589,7 @@ ObjectTrackingThread::loop()
 	//transform weighted average into base_link
 	fawkes::tf::Stamped<fawkes::tf::Point> weighted_object_pos_base;
 	fawkes::tf::Stamped<fawkes::tf::Point> weighted_object_pos_target;
-	weighted_object_pos_target.stamp    = fawkes::Time(0.0);
+	weighted_object_pos_target.stamp    = capture_time;
 	weighted_object_pos_target.frame_id = target_frame_;
 	weighted_object_pos_target.setX(weighted_object_pos[0]);
 	weighted_object_pos_target.setY(weighted_object_pos[1]);


### PR DESCRIPTION
Use time stamp from captured object image for object tracking if available.