### PR TITLE
rcll-central: preemptively switch robot location on move

### DIFF
--- a/src/clips-specs/rcll-central/exploration.clp
+++ b/src/clips-specs/rcll-central/exploration.clp
@@ -261,15 +261,7 @@
 	 	) then
 		(bind ?x (nth$ 1 ?trans))
 		(bind ?y (nth$ 2 ?trans))
-		(bind ?prefix "C")
-		(if (< ?y 0) then (return))
-		(if (< ?x 0) then
-			(bind ?x (* -1 ?x))
-			(bind ?prefix "M")
-		)
-		(bind ?x (round (+ ?x 0.5)))
-		(bind ?y (round (+ ?y 0.5)))
-		(bind ?zn2 (str-cat ?prefix "_Z" ?x ?y))
+		(bind ?zn2 (zone-str-from-coords ?x ?y))
 
 		(bind ?yaw (tf-yaw-from-quat $?rot))
 		(bind ?odd TRUE)

--- a/src/clips-specs/rcll-central/utils.clp
+++ b/src/clips-specs/rcll-central/utils.clp
@@ -260,6 +260,19 @@
   )
 )
 
+(deffunction zone-str-from-coords (?x ?y)
+" Map x y coordinates to a zone name they belong to, e..g, M_Z51
+"
+  (bind ?prefix "C")
+  (if (< ?y 0) then (return))
+  (if (< ?x 0) then
+    (bind ?x (* -1 ?x))
+    (bind ?prefix "M")
+  )
+  (bind ?x (round (+ ?x 0.5)))
+  (bind ?y (round (+ ?y 0.5)))
+  (return (str-cat ?prefix "_Z" ?x ?y))
+)
 
 (deffunction zone-center (?zn)
   "Calculates the coordinates of the center of a zone


### PR DESCRIPTION
This fixes issues that were introduced when discarding go-wait actions per default.
Currently, if a robot wants to move to a location where another robot is standing, then the robot waits until the other robot finished moving away, which potentially takes quite a long time.

To get around that, simply update the current position dynamically once, while the other robot move action is running.
This causes its original position to be free again and lets other robots move it.
In order to realize this, simply check if the robot moved sufficiently far away from it's origin zone (e.g., 1 meter) and then calculate the current zone it is in and set it as it's current position (the predicate `at`).