### PR TITLE
Axis Movement Fixes from RoboCup 2024 + FH Fixes

### DIFF
--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -184,7 +184,7 @@ function gripper_aligned()
 
     return within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x) and
                within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
-                                GRIPPER_TOLERANCE, y) and
+                                GRIPPER_TOLERANCE.y, y) and
                within_tolerance(
                    math.max(0.01, math.min(gripper_target.z, z_max)),
                    arduino:z_position(), GRIPPER_TOLERANCE.z)

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -184,15 +184,16 @@ function gripper_aligned()
     print_debug("fine-tune gripper pose aligned:")
     print_debug(
         "within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x): ",
-        within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x))
+        tostring(within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x)))
     print_debug(
         "within_tolerance(arduino:y_position() - y_max / 2, y_max / 2, GRIPPER_TOLERANCE.y, y): ",
-        within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
-                         GRIPPER_TOLERANCE.y, y))
+        tostring(within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
+                                  GRIPPER_TOLERANCE.y, y)))
     print_debug(
         "math.max(0.01, math.min(gripper_target.z, z_max)), arduino:z_position(), GRIPPER_TOLERANCE.z: ",
-        math.max(0.01, math.min(gripper_target.z, z_max)), arduino:z_position(),
-        GRIPPER_TOLERANCE.z)
+        tostring(
+            within_tolerance(math.max(0.01, math.min(gripper_target.z, z_max)),
+                             arduino:z_position(), GRIPPER_TOLERANCE.z)))
     return within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x) and
                within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
                                 GRIPPER_TOLERANCE.y, y) and
@@ -340,14 +341,18 @@ function ready_for_gripper_movement()
     print_debug("default gripper ready for movement:")
     print_debug(
         "within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x): ",
-        within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x))
+        tostring(
+            within_tolerance(arduino:x_position(), default_x,
+                             GRIPPER_TOLERANCE.x)))
     print_debug(
         "within_tolerance(arduino:y_position() - y_max / 2, default_y, GRIPPER_TOLERANCE.y): ",
-        within_tolerance(arduino:y_position() - y_max / 2, default_y,
-                         GRIPPER_TOLERANCE.y))
+        tostring(within_tolerance(arduino:y_position() - y_max / 2, default_y,
+                                  GRIPPER_TOLERANCE.y)))
     print_debug(
         "within_tolerance(arduino:z_position(), default_z, GRIPPER_TOLERANCE.z) :",
-        within_tolerance(arduino:z_position(), default_z, GRIPPER_TOLERANCE.z))
+        tostring(
+            within_tolerance(arduino:z_position(), default_z,
+                             GRIPPER_TOLERANCE.z)))
     return
         within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x) and
             within_tolerance(arduino:y_position() - y_max / 2, default_y,

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -54,7 +54,7 @@ Parameters:
 
 local LASER_BASE_OFFSET = 0.5 -- distance between robotino middle point and laser-line
 -- used for DRIVE_TO_LASER_LINE
-local GRIPPER_TOLERANCE = {x = 0.005, y = 0.001, z = 0.001} -- accuracy
+local GRIPPER_TOLERANCE = {x = 0.0075, y = 0.0015, z = 0.002} -- accuracy
 local MISSING_MAX = 5 -- limit for missing object detections in a row while fine-tuning gripper
 local MIN_VIS_HIST_LINE = 5 -- minimum visibility history for laser-line before considering it
 local MIN_ACTUAL_DIST = 1.8 -- minimum distance b/w bot and laser center
@@ -181,7 +181,18 @@ function gripper_aligned()
         z = object_tracking_if:gripper_frame(2),
         ori = fawkes.tf.create_quaternion_from_yaw(0)
     }, "base_link", "end_effector_home")
-
+    print_debug("fine-tune gripper pose aligned:")
+    print_debug(
+        "within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x): ",
+        within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x))
+    print_debug(
+        "within_tolerance(arduino:y_position() - y_max / 2, y_max / 2, GRIPPER_TOLERANCE.y, y): ",
+        within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
+                         GRIPPER_TOLERANCE.y, y))
+    print_debug(
+        "math.max(0.01, math.min(gripper_target.z, z_max)), arduino:z_position(), GRIPPER_TOLERANCE.z: ",
+        math.max(0.01, math.min(gripper_target.z, z_max)), arduino:z_position(),
+        GRIPPER_TOLERANCE.z)
     return within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x) and
                within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
                                 GRIPPER_TOLERANCE.y, y) and
@@ -218,18 +229,12 @@ function set_gripper(x, y, z)
     end
 
     if (not arduino:is_final() and
-        (math.abs(fsm.vars.gripper_target_pos_y - y_clipped) >
-            GRIPPER_TOLERANCE.y * 1 or
-            math.abs(fsm.vars.gripper_target_pos_z - z_clipped) >
+        (math.abs(fsm.vars.gripper_target_pos_z - z_clipped) >
             GRIPPER_TOLERANCE.z * 1.5)) or
         (arduino:is_final() and fsm.vars.target == "SLIDE" and
-            (math.abs(fsm.vars.gripper_target_pos_y - y_clipped) >
-                GRIPPER_TOLERANCE.y * 1.3 or
-                math.abs(fsm.vars.gripper_target_pos_z - z_clipped) >
+            (math.abs(fsm.vars.gripper_target_pos_z - z_clipped) >
                 GRIPPER_TOLERANCE.z * 1.3)) or (arduino:is_final() and
-        (math.abs(fsm.vars.gripper_target_pos_y - y_clipped) >
-            GRIPPER_TOLERANCE.y or
-            math.abs(fsm.vars.gripper_target_pos_z - z_clipped) >
+        (math.abs(fsm.vars.gripper_target_pos_z - z_clipped) >
             GRIPPER_TOLERANCE.z)) then
         fsm.vars.gripper_wait = 0
         fsm.vars.gripper_target_pos_x = x_clipped
@@ -331,6 +336,18 @@ function within_tolerance(value, target, margin)
 end
 
 function ready_for_gripper_movement()
+
+    print_debug("default gripper ready for movement:")
+    print_debug(
+        "within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x): ",
+        within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x))
+    print_debug(
+        "within_tolerance(arduino:y_position() - y_max / 2, default_y, GRIPPER_TOLERANCE.y): ",
+        within_tolerance(arduino:y_position() - y_max / 2, default_y,
+                         GRIPPER_TOLERANCE.y))
+    print_debug(
+        "within_tolerance(arduino:z_position(), default_z, GRIPPER_TOLERANCE.z) :",
+        within_tolerance(arduino:z_position(), default_z, GRIPPER_TOLERANCE.z))
     return
         within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x) and
             within_tolerance(arduino:y_position() - y_max / 2, default_y,

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -197,12 +197,8 @@ function gripper_aligned()
                 within_tolerance(
                     math.max(0.01, math.min(gripper_target.z, z_max)),
                     arduino:z_position(), GRIPPER_TOLERANCE.z)))
-    return within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x) and
-               within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
-                                GRIPPER_TOLERANCE.y, y) and
-               within_tolerance(
-                   math.max(0.01, math.min(gripper_target.z, z_max)),
-                   arduino:z_position(), GRIPPER_TOLERANCE.z)
+    return within_tolerance(math.max(0.01, math.min(gripper_target.z, z_max)),
+                            arduino:z_position(), GRIPPER_TOLERANCE.z)
 end
 
 function set_gripper(x, y, z)

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -182,9 +182,9 @@ function gripper_aligned()
         ori = fawkes.tf.create_quaternion_from_yaw(0)
     }, "base_link", "end_effector_home")
 
-    return within_tolerance(arduino:x_position(), 0, 0.0001) and
+    return within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x) and
                within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
-                                0.0001) and
+                                GRIPPER_TOLERANCE, y) and
                within_tolerance(
                    math.max(0.01, math.min(gripper_target.z, z_max)),
                    arduino:z_position(), GRIPPER_TOLERANCE.z)
@@ -331,10 +331,12 @@ function within_tolerance(value, target, margin)
 end
 
 function ready_for_gripper_movement()
-    return within_tolerance(arduino:x_position(), default_x, 0.0001) and
-               within_tolerance(arduino:y_position() - y_max / 2, default_y,
-                                0.0001) and
-               within_tolerance(arduino:z_position(), default_z, 0.0001)
+    return
+        within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x) and
+            within_tolerance(arduino:y_position() - y_max / 2, default_y,
+                             GRIPPER_TOLERANCE.y) and
+            within_tolerance(arduino:z_position(), default_z,
+                             GRIPPER_TOLERANCE.z)
 end
 
 function dry_expected_object_found()

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -197,8 +197,18 @@ function gripper_aligned()
                 within_tolerance(
                     math.max(0.01, math.min(gripper_target.z, z_max)),
                     arduino:z_position(), GRIPPER_TOLERANCE.z * 1.1)))
-    return within_tolerance(math.max(0.01, math.min(gripper_target.z, z_max)),
-                            arduino:z_position(), GRIPPER_TOLERANCE.z * 1.1)
+    local result = within_tolerance(math.max(0.01,
+                                             math.min(gripper_target.z, z_max)),
+                                    arduino:z_position(),
+                                    GRIPPER_TOLERANCE.z * 1.1)
+    if result == true then
+        if fsm.vars.img_wait > 10 then return result end
+        fsm.vars.img_wait = fsm.vars.img_wait + 1
+        return false
+    else
+        fsm.vars.img_wait = 0
+        return result
+    end
 end
 
 function set_gripper(x, y, z)
@@ -237,6 +247,7 @@ function set_gripper(x, y, z)
         (math.abs(fsm.vars.gripper_target_pos_z - z_clipped) >
             GRIPPER_TOLERANCE.z)) then
         fsm.vars.gripper_wait = 0
+        fsm.vars.img_wait = 0
         fsm.vars.gripper_target_pos_x = x_clipped
         fsm.vars.gripper_target_pos_y = y_clipped
         fsm.vars.gripper_target_pos_z = z_clipped

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -183,17 +183,20 @@ function gripper_aligned()
     }, "base_link", "end_effector_home")
     print_debug("fine-tune gripper pose aligned:")
     print_debug(
-        "within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x): ",
-        tostring(within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x)))
+        "within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x): " ..
+            tostring(
+                within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x)))
     print_debug(
-        "within_tolerance(arduino:y_position() - y_max / 2, y_max / 2, GRIPPER_TOLERANCE.y, y): ",
-        tostring(within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
-                                  GRIPPER_TOLERANCE.y, y)))
+        "within_tolerance(arduino:y_position() - y_max / 2, y_max / 2, GRIPPER_TOLERANCE.y, y): " ..
+            tostring(
+                within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
+                                 GRIPPER_TOLERANCE.y, y)))
     print_debug(
-        "math.max(0.01, math.min(gripper_target.z, z_max)), arduino:z_position(), GRIPPER_TOLERANCE.z: ",
-        tostring(
-            within_tolerance(math.max(0.01, math.min(gripper_target.z, z_max)),
-                             arduino:z_position(), GRIPPER_TOLERANCE.z)))
+        "math.max(0.01, math.min(gripper_target.z, z_max)), arduino:z_position(), GRIPPER_TOLERANCE.z: " ..
+            tostring(
+                within_tolerance(
+                    math.max(0.01, math.min(gripper_target.z, z_max)),
+                    arduino:z_position(), GRIPPER_TOLERANCE.z)))
     return within_tolerance(arduino:x_position(), 0, GRIPPER_TOLERANCE.x) and
                within_tolerance(arduino:y_position() - y_max / 2, y_max / 2,
                                 GRIPPER_TOLERANCE.y, y) and
@@ -340,19 +343,20 @@ function ready_for_gripper_movement()
 
     print_debug("default gripper ready for movement:")
     print_debug(
-        "within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x): ",
-        tostring(
-            within_tolerance(arduino:x_position(), default_x,
-                             GRIPPER_TOLERANCE.x)))
+        "within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x): " ..
+            tostring(
+                within_tolerance(arduino:x_position(), default_x,
+                                 GRIPPER_TOLERANCE.x)))
     print_debug(
-        "within_tolerance(arduino:y_position() - y_max / 2, default_y, GRIPPER_TOLERANCE.y): ",
-        tostring(within_tolerance(arduino:y_position() - y_max / 2, default_y,
-                                  GRIPPER_TOLERANCE.y)))
+        "within_tolerance(arduino:y_position() - y_max / 2, default_y, GRIPPER_TOLERANCE.y): " ..
+            tostring(
+                within_tolerance(arduino:y_position() - y_max / 2, default_y,
+                                 GRIPPER_TOLERANCE.y)))
     print_debug(
-        "within_tolerance(arduino:z_position(), default_z, GRIPPER_TOLERANCE.z) :",
-        tostring(
-            within_tolerance(arduino:z_position(), default_z,
-                             GRIPPER_TOLERANCE.z)))
+        "within_tolerance(arduino:z_position(), default_z, GRIPPER_TOLERANCE.z) :" ..
+            tostring(
+                within_tolerance(arduino:z_position(), default_z,
+                                 GRIPPER_TOLERANCE.z)))
     return
         within_tolerance(arduino:x_position(), default_x, GRIPPER_TOLERANCE.x) and
             within_tolerance(arduino:y_position() - y_max / 2, default_y,

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -196,9 +196,9 @@ function gripper_aligned()
             tostring(
                 within_tolerance(
                     math.max(0.01, math.min(gripper_target.z, z_max)),
-                    arduino:z_position(), GRIPPER_TOLERANCE.z)))
+                    arduino:z_position(), GRIPPER_TOLERANCE.z * 1.1)))
     return within_tolerance(math.max(0.01, math.min(gripper_target.z, z_max)),
-                            arduino:z_position(), GRIPPER_TOLERANCE.z)
+                            arduino:z_position(), GRIPPER_TOLERANCE.z * 1.1)
 end
 
 function set_gripper(x, y, z)


### PR DESCRIPTION
This is the current state of the manipulation. It tries to fix a bug where the axis never reaches its destination and is stuck in the moving state.
Also it fixes the lagging camera before manipulation. The img_wait seems a little bit too long and could be reduced.

Both should be cleaned up in the future by getting rid of moving any axis before manipulation and instead having a state which just waits for a certain amount of time to get rid of the lag after moving the base.