### PR TITLE
arduino: only publish tf in loop

### DIFF
--- a/src/plugins/arduino/tf_thread.cpp
+++ b/src/plugins/arduino/tf_thread.cpp
@@ -137,7 +137,6 @@ ArduinoTFThread::set_position(float new_x_pos, float new_y_pos, float new_z_pos)
 	cur_x_ = new_x_pos;
 	cur_y_ = new_y_pos;
 	cur_z_ = new_z_pos;
-	update();
 }
 
 void


### PR DESCRIPTION
This ensures a well-defined data flow and prevents the loop time being crushed due to locks that are stolen by the asynchronous position updates.