### PR TITLE
agent task skiller

### DIFF
--- a/cfg/conf.d/agent-task-skiller-bridge.yaml
+++ b/cfg/conf.d/agent-task-skiller-bridge.yaml
@@ -4,10 +4,10 @@
 doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/clips-protobuf
 ---
 agent-task-skiller-bridge:
-  recv_port_magenta: 4442
-  recv_port_cyan: 4441
-  recv_port_public: 4444
-  peer_address: 127.0.0.1
+  recv_port_magenta: 5442
+  recv_port_cyan: 5441
+  recv_port_public: 5444
+  peer_address: 172.26.255.255
   team_name: "Carologistics"
   robot_id: 1
   crypto_key: "randomkey"

--- a/cfg/conf.d/agent-task-skiller-bridge.yaml
+++ b/cfg/conf.d/agent-task-skiller-bridge.yaml
@@ -1,0 +1,13 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+---
+doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/clips-protobuf
+---
+agent-task-skiller-bridge:
+  recv_port_magenta: 4442
+  recv_port_cyan: 4441
+  recv_port_public: 4444
+  peer_address: 127.0.0.1
+  team_name: "Carologistics"
+  robot_id: 1
+  crypto_key: "randomkey"

--- a/cfg/host_robotino-base-1.d/agent-task-skiller-bridge.yaml
+++ b/cfg/host_robotino-base-1.d/agent-task-skiller-bridge.yaml
@@ -1,0 +1,5 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+---
+agent-task-skiller-bridge:
+  robot_id: 1

--- a/cfg/host_robotino-base-2.d/agent-task-skiller-bridge.yaml
+++ b/cfg/host_robotino-base-2.d/agent-task-skiller-bridge.yaml
@@ -1,0 +1,5 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+---
+agent-task-skiller-bridge:
+  robot_id: 2

--- a/cfg/host_robotino-base-3.d/agent-task-skiller-bridge.yaml
+++ b/cfg/host_robotino-base-3.d/agent-task-skiller-bridge.yaml
@@ -1,0 +1,5 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+---
+agent-task-skiller-bridge:
+  robot_id: 3

--- a/src/plugins/agent-task-skiller-bridge/CMakeLists.txt
+++ b/src/plugins/agent-task-skiller-bridge/CMakeLists.txt
@@ -1,7 +1,7 @@
 # *****************************************************************************
 # CMake Build System for Fawkes
 # -------------------
-# Copyright (C) 2023 by Tarik Viehmann and Daniel Swoboda
+# Copyright (C) 2024 by Tarik Viehmann
 #
 # *****************************************************************************
 #
@@ -20,20 +20,26 @@
 #
 # *****************************************************************************
 
-set_output_directory_plugins()
+set(PLUGIN_agent-task-skiller-bridge
+    ON
+    CACHE BOOL "Build agent-task-skiller-bridge")
 
-set(CMAKE_SHARED_MODULE_PREFIX "")
-add_subdirectory(agent-task-skiller-bridge)
-add_subdirectory(clips-motor-switch)
-add_subdirectory(navgraph-generator-mps)
-add_subdirectory(skiller_motor_state)
-add_subdirectory(mps-laser-gen)
-add_subdirectory(laser_front_dist)
-add_subdirectory(tag_vision)
-add_subdirectory(picam-client)
-add_subdirectory(object-tracking)
-add_subdirectory(conveyor_pose)
-add_subdirectory(conveyor_plane)
-add_subdirectory(arduino)
-add_subdirectory(box_detect)
-add_subdirectory(ros2)
+if(PLUGIN_clips-motor-switch)
+  add_library(agent-task-skiller-bridge MODULE bridge-plugin.cpp bridge-thread.cpp)
+  depend_on_protobuf(agent-task-skiller-bridge)
+  depend_on_boost_libs(agent-task-skiller-bridge system)
+  target_link_libraries(
+    agent-task-skiller-bridge
+    fawkescore
+    fawkesutils
+    fawkesaspects
+    fawkesinterface
+    fawkesblackboard
+    fawkesconfig
+    SkillerInterface
+    rcll-protobuf-msgs
+    protobuf_comm
+    protobuf::libprotobuf )
+else()
+  plugin_disabled_message("agent-task-skiller-bridge")
+endif()

--- a/src/plugins/agent-task-skiller-bridge/CMakeLists.txt
+++ b/src/plugins/agent-task-skiller-bridge/CMakeLists.txt
@@ -25,7 +25,8 @@ set(PLUGIN_agent-task-skiller-bridge
     CACHE BOOL "Build agent-task-skiller-bridge")
 
 if(PLUGIN_agent-task-skiller-bridge)
-  add_library(agent-task-skiller-bridge MODULE bridge-plugin.cpp bridge-thread.cpp)
+  add_library(agent-task-skiller-bridge MODULE bridge-plugin.cpp
+                                               bridge-thread.cpp)
   depend_on_protobuf(agent-task-skiller-bridge)
   depend_on_boost_libs(agent-task-skiller-bridge system)
   target_link_libraries(
@@ -37,6 +38,7 @@ if(PLUGIN_agent-task-skiller-bridge)
     fawkesblackboard
     fawkesconfig
     SkillerInterface
+    Position3DInterface
     rcll-protobuf-msgs
     protobuf_comm
     protobuf::libprotobuf )

--- a/src/plugins/agent-task-skiller-bridge/CMakeLists.txt
+++ b/src/plugins/agent-task-skiller-bridge/CMakeLists.txt
@@ -24,7 +24,7 @@ set(PLUGIN_agent-task-skiller-bridge
     ON
     CACHE BOOL "Build agent-task-skiller-bridge")
 
-if(PLUGIN_clips-motor-switch)
+if(PLUGIN_agent-task-skiller-bridge)
   add_library(agent-task-skiller-bridge MODULE bridge-plugin.cpp bridge-thread.cpp)
   depend_on_protobuf(agent-task-skiller-bridge)
   depend_on_boost_libs(agent-task-skiller-bridge system)

--- a/src/plugins/agent-task-skiller-bridge/bridge-plugin.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-plugin.cpp
@@ -1,0 +1,45 @@
+
+/***************************************************************************
+ *  bridge-plugin.cpp - bridge between skiller and agent task proto msgs
+ *
+ *  Created: Mon May 20 2024
+ *  Copyright  2024  Tarik Viehmann
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "bridge-thread.h"
+
+#include <core/plugin.h>
+
+using namespace fawkes;
+
+/** Agent task skiller bridge plguin
+ * @author Tarik Viehmann
+ */
+class AgentTaskSkillerBridgePlugin : public fawkes::Plugin
+{
+public:
+	/** Constructor.
+   * @param config Fawkes configuration
+   */
+	AgentTaskSkillerBridgePlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new AgentTaskSkillerBridgeThread());
+	}
+};
+
+PLUGIN_DESCRIPTION("Translate between skiller and agent task protobuf messages")
+EXPORT_PLUGIN(AgentTaskSkillerBridgePlugin)

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -125,7 +125,7 @@ AgentTaskSkillerBridgeThread::init()
 	                 recv_port_cyan_,
 	                 team_name_.c_str());
 	private_peer_ = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(peer_address_,
-	                                                                       4466,
+	                                                                       5441,
 	                                                                       recv_port_cyan_,
 	                                                                       message_register_.get());
 	private_peer_->signal_received().connect(
@@ -204,7 +204,7 @@ AgentTaskSkillerBridgeThread::handle_peer_msg(boost::asio::ip::udp::endpoint &,
 				                 recv_port_cyan_,
 				                 team_name_.c_str());
 				private_peer_ = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(
-				  peer_address_, 4466, recv_port_cyan_, message_register_.get(), crypto_key_);
+				  peer_address_, 5441, recv_port_cyan_, message_register_.get(), crypto_key_);
 				private_peer_->signal_received().connect(
 				  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_msg,
 				              this,
@@ -225,7 +225,7 @@ AgentTaskSkillerBridgeThread::handle_peer_msg(boost::asio::ip::udp::endpoint &,
 				                 recv_port_magenta_,
 				                 team_name_.c_str());
 				private_peer_ = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(
-				  peer_address_, 4466, recv_port_magenta_, message_register_.get(), crypto_key_);
+				  peer_address_, 5441, recv_port_magenta_, message_register_.get(), crypto_key_);
 				private_peer_->signal_received().connect(
 				  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_msg,
 				              this,

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -261,7 +261,7 @@ AgentTaskSkillerBridgeThread::construct_task_string(const llsf_msgs::AgentTask &
 		const llsf_msgs::Move &move     = agent_task_msg.move();
 		std::string            waypoint = move.waypoint();
 		std::string machine_point       = move.has_machine_point() ? move.machine_point() : "INPUT";
-		return "goto{place=\"" + waypoint + "-" + machine_point + "\"}";
+		return "moveto{place=\"" + waypoint + "-" + machine_point + "\"}";
 	} else if (agent_task_msg.has_retrieve()) {
 		const llsf_msgs::Retrieve &retrieve = agent_task_msg.retrieve();
 		return "manipulate_wp{mps=\"" + retrieve.machine_id() + "\",safe_put=false,map_pos=true,side=\""

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -93,25 +93,46 @@ AgentTaskSkillerBridgeThread::init()
 	SkillerInterface::AcquireControlMessage *aqm = new SkillerInterface::AcquireControlMessage();
 	skiller_if_->msgq_enqueue(aqm);
 
-	logger->log_info(name(),
-	                 "Listening to %s on %i (public) %i (magenta) %i (cyan)",
-	                 peer_address_.c_str(),
-	                 recv_port_public_,
-	                 recv_port_magenta_,
-	                 recv_port_public_);
+	// logger->log_info(name(),
+	//                  "Listening to %s on %i (public) %i (magenta) %i (cyan)",
+	//                  peer_address_.c_str(),
+	//                  recv_port_public_,
+	//                  recv_port_magenta_,
+	//                  recv_port_public_);
 	message_register_ = std::make_shared<protobuf_comm::MessageRegister>(proto_dirs);
-	public_peer_      = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(peer_address_,
-                                                                        4477,
-                                                                        recv_port_public_,
-                                                                        message_register_.get());
-	public_peer_->signal_received().connect(
+	// public_peer_      = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(peer_address_,
+	//                                                                       4477,
+	//                                                                       recv_port_public_,
+	//                                                                       message_register_.get());
+	// public_peer_->signal_received().connect(
+	//   boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_msg,
+	//               this,
+	//               boost::placeholders::_1,
+	//               boost::placeholders::_2,
+	//               boost::placeholders::_3,
+	//               boost::placeholders::_4));
+	// public_peer_->signal_recv_error().connect(
+	//   boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_recv_error,
+	//               this,
+	//               boost::placeholders::_1,
+	//               boost::placeholders::_2));
+	logger->log_info(name(),
+	                 "Listening to CYAN peer %s:%i for team %s",
+	                 peer_address_.c_str(),
+	                 recv_port_cyan_,
+	                 team_name_.c_str());
+	private_peer_ = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(peer_address_,
+	                                                                       4466,
+	                                                                       recv_port_cyan_,
+	                                                                       message_register_.get());
+	private_peer_->signal_received().connect(
 	  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_msg,
 	              this,
 	              boost::placeholders::_1,
 	              boost::placeholders::_2,
 	              boost::placeholders::_3,
 	              boost::placeholders::_4));
-	public_peer_->signal_recv_error().connect(
+	private_peer_->signal_recv_error().connect(
 	  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_recv_error,
 	              this,
 	              boost::placeholders::_1,

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -153,6 +153,7 @@ AgentTaskSkillerBridgeThread::finalize()
 void
 AgentTaskSkillerBridgeThread::loop()
 {
+	std::scoped_lock lock(task_mtx);
 	if (next_skill_ != "") {
 		// other skill is runnung, cancel it frst:
 		if (curr_skill_ != "") {
@@ -246,6 +247,7 @@ AgentTaskSkillerBridgeThread::handle_peer_msg(boost::asio::ip::udp::endpoint &,
 			}
 		}
 	} else if (desc->name() == "AgentTask") {
+		std::scoped_lock            lock(task_mtx);
 		const llsf_msgs::AgentTask *agent_task_msg =
 		  dynamic_cast<const llsf_msgs::AgentTask *>(msg_ptr.get());
 		if (agent_task_msg->robot_id() == robot_id_) {

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -48,13 +48,13 @@ void
 AgentTaskSkillerBridgeThread::init()
 {
 	logger->log_info(name(), "try load stuff");
-	std::string peer_address = config->get_string("/agent-task-skiller-bridge/peer_address");
-	recv_port_magenta_       = config->get_int("/agent-task-skiller-bridge/recv_port_magenta");
-	recv_port_cyan_          = config->get_int("/agent-task-skiller-bridge/recv_port_cyan");
-	recv_port_public_        = config->get_int("/agent-task-skiller-bridge/recv_port_public");
-	team_name_               = config->get_string("/agent-task-skiller-bridge/team_name");
-	crypto_key_              = config->get_string("/agent-task-skiller-bridge/crypto_key");
-	crypto_key_              = config->get_int("/agent-task-skiller-bridge/robot_id");
+	peer_address_      = config->get_string("/agent-task-skiller-bridge/peer_address");
+	recv_port_magenta_ = config->get_int("/agent-task-skiller-bridge/recv_port_magenta");
+	recv_port_cyan_    = config->get_int("/agent-task-skiller-bridge/recv_port_cyan");
+	recv_port_public_  = config->get_int("/agent-task-skiller-bridge/recv_port_public");
+	team_name_         = config->get_string("/agent-task-skiller-bridge/team_name");
+	crypto_key_        = config->get_string("/agent-task-skiller-bridge/crypto_key");
+	robot_id_          = config->get_int("/agent-task-skiller-bridge/robot_id");
 
 	std::vector<std::string> proto_dirs;
 	try {
@@ -221,6 +221,7 @@ AgentTaskSkillerBridgeThread::handle_peer_msg(boost::asio::ip::udp::endpoint &,
 	} else if (desc->name() == "AgentTask") {
 		const llsf_msgs::AgentTask *agent_task_msg =
 		  dynamic_cast<const llsf_msgs::AgentTask *>(msg_ptr.get());
+		logger->log_info(name(), "Got task for %i, i am %i", agent_task_msg->robot_id(), robot_id_);
 		if (agent_task_msg->robot_id() == robot_id_) {
 			next_skill_          = construct_task_string(*agent_task_msg);
 			next_agent_task_msg_ = *agent_task_msg;

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -1,0 +1,310 @@
+
+/***************************************************************************
+ *  bridge-plugin.cpp - bridge between skiller and agent task proto msgs
+ *
+ *  Created: Mon May 20 2024
+ *  Copyright  2024  Tarik Viehmann
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "bridge-thread.h"
+
+#include <core/threading/mutex_locker.h>
+#include <llsf_msgs/AgentTask.pb.h>
+#include <llsf_msgs/GameState.pb.h>
+
+using namespace fawkes;
+
+/** @class AgentTaskSkillerBridgeThread "bridge-thread.h"
+ * Bridge between the skiller and agent task messages sent via protobuf.
+ * @author Tarik Viehmann
+ */
+
+/** Constructor. */
+AgentTaskSkillerBridgeThread::AgentTaskSkillerBridgeThread()
+: Thread("AgentTaskSkillerBridgeThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlackBoardInterfaceListener("AgentTaskSkillerBridgeThread")
+{
+}
+
+/** Destructor. */
+AgentTaskSkillerBridgeThread::~AgentTaskSkillerBridgeThread()
+{
+}
+
+void
+AgentTaskSkillerBridgeThread::init()
+{
+	logger->log_info(name(), "try load stuff");
+	std::string peer_address = config->get_string("/agent-task-skiller-bridge/peer_address");
+	recv_port_magenta_       = config->get_int("/agent-task-skiller-bridge/recv_port_magenta");
+	recv_port_cyan_          = config->get_int("/agent-task-skiller-bridge/recv_port_cyan");
+	recv_port_public_        = config->get_int("/agent-task-skiller-bridge/recv_port_public");
+	team_name_               = config->get_string("/agent-task-skiller-bridge/team_name");
+	crypto_key_              = config->get_string("/agent-task-skiller-bridge/crypto_key");
+	crypto_key_              = config->get_int("/agent-task-skiller-bridge/robot_id");
+
+	std::vector<std::string> proto_dirs;
+	try {
+		proto_dirs = config->get_strings("/clips-protobuf/proto-dirs");
+		for (size_t i = 0; i < proto_dirs.size(); ++i) {
+			std::string::size_type pos;
+			if ((pos = proto_dirs[i].find("@BASEDIR@")) != std::string::npos) {
+				proto_dirs[i].replace(pos, 9, BASEDIR);
+			}
+			if ((pos = proto_dirs[i].find("@FAWKES_BASEDIR@")) != std::string::npos) {
+				proto_dirs[i].replace(pos, 16, FAWKES_BASEDIR);
+			}
+			if ((pos = proto_dirs[i].find("@RESDIR@")) != std::string::npos) {
+				proto_dirs[i].replace(pos, 8, RESDIR);
+			}
+			if ((pos = proto_dirs[i].find("@CONFDIR@")) != std::string::npos) {
+				proto_dirs[i].replace(pos, 9, CONFDIR);
+			}
+			if (proto_dirs[i][proto_dirs.size() - 1] != '/') {
+				proto_dirs[i] += "/";
+			}
+			//logger->log_warn(name(), "DIR: %s", proto_dirs[i].c_str());
+		}
+	} catch (...) {
+		logger->log_error(name(), "could not load stuff, i break");
+		return;
+	}
+	logger->log_info(name(), "could  load stuff");
+
+	skiller_if_ = blackboard->open_for_reading<SkillerInterface>("Skiller");
+	bbil_add_data_interface(skiller_if_);
+	bbil_add_reader_interface(skiller_if_);
+
+	logger->log_info(name(), "Acquire exclusive Skiller Control");
+	SkillerInterface::AcquireControlMessage *aqm = new SkillerInterface::AcquireControlMessage();
+	skiller_if_->msgq_enqueue(aqm);
+
+	logger->log_info(name(),
+	                 "Listening to %s on %i (public) %i (magenta) %i (cyan)",
+	                 peer_address_.c_str(),
+	                 recv_port_public_,
+	                 recv_port_magenta_,
+	                 recv_port_public_);
+	message_register_ = std::make_shared<protobuf_comm::MessageRegister>(proto_dirs);
+	public_peer_      = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(peer_address_,
+                                                                        4477,
+                                                                        recv_port_public_,
+                                                                        message_register_.get());
+	public_peer_->signal_received().connect(
+	  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_msg,
+	              this,
+	              boost::placeholders::_1,
+	              boost::placeholders::_2,
+	              boost::placeholders::_3,
+	              boost::placeholders::_4));
+	public_peer_->signal_recv_error().connect(
+	  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_recv_error,
+	              this,
+	              boost::placeholders::_1,
+	              boost::placeholders::_2));
+}
+
+void
+AgentTaskSkillerBridgeThread::finalize()
+{
+	SkillerInterface::ReleaseControlMessage *rcm = new SkillerInterface::ReleaseControlMessage();
+	skiller_if_->msgq_enqueue(rcm);
+	blackboard->close(skiller_if_);
+}
+
+void
+AgentTaskSkillerBridgeThread::loop()
+{
+	if (next_skill_ != "") {
+		// other skill is runnung, cancel it frst:
+		if (curr_skill_ != "") {
+			logger->log_info(name(),
+			                 "Cancel previous skill before accepting new commands: %s",
+			                 curr_skill_.c_str());
+			SkillerInterface::StopExecMessage *sem = new SkillerInterface::StopExecMessage();
+			skiller_if_->msgq_enqueue(sem);
+			return; // wait for skill to terminate, send response and then continue
+
+		} else {
+			curr_skill_          = next_skill_;
+			next_skill_          = "";
+			curr_agent_task_msg_ = next_agent_task_msg_;
+			SkillerInterface::ExecSkillMessage *sem =
+			  new SkillerInterface::ExecSkillMessage(curr_skill_.c_str());
+			logger->log_info(name(), "Sending skill: %s", curr_skill_.c_str());
+			skiller_if_->msgq_enqueue(sem);
+			return;
+		}
+	}
+	if (!running_) {
+		send_response();
+		error_code_ = 0;
+		curr_skill_ = "";
+	}
+}
+
+void
+AgentTaskSkillerBridgeThread::handle_peer_msg(boost::asio::ip::udp::endpoint &,
+                                              uint16_t,
+                                              uint16_t,
+                                              std::shared_ptr<google::protobuf::Message> msg_ptr)
+{
+	if (!msg_ptr) {
+		logger->log_debug(name(), "Received invalid msg ptr");
+		return;
+	}
+	const google::protobuf::Descriptor *desc = msg_ptr->GetDescriptor();
+	logger->log_info(name(), "Received msg %s", desc->name().c_str());
+	if (desc->name() == "GameState") {
+		const llsf_msgs::GameState *game_state_msg =
+		  dynamic_cast<const llsf_msgs::GameState *>(msg_ptr.get());
+		if (!private_peer_) {
+			if (game_state_msg->team_cyan() == team_name_) {
+				logger->log_info(name(),
+				                 "Listening to CYAN peer %s:%i for team %s",
+				                 peer_address_.c_str(),
+				                 recv_port_cyan_,
+				                 team_name_.c_str());
+				private_peer_ = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(
+				  peer_address_, 4466, recv_port_cyan_, message_register_.get(), crypto_key_);
+				private_peer_->signal_received().connect(
+				  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_msg,
+				              this,
+				              boost::placeholders::_1,
+				              boost::placeholders::_2,
+				              boost::placeholders::_3,
+				              boost::placeholders::_4));
+				private_peer_->signal_recv_error().connect(
+				  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_recv_error,
+				              this,
+				              boost::placeholders::_1,
+				              boost::placeholders::_2));
+			} else if (game_state_msg->team_magenta() == team_name_) {
+				logger->log_info(name(),
+				                 "Listening to MAGENTA peer %s:%i for team %s",
+				                 peer_address_.c_str(),
+				                 recv_port_magenta_,
+				                 team_name_.c_str());
+				private_peer_ = std::make_shared<protobuf_comm::ProtobufBroadcastPeer>(
+				  peer_address_, 4466, recv_port_magenta_, message_register_.get(), crypto_key_);
+				private_peer_->signal_received().connect(
+				  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_msg,
+				              this,
+				              boost::placeholders::_1,
+				              boost::placeholders::_2,
+				              boost::placeholders::_3,
+				              boost::placeholders::_4));
+				private_peer_->signal_recv_error().connect(
+				  boost::bind(&AgentTaskSkillerBridgeThread::handle_peer_recv_error,
+				              this,
+				              boost::placeholders::_1,
+				              boost::placeholders::_2));
+			} else {
+				logger->log_info(name(),
+				                 "Waiting for RefBox to send information on team %s",
+				                 team_name_.c_str());
+			}
+		}
+	} else if (desc->name() == "AgentTask") {
+		const llsf_msgs::AgentTask *agent_task_msg =
+		  dynamic_cast<const llsf_msgs::AgentTask *>(msg_ptr.get());
+		if (agent_task_msg->robot_id() == robot_id_) {
+			next_skill_          = construct_task_string(*agent_task_msg);
+			next_agent_task_msg_ = *agent_task_msg;
+			wakeup();
+		}
+	} else {
+		logger->log_debug(name(), "Received %s", desc->name().c_str());
+	}
+}
+
+std::string
+AgentTaskSkillerBridgeThread::construct_task_string(const llsf_msgs::AgentTask &agent_task_msg)
+{
+	if (agent_task_msg.has_move()) {
+		const llsf_msgs::Move &move     = agent_task_msg.move();
+		std::string            waypoint = move.waypoint();
+		std::string machine_point       = move.has_machine_point() ? move.machine_point() : "INPUT";
+		return "goto{place=\"" + waypoint + "-" + machine_point + "\"}";
+	} else if (agent_task_msg.has_retrieve()) {
+		const llsf_msgs::Retrieve &retrieve = agent_task_msg.retrieve();
+		return "manipulate_wp{mps=" + retrieve.machine_id() + ",safe_put=false,map_pos=true,side="
+		       + retrieve.machine_point() + ",target=\"WORKPIECE\",c=\"C3\"}";
+	} else if (agent_task_msg.has_deliver()) {
+		const llsf_msgs::Deliver &deliver = agent_task_msg.deliver();
+		if (deliver.machine_point() == "SLIDE") {
+			return "manipulate_wp{mps=" + deliver.machine_id()
+			       + ",map_pos=true,side=" + deliver.machine_point() + ",target=\"SLIDE\",c=\"C3\"}";
+		}
+		return "manipulate_wp{mps=" + deliver.machine_id()
+		       + ",map_pos=true,side=" + deliver.machine_point() + ",target=\"CONVEYOR\",c=\"C3\"}";
+	} else if (agent_task_msg.has_buffer()) {
+		return "unknown";
+	} else if (agent_task_msg.has_explore_machine()) {
+		return "unknown";
+	} else {
+		return "unknown";
+	}
+}
+void
+AgentTaskSkillerBridgeThread::handle_peer_recv_error(boost::asio::ip::udp::endpoint &, std::string)
+{
+}
+
+void
+AgentTaskSkillerBridgeThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
+{
+	SkillerInterface *skiller_if = dynamic_cast<SkillerInterface *>(interface);
+	if (!skiller_if)
+		return;
+	skiller_if->read();
+	if (skiller_if->serial().get_string() != std::string(skiller_if->exclusive_controller())) {
+		successful_ = false;
+		error_code_ = 0; // Skiller control lost
+		wakeup();
+		return;
+	}
+	switch (skiller_if->status()) {
+	case fawkes::SkillerInterface::SkillStatusEnum::S_INACTIVE: running_ = false; break;
+	case fawkes::SkillerInterface::SkillStatusEnum::S_FINAL:
+		successful_ = true;
+		running_    = false;
+		wakeup();
+		break;
+	case fawkes::SkillerInterface::SkillStatusEnum::S_RUNNING: running_ = true; break;
+	case fawkes::SkillerInterface::SkillStatusEnum::S_FAILED:
+		successful_ = false;
+		running_    = false;
+		wakeup();
+		break;
+	}
+}
+
+void
+AgentTaskSkillerBridgeThread::send_response()
+{
+	llsf_msgs::AgentTask response = curr_agent_task_msg_;
+	response.set_cancel_task(!successful_);
+	response.set_pause_task(false);
+	response.set_successful(successful_);
+	response.set_canceled(false);
+	response.set_error_code(error_code_);
+	logger->log_info(name(),
+	                 "Send response: Succesfull %s (code %i)",
+	                 successful_ ? "true" : "false",
+	                 error_code_);
+	private_peer_->send(response);
+}

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -248,11 +248,25 @@ AgentTaskSkillerBridgeThread::handle_peer_msg(boost::asio::ip::udp::endpoint &,
 	} else if (desc->name() == "AgentTask") {
 		const llsf_msgs::AgentTask *agent_task_msg =
 		  dynamic_cast<const llsf_msgs::AgentTask *>(msg_ptr.get());
-		logger->log_info(name(), "Got task for %i, i am %i", agent_task_msg->robot_id(), robot_id_);
 		if (agent_task_msg->robot_id() == robot_id_) {
 			next_skill_          = construct_task_string(*agent_task_msg);
 			next_agent_task_msg_ = *agent_task_msg;
-			wakeup();
+			if (next_agent_task_msg_.task_id() != curr_agent_task_msg_.task_id()) {
+				logger->log_info(name(), "Got new task id %i", next_agent_task_msg_.task_id());
+				// If a previous thread is running, stop it
+				if (response_thread_.joinable()) {
+					stop_thread_ = true;
+					response_thread_.join();
+					stop_thread_ = false;
+				}
+				wakeup();
+			} else {
+				next_skill_ = "";
+				logger->log_info(name(),
+				                 "Ignoring same task id %i, currently at %i",
+				                 next_agent_task_msg_.task_id(),
+				                 curr_agent_task_msg_.task_id());
+			}
 		}
 	} else {
 		logger->log_debug(name(), "Received %s", desc->name().c_str());
@@ -301,6 +315,7 @@ AgentTaskSkillerBridgeThread::bb_interface_data_refreshed(fawkes::Interface *int
 		if (skiller_if->serial().get_string() != std::string(skiller_if->exclusive_controller())) {
 			successful_ = false;
 			error_code_ = 0; // Skiller control lost
+			logger->log_info(name(), "Skill control lost, wakeup");
 			wakeup();
 			return;
 		}
@@ -309,12 +324,14 @@ AgentTaskSkillerBridgeThread::bb_interface_data_refreshed(fawkes::Interface *int
 		case fawkes::SkillerInterface::SkillStatusEnum::S_FINAL:
 			successful_ = true;
 			running_    = false;
+			logger->log_info(name(), "Final, wakeup");
 			wakeup();
 			break;
 		case fawkes::SkillerInterface::SkillStatusEnum::S_RUNNING: running_ = true; break;
 		case fawkes::SkillerInterface::SkillStatusEnum::S_FAILED:
 			successful_ = false;
 			running_    = false;
+			logger->log_info(name(), "Failed, wakeup");
 			wakeup();
 			break;
 		}
@@ -392,8 +409,8 @@ AgentTaskSkillerBridgeThread::send_response()
 		response.set_error_code(error_code_);
 		while (!stop_thread_) {
 			logger->log_info(name(),
-			                 "Send response: Succesfull %s (code %i)",
-			                 successful_ ? "true" : "false",
+			                 "Send response: Succesful %s (code %i)",
+			                 response.successful() ? "true" : "false",
 			                 error_code_);
 			private_peer_->send(response);
 			std::this_thread::sleep_for(std::chrono::milliseconds(1000));

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -242,16 +242,16 @@ AgentTaskSkillerBridgeThread::construct_task_string(const llsf_msgs::AgentTask &
 		return "goto{place=\"" + waypoint + "-" + machine_point + "\"}";
 	} else if (agent_task_msg.has_retrieve()) {
 		const llsf_msgs::Retrieve &retrieve = agent_task_msg.retrieve();
-		return "manipulate_wp{mps=" + retrieve.machine_id() + ",safe_put=false,map_pos=true,side="
-		       + retrieve.machine_point() + ",target=\"WORKPIECE\",c=\"C3\"}";
+		return "manipulate_wp{mps=\"" + retrieve.machine_id() + "\",safe_put=false,map_pos=true,side=\""
+		       + retrieve.machine_point() + "\",target=\"WORKPIECE\",c=\"C3\"}";
 	} else if (agent_task_msg.has_deliver()) {
 		const llsf_msgs::Deliver &deliver = agent_task_msg.deliver();
 		if (deliver.machine_point() == "SLIDE") {
-			return "manipulate_wp{mps=" + deliver.machine_id()
-			       + ",map_pos=true,side=" + deliver.machine_point() + ",target=\"SLIDE\",c=\"C3\"}";
+			return "manipulate_wp{mps=\"" + deliver.machine_id() + "\",map_pos=true,side=\""
+			       + deliver.machine_point() + "\",target=\"SLIDE\",c=\"C3\"}";
 		}
-		return "manipulate_wp{mps=" + deliver.machine_id()
-		       + ",map_pos=true,side=" + deliver.machine_point() + ",target=\"CONVEYOR\",c=\"C3\"}";
+		return "manipulate_wp{mps=\"" + deliver.machine_id() + "\",map_pos=true,side=\""
+		       + deliver.machine_point() + "\",target=\"CONVEYOR\",c=\"C3\"}";
 	} else if (agent_task_msg.has_buffer()) {
 		return "unknown";
 	} else if (agent_task_msg.has_explore_machine()) {

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -192,7 +192,7 @@ AgentTaskSkillerBridgeThread::handle_peer_msg(boost::asio::ip::udp::endpoint &,
 		return;
 	}
 	const google::protobuf::Descriptor *desc = msg_ptr->GetDescriptor();
-	logger->log_info(name(), "Received msg %s", desc->name().c_str());
+	logger->log_debug(name(), "Received msg %s", desc->name().c_str());
 	if (desc->name() == "GameState") {
 		const llsf_msgs::GameState *game_state_msg =
 		  dynamic_cast<const llsf_msgs::GameState *>(msg_ptr.get());

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.cpp
@@ -86,7 +86,8 @@ AgentTaskSkillerBridgeThread::init()
 
 	skiller_if_ = blackboard->open_for_reading<SkillerInterface>("Skiller");
 	bbil_add_data_interface(skiller_if_);
-	bbil_add_reader_interface(skiller_if_);
+	blackboard->register_listener(this);
+	//bbil_add_reader_interface(skiller_if_);
 
 	logger->log_info(name(), "Acquire exclusive Skiller Control");
 	SkillerInterface::AcquireControlMessage *aqm = new SkillerInterface::AcquireControlMessage();

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.h
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.h
@@ -92,6 +92,7 @@ private:
 	std::string next_skill_;
 	std::string curr_skill_;
 	bool        running_     = false;
+	bool        terminated_  = false;
 	bool        successful_  = false;
 	bool        stop_thread_ = false;
 	int         error_code_  = 0;
@@ -105,6 +106,9 @@ private:
 	unsigned short recv_port_cyan_;
 	unsigned short recv_port_public_;
 	std::string    peer_address_;
+
+	std::array<std::string, 3> shelf_slots = {"-LEFT", "-MIDDLE", "-RIGHT"};
+	size_t                     shelf_index = 0;
 
 	double *rotation_;
 	double *translation_;

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.h
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.h
@@ -1,0 +1,104 @@
+
+/***************************************************************************
+ *  bridge-plugin.cpp - bridge between skiller and agent task proto msgs
+ *
+ *  Created: Mon May 20 2024
+ *  Copyright  2024  Tarik Viehmann
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef __PLGUINS_AGENT_TASK_SKILLER_BRIDGE_THREAD_H_
+#define __PLGUINS_AGENT_TASK_SKILLER_BRIDGE_THREAD_H_
+
+#include <aspect/blackboard.h>
+#include <aspect/blocked_timing.h>
+#include <aspect/configurable.h>
+#include <aspect/logging.h>
+#include <blackboard/interface_listener.h>
+#include <core/threading/thread.h>
+#include <google/protobuf/message.h>
+#include <interfaces/SkillerInterface.h>
+#include <llsf_msgs/AgentTask.pb.h>
+#include <protobuf_comm/message_register.h>
+#include <protobuf_comm/peer.h>
+
+#include <boost/asio.hpp>
+#include <string>
+#include <vector>
+
+namespace fawkes {
+
+class AgentTaskSkillerBridgeThread : public fawkes::Thread,
+                                     public fawkes::LoggingAspect,
+                                     public fawkes::ConfigurableAspect,
+                                     public fawkes::BlackBoardAspect,
+                                     public fawkes::BlackBoardInterfaceListener
+{
+public:
+	AgentTaskSkillerBridgeThread();
+	virtual ~AgentTaskSkillerBridgeThread();
+
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
+
+	// for BlackBoardInterfaceListener
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
+
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+protected:
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
+
+private:
+	std::string               cfg_skiller_iface_id_;
+	fawkes::SkillerInterface *skiller_if_;
+
+	std::shared_ptr<protobuf_comm::ProtobufBroadcastPeer> private_peer_;
+	std::shared_ptr<protobuf_comm::ProtobufBroadcastPeer> public_peer_;
+	std::shared_ptr<protobuf_comm::MessageRegister>       message_register_;
+
+	void        handle_peer_msg(boost::asio::ip::udp::endpoint            &endpoint,
+	                            uint16_t                                   component_id,
+	                            uint16_t                                   msg_type,
+	                            std::shared_ptr<google::protobuf::Message> msg);
+	void        handle_peer_recv_error(boost::asio::ip::udp::endpoint &endpoint, std::string msg);
+	void        send_response();
+	std::string construct_task_string(const llsf_msgs::AgentTask &agent_task_msg);
+
+	std::string team_name_;
+	std::string crypto_key_;
+	int         robot_id_;
+
+	std::string next_skill_;
+	std::string curr_skill_;
+	bool        running_    = false;
+	bool        successful_ = false;
+	int         error_code_ = 0;
+
+	llsf_msgs::AgentTask next_agent_task_msg_;
+	llsf_msgs::AgentTask curr_agent_task_msg_;
+
+	unsigned short recv_port_magenta_;
+	unsigned short recv_port_cyan_;
+	unsigned short recv_port_public_;
+	std::string    peer_address_;
+};
+} // namespace fawkes
+
+#endif

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.h
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.h
@@ -91,9 +91,12 @@ private:
 
 	std::string next_skill_;
 	std::string curr_skill_;
-	bool        running_    = false;
-	bool        successful_ = false;
-	int         error_code_ = 0;
+	bool        running_     = false;
+	bool        successful_  = false;
+	bool        stop_thread_ = false;
+	int         error_code_  = 0;
+
+	std::thread response_thread_;
 
 	llsf_msgs::AgentTask next_agent_task_msg_;
 	llsf_msgs::AgentTask curr_agent_task_msg_;

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.h
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.h
@@ -29,6 +29,7 @@
 #include <blackboard/interface_listener.h>
 #include <core/threading/thread.h>
 #include <google/protobuf/message.h>
+#include <interfaces/Position3DInterface.h>
 #include <interfaces/SkillerInterface.h>
 #include <llsf_msgs/AgentTask.pb.h>
 #include <protobuf_comm/message_register.h>
@@ -66,8 +67,9 @@ protected:
 	}
 
 private:
-	std::string               cfg_skiller_iface_id_;
-	fawkes::SkillerInterface *skiller_if_;
+	std::string                  cfg_skiller_iface_id_;
+	fawkes::SkillerInterface    *skiller_if_;
+	fawkes::Position3DInterface *pos_if_;
 
 	std::shared_ptr<protobuf_comm::ProtobufBroadcastPeer> private_peer_;
 	std::shared_ptr<protobuf_comm::ProtobufBroadcastPeer> public_peer_;
@@ -79,9 +81,11 @@ private:
 	                            std::shared_ptr<google::protobuf::Message> msg);
 	void        handle_peer_recv_error(boost::asio::ip::udp::endpoint &endpoint, std::string msg);
 	void        send_response();
+	void        send_pose();
 	std::string construct_task_string(const llsf_msgs::AgentTask &agent_task_msg);
 
 	std::string team_name_;
+	std::string team_color_;
 	std::string crypto_key_;
 	int         robot_id_;
 
@@ -98,6 +102,9 @@ private:
 	unsigned short recv_port_cyan_;
 	unsigned short recv_port_public_;
 	std::string    peer_address_;
+
+	double *rotation_;
+	double *translation_;
 };
 } // namespace fawkes
 

--- a/src/plugins/agent-task-skiller-bridge/bridge-thread.h
+++ b/src/plugins/agent-task-skiller-bridge/bridge-thread.h
@@ -108,6 +108,8 @@ private:
 
 	double *rotation_;
 	double *translation_;
+
+	std::mutex task_mtx;
 };
 } // namespace fawkes
 


### PR DESCRIPTION
This PR introduces a bridge to receive agent task protobuf messages, translate it's content to skill calls and send back feedback.

It needs to be polished a bit, but the base functionality should work already.