### PR TITLE
laser-front-dist: fix panda bug hopefully

### DIFF
--- a/cfg/conf.d/laser-front-dist.yaml
+++ b/cfg/conf.d/laser-front-dist.yaml
@@ -7,6 +7,6 @@ plugins/laser-front-dist:
 
   output_result_interface: "front_dist"
 
-  number_beams_used: 13
+  number_beams_used: 120
 
   target_frame: !frame front_dist


### PR DESCRIPTION
The laster front dist is now the closest distance of lasers in front of the bot instead of a mean over a small fraction. This results in more accurate distances if the bot is standing in front of a mps with an angle and should therefore fix the panda bug (where the bot is rubbing the mps while using VS like a bear/cat [big bear cat = daxiaongmao obviously] which uses this distance for velocity computations).