### PR TITLE
manipulate_wp: fix search ll loop

### DIFF
--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -567,7 +567,7 @@ function FIND_LASER_LINE:init()
     fsm.vars.search_attemps = 0
 end
 
-function SEARCH_LASER_LINE:init()
+function SEARCH_LASER_LINE:loop()
     fsm.vars.search_attemps = fsm.vars.search_attemps + 1
 end
 


### PR DESCRIPTION
This PR fixes the bug where we loop infinitely when not seeing the laser-line.