### PR TITLE
CX: reworked maintenance

### DIFF
--- a/cfg/conf.d/clips-executive.yaml
+++ b/cfg/conf.d/clips-executive.yaml
@@ -186,7 +186,6 @@ clips-executive:
           challenge-flip-insertion: true
           use-static-navgraph: false
 
-          start-with-waiting-robots: true
           exploration:
             # Reduce navigator velocity while traveling the field so we can
             # find laser-lines more reliably

--- a/src/clips-specs/rcll-central/domain.clp
+++ b/src/clips-specs/rcll-central/domain.clp
@@ -381,6 +381,7 @@
 		    (bind ?curr-robot (nth$ 1 ?r-active))
 		    (if (neq ?curr-robot laptop1) then
 		      (assert (wm-fact (key central agent robot args? r ?curr-robot))
+		              (wm-fact (key central agent robot-waiting args? r ?curr-robot))
 		              (domain-object (name ?curr-robot) (type robot))
 		              (domain-fact (name robot-waiting) (param-values ?curr-robot))
 		              (domain-fact (name at) (param-values ?curr-robot START INPUT)))
@@ -391,15 +392,6 @@
 		    (retract ?cf)
 		)
 	)
-)
-
-(defrule start-with-waiting-robots
-	(wm-fact (key config rcll start-with-waiting-robots) (value TRUE))
-	(wm-fact (key central agent robot args? r ?robot))
-	(not (wm-fact (key central agent robot-waiting args? r ?robot)))
-	(wm-fact (key refbox phase) (value SETUP))
-	=>
-	(assert (wm-fact (key central agent robot-waiting args? r ?robot)))
 )
 
 (defrule start-with-no-mps-workload-update-needed

--- a/src/clips-specs/rcll-central/execution-monitoring.clp
+++ b/src/clips-specs/rcll-central/execution-monitoring.clp
@@ -1140,6 +1140,9 @@
 	)
 
 	(do-for-all-facts ((?df domain-fact)) (str-index ?robot (implode$ ?df:param-values))
+		(if (eq ?df:name holding) then
+			(assert (wm-fact (key monitoring cleanup-wp args? wp (nth$ 2 ?df:param-values))))
+		)
 		(retract ?df)
 	)
 

--- a/src/clips-specs/rcll-central/refbox-actions.clp
+++ b/src/clips-specs/rcll-central/refbox-actions.clp
@@ -132,6 +132,7 @@
   (not (wm-fact (id "/simulator/comm/peer-id/public")))
   ?bs <- (wm-fact (key refbox beacon seq) (value ?seq))
   (wm-fact (key central agent robot args? r ?robot))
+  (not (wm-fact (key central agent robot-lost args? r ?robot)))
   (wm-fact (key refbox robot task seq args? r ?robot) (value ?task-seq))
   (not (refbox-agent-task (robot ?robot) (task-id ?task-seq)))
   ?bt <- (timer (name ?tn&:(eq ?tn (sym-cat refbox-beacon-timer- ?robot)))
@@ -154,6 +155,7 @@
   ?bs <- (wm-fact (key refbox beacon seq) (value ?seq))
   ?at <- (refbox-agent-task (task-id ?task-seq) (robot ?robot))
   (wm-fact (key central agent robot args? r ?robot))
+  (not (wm-fact (key central agent robot-lost args? r ?robot)))
   (wm-fact (key refbox robot task seq args? r ?robot) (value ?task-seq))
   ; TODO could we skip a task by accident?
   ?bt <- (timer (name ?tn&:(eq ?tn (sym-cat refbox-beacon-timer- ?robot)))

--- a/src/clips-specs/rcll-central/refbox-worldmodel.clp
+++ b/src/clips-specs/rcll-central/refbox-worldmodel.clp
@@ -312,15 +312,16 @@
     (if (and (eq ?old-state MAINTENANCE)
              (eq ?state ACTIVE))
      then
-      (assert (wm-fact (key central agent robot-waiting args? r ?robot)))
+      (assert (wm-fact (key monitoring robot-out-of-maintenance args? r ?robot)))
     )
     (if (and (eq ?old-state ACTIVE)
              (neq ?state ACTIVE))
      then
-      (assert (reset-robot-in-wm ?robot))
+      (assert (wm-fact (key monitoring robot-in-maintenance args? r ?robot)))
     )
   )
 )
+
 
 (defrule refbox-recv-NavigationRoutes-initialize
   "When there are no waypoints,reached and remaining facts, initialize them based on


### PR DESCRIPTION
This PR remodels the maintenenance to give it a consistent behavior.
The idea is to differentiate between robot-lost and robot-in-maintenance states. Robot lost essentially just means it stops all goals and beacon signals.
robots in maintenance also clear their goals but additionally reset the robot wm state.
a robot can only become active again if it is reachable (not lost) and not in maintenance and not in cleanup.
