### PR TITLE
object tracking: fix laser-line offset and threshold

### DIFF
--- a/cfg/conf.d/object_tracking.yaml
+++ b/cfg/conf.d/object_tracking.yaml
@@ -81,7 +81,7 @@ plugins/object_tracking:
 
   # maximal distance between yolo response and last weighted average to accept
   #  as target object
-  max_acceptable_dist: 0.55
+  max_acceptable_dist: 0.15
 
   yolo:
     weights_path: "../cfg/yolo/yolov4-tiny.weights"

--- a/src/plugins/object-tracking/object_tracking_thread.cpp
+++ b/src/plugins/object-tracking/object_tracking_thread.cpp
@@ -712,9 +712,9 @@ ObjectTrackingThread::laserline_get_expected_position(
 
 	//get point on laser-line with y_offset_
 	float x_pos =
-	  ll->end_point_2(0) + (ll->end_point_1(0) - ll->end_point_2(0)) * (0.5 + y_offset_ / 0.7);
+	  ll->end_point_1(0) + (ll->end_point_2(0) - ll->end_point_1(0)) * (0.5 + y_offset_ / 0.7);
 	float y_pos =
-	  ll->end_point_2(1) + (ll->end_point_1(1) - ll->end_point_2(1)) * (0.5 + y_offset_ / 0.7);
+	  ll->end_point_1(1) + (ll->end_point_2(1) - ll->end_point_1(1)) * (0.5 + y_offset_ / 0.7);
 	float z_pos = z_offset_;
 
 	float angle = ll->bearing();


### PR DESCRIPTION
The laser-line flip through ROS still had impact on the object tracking. We hotfixed it by increasing the threshold between expected position of the target and detected position.
This PR fixes the laser-line calculations in object tracking and reducing the threshold to the usual threshold which does not allow to pick workpieces on the other side of the conveyor.