### PR TITLE
Xcalibrate: allows to only calibrate the x axis

### DIFF
--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -263,7 +263,7 @@ function move_gripper_default_pose_exit()
     abs_message:set_target_frame("end_effector_home")
     arduino:msgq_enqueue_copy(abs_message)
     local close_msg = arduino.CloseGripperMessage:new()
-    arduino:msgq_enqueue(close_msg)
+    arduino:msgq_enqueue_copy(close_msg)
 end
 
 function input_invalid()

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -256,6 +256,12 @@ function move_gripper_default_pose()
 end
 
 function move_gripper_default_pose_exit()
+    if fsm.vars.target ~= "WORKPIECE" then
+        local close_msg = arduino.CloseGripperMessage:new()
+        arduino:msgq_enqueue_copy(close_msg)
+        local calib_msg = arduino.CalibrateMessage:new()
+        arduino:msgq_enqueue_copy(calib_msg)
+    end
     local abs_message = arduino.MoveXYZAbsMessage:new()
     abs_message:set_x(default_x_exit)
     abs_message:set_y(default_y_exit)

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -87,7 +87,7 @@ local default_z = 0.03
 
 local default_x_exit = 0.06
 local default_y_exit = -0.03
-local default_z_exit = 0.03
+local default_z_exit = 0
 -- read config values for computing expected target position
 -- conveyor
 if config:exists("plugins/object_tracking/belt_values/belt_offset_side") then
@@ -256,12 +256,6 @@ function move_gripper_default_pose()
 end
 
 function move_gripper_default_pose_exit()
-    if fsm.vars.target ~= "WORKPIECE" then
-        local close_msg = arduino.CloseGripperMessage:new()
-        arduino:msgq_enqueue_copy(close_msg)
-        local calib_msg = arduino.CalibrateMessage:new()
-        arduino:msgq_enqueue_copy(calib_msg)
-    end
     local abs_message = arduino.MoveXYZAbsMessage:new()
     abs_message:set_x(default_x_exit)
     abs_message:set_y(default_y_exit)
@@ -456,6 +450,12 @@ fsm:add_transitions{
 }
 
 function INIT:init()
+    if fsm.vars.target ~= "WORKPIECE" then
+        local close_msg = arduino.CloseGripperMessage:new()
+        arduino:msgq_enqueue_copy(close_msg)
+        local calib_msg = arduino.CalibrateMessage:new()
+        arduino:msgq_enqueue_copy(calib_msg)
+    end
     laserline_switch:msgq_enqueue(laserline_switch.EnableSwitchMessage:new())
 
     fsm.vars.lines = {}

--- a/src/lua/skills/robotino/pick_or_put_vs.lua
+++ b/src/lua/skills/robotino/pick_or_put_vs.lua
@@ -379,7 +379,7 @@ function DRIVE_BACK:init()
         local calib_x_msg = arduino.CalibrateXMessage:new()
         arduino:msgq_enqueue_copy(calib_x_msg)
     else
-        local close_msg = arduino.CloseMessage:new()
+        local close_msg = arduino.CloseGripperMessage:new()
         arduino:msgq_enqueue_copy(close_msg)
         local calib_msg = arduino.CalibrateMessage:new()
         arduino:msgq_enqueue_copy(calib_msg)

--- a/src/lua/skills/robotino/pick_or_put_vs.lua
+++ b/src/lua/skills/robotino/pick_or_put_vs.lua
@@ -378,11 +378,6 @@ function DRIVE_BACK:init()
     if fsm.vars.target == "WORKPIECE" then
         local calib_x_msg = arduino.CalibrateXMessage:new()
         arduino:msgq_enqueue_copy(calib_x_msg)
-    else
-        local close_msg = arduino.CloseGripperMessage:new()
-        arduino:msgq_enqueue_copy(close_msg)
-        local calib_msg = arduino.CalibrateMessage:new()
-        arduino:msgq_enqueue_copy(calib_msg)
     end
     self.args["motor_move"].x = drive_back_x
 end

--- a/src/lua/skills/robotino/pick_or_put_vs.lua
+++ b/src/lua/skills/robotino/pick_or_put_vs.lua
@@ -374,6 +374,17 @@ function GRIPPER_DEFAULT:init()
     self.args["gripper_commands"].wait = false
 end
 
-function DRIVE_BACK:init() self.args["motor_move"].x = drive_back_x end
+function DRIVE_BACK:init()
+    if fsm.vars.target == "WORKPIECE" then
+        local calib_x_msg = arduino.CalibrateXMessage:new()
+        arduino:msgq_enqueue_copy(calib_x_msg)
+    else
+        local close_msg = arduino.CloseMessage:new()
+        arduino:msgq_enqueue_copy(close_msg)
+        local calib_msg = arduino.CalibrateMessage:new()
+        arduino:msgq_enqueue_copy(calib_msg)
+    end
+    self.args["motor_move"].x = drive_back_x
+end
 
 function CLOSE_DEFAULT:init() self.args["gripper_commands"].command = "CLOSE" end

--- a/src/lua/skills/robotino/pick_or_put_vs.lua
+++ b/src/lua/skills/robotino/pick_or_put_vs.lua
@@ -375,10 +375,8 @@ function GRIPPER_DEFAULT:init()
 end
 
 function DRIVE_BACK:init()
-    if fsm.vars.target == "WORKPIECE" then
-        local calib_x_msg = arduino.CalibrateXMessage:new()
-        arduino:msgq_enqueue_copy(calib_x_msg)
-    end
+    local calib_x_msg = arduino.CalibrateXMessage:new()
+    arduino:msgq_enqueue_copy(calib_x_msg)
     self.args["motor_move"].x = drive_back_x
 end
 

--- a/src/lua/skills/robotino/pick_or_put_vs.lua
+++ b/src/lua/skills/robotino/pick_or_put_vs.lua
@@ -160,13 +160,6 @@ fsm:define_states{
         "MOVE_GRIPPER_UP",
         SkillJumpState,
         skills = {{gripper_commands}},
-        final_to = "GRIPPER_DEFAULT",
-        fail_to = "FAILED"
-    },
-    {
-        "GRIPPER_DEFAULT",
-        SkillJumpState,
-        skills = {{gripper_commands}},
         final_to = "DRIVE_BACK",
         fail_to = "FAILED"
     },
@@ -364,14 +357,6 @@ function MOVE_GRIPPER_UP:init()
     self.args["gripper_commands"].y = arduino:y_position() - y_max / 2
     self.args["gripper_commands"].z = math.max(0.01, math.min(z_given, z_max))
     self.args["gripper_commands"].command = "MOVEABS"
-end
-
-function GRIPPER_DEFAULT:init()
-    self.args["gripper_commands"].x = 0
-    self.args["gripper_commands"].y = y_max / 2
-    self.args["gripper_commands"].z = 0.03
-    self.args["gripper_commands"].command = "MOVEABS"
-    self.args["gripper_commands"].wait = false
 end
 
 function DRIVE_BACK:init()

--- a/src/plugins/arduino/ArduinoSketch/ArduinoSketch.ino
+++ b/src/plugins/arduino/ArduinoSketch/ArduinoSketch.ino
@@ -291,6 +291,28 @@ calibrate()
 }
 
 void
+Xcalibrate(){
+  bool x_done = false;
+  do{
+    motor_X.enableOutputs();
+    noInterrupts();
+		if (!x_done)
+			motor_X.move(20000L);
+		movement_done_flag = false;
+		interrupts();
+		// due to high step count, reaching end stops is guaranteed!
+		set_status(STATUS_MOVING);
+    while (!movement_done_flag && (!x_done)) {
+			if (!x_done && digitalRead(MOTOR_X_LIMIT_PIN) == LOW) {
+				x_done = true;
+				reach_end_handle(motor_X, 0);
+			}
+		}
+		movement_done_flag = false;
+  }while(!x_done);
+}
+
+void
 reach_end_handle(AccelStepper &motor, byte extra)
 {
 	motor.hard_stop();
@@ -465,6 +487,7 @@ read_package()
 		case CMD_CLOSE: open_gripper = LOW; break;
 		case CMD_CALIBRATE: calibrate(); break;
 		case CMD_DOUBLE_CALIBRATE: double_calibrate(); break;
+    case CMD_X_CALIBRATE: Xcalibrate(); break;
 		case CMD_SET_SPEED:
 			set_new_speed(new_value);
 			send_status();

--- a/src/plugins/arduino/ArduinoSketch/ArduinoSketch.ino
+++ b/src/plugins/arduino/ArduinoSketch/ArduinoSketch.ino
@@ -291,25 +291,26 @@ calibrate()
 }
 
 void
-Xcalibrate(){
-  bool x_done = false;
-  do{
-    motor_X.enableOutputs();
-    noInterrupts();
+Xcalibrate()
+{
+	bool x_done = false;
+	do {
+		motor_X.enableOutputs();
+		noInterrupts();
 		if (!x_done)
 			motor_X.move(20000L);
 		movement_done_flag = false;
 		interrupts();
 		// due to high step count, reaching end stops is guaranteed!
 		set_status(STATUS_MOVING);
-    while (!movement_done_flag && (!x_done)) {
+		while (!movement_done_flag && (!x_done)) {
 			if (!x_done && digitalRead(MOTOR_X_LIMIT_PIN) == LOW) {
 				x_done = true;
 				reach_end_handle(motor_X, 0);
 			}
 		}
 		movement_done_flag = false;
-  }while(!x_done);
+	} while (!x_done);
 }
 
 void
@@ -487,7 +488,7 @@ read_package()
 		case CMD_CLOSE: open_gripper = LOW; break;
 		case CMD_CALIBRATE: calibrate(); break;
 		case CMD_DOUBLE_CALIBRATE: double_calibrate(); break;
-    case CMD_X_CALIBRATE: Xcalibrate(); break;
+		case CMD_X_CALIBRATE: Xcalibrate(); break;
 		case CMD_SET_SPEED:
 			set_new_speed(new_value);
 			send_status();

--- a/src/plugins/arduino/ArduinoSketch/commands.h
+++ b/src/plugins/arduino/ArduinoSketch/commands.h
@@ -28,6 +28,7 @@
  */
 #define CMD_CALIBRATE 'C'
 #define CMD_DOUBLE_CALIBRATE 'c'
+#define CMD_X_CALIBRATE 'r'
 #define CMD_X_NEW_POS 'X'
 #define CMD_Y_NEW_POS 'Y'
 #define CMD_Z_NEW_POS 'Z'

--- a/src/plugins/arduino/ArduinoSketch/commands.h
+++ b/src/plugins/arduino/ArduinoSketch/commands.h
@@ -60,9 +60,9 @@ public:
 	static bool
 	isValidSerialCommand(char cmd)
 	{
-		if (cmd == CMD_CALIBRATE || cmd == CMD_DOUBLE_CALIBRATE || cmd == CMD_X_NEW_POS
-		    || cmd == CMD_Y_NEW_POS || cmd == CMD_Z_NEW_POS || cmd == CMD_CLOSE || cmd == CMD_OPEN
-		    || cmd == CMD_STOP || cmd == CMD_FAST_STOP || cmd == CMD_STATUS_REQ
+		if (cmd == CMD_CALIBRATE || cmd == CMD_X_CALIBRATE || cmd == CMD_DOUBLE_CALIBRATE
+		    || cmd == CMD_X_NEW_POS || cmd == CMD_Y_NEW_POS || cmd == CMD_Z_NEW_POS || cmd == CMD_CLOSE
+		    || cmd == CMD_OPEN || cmd == CMD_STOP || cmd == CMD_FAST_STOP || cmd == CMD_STATUS_REQ
 		    || cmd == CMD_A_SET_TOGGLE_STEPS || cmd == CMD_X_NEW_SPEED || cmd == CMD_Y_NEW_SPEED
 		    || cmd == CMD_Z_NEW_SPEED || cmd == CMD_A_NEW_SPEED || cmd == CMD_SET_SPEED
 		    || cmd == CMD_X_NEW_ACC || cmd == CMD_Y_NEW_ACC || cmd == CMD_Z_NEW_ACC

--- a/src/plugins/arduino/com_thread.cpp
+++ b/src/plugins/arduino/com_thread.cpp
@@ -287,6 +287,7 @@ ArduinoComThread::send_message(ArduinoComMessage &msg)
 	if (!port_) {
 		return false;
 	}
+	logger->log_debug(name(), "send_packet: %s", msg.buffer().c_str());
 	if (!port_->write(msg.buffer())) {
 		logger->log_error(name(), "Error while trying to send data to Arduino!");
 		return false;
@@ -540,6 +541,9 @@ ArduinoComThread::bb_interface_message_received(Interface *interface, Message *m
 		append_message_to_queue(msg);
 	} else if (message->is_of_type<ArduinoInterface::CalibrateMessage>()) {
 		append_message_to_queue(CMD_CALIBRATE);
+		status = true;
+	} else if (message->is_of_type<ArduinoInterface::CalibrateXMessage>()) {
+		append_message_to_queue(CMD_X_CALIBRATE);
 		status = true;
 	} else if (message->is_of_type<ArduinoInterface::CloseGripperMessage>()) {
 		append_message_to_queue(CMD_CLOSE);

--- a/src/plugins/arduino/interfaces/ArduinoInterface.xml
+++ b/src/plugins/arduino/interfaces/ArduinoInterface.xml
@@ -62,6 +62,9 @@
   <message name="Calibrate">
     <comment>Restore gripper's position to the initial position set in the configuration.</comment>
   </message>
+  <message name="CalibrateX">
+    <comment>Run a calibration of gripper's X</comment>
+  </message>
   <message name="Stop">
     <comment>Stops all Axis movement.</comment>
   </message>


### PR DESCRIPTION
With this new gripper command, we are able to only calibrate the axis' x axis. This is used after every picking skill.

@techtasie im branch von Amrith akrishnan/Xcalibrate gibt es noch den commit von dir mit Revert ["manipulate_wp: calibratating better times"](https://github.com/carologistics/fawkes-robotino/commit/2cae6114ae85f999463e84fd0eca1ce79edbe44a). Ist der benötigt? Sieht mir danach aus, aber kannst du das bitte noch einmal checken?