### PR TITLE
Mtschesche/end with dry run

### DIFF
--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -21,7 +21,7 @@ module(..., skillenv.module_init)
 -- Crucial skill information
 name = "manipulate_wp"
 fsm = SkillHSM:new{name = name, start = "INIT", debug = true}
-depends_skills = {"moveto", "motor_move", "pick_or_put_vs"}
+depends_skills = {"moveto", "motor_move", "pick_or_put_vs", "gripper_commands"}
 depends_interfaces = {
     {v = "line1", type = "LaserLineInterface", id = "/laser-lines/1"},
     {v = "line2", type = "LaserLineInterface", id = "/laser-lines/2"},
@@ -401,6 +401,8 @@ end
 
 function sensed_wp() return arduino:is_wp_sensed() end
 
+function slide_put() return fsm.vars.target == "SLIDE" end
+
 
 fsm:define_states{
     export_to = _M,
@@ -526,6 +528,11 @@ fsm:add_transitions{
         "FINAL",
         cond = "not vars.dry_end",
         desc = "Action successful, but no checking"
+    }, {
+        "DRY_END",
+        "FINAL",
+        cond = slide_put,
+        desc = "Action successful, no checking"
     }, {
         "DRY_END",
         "CHECK_FOR_WP",

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -430,12 +430,12 @@ fsm:define_states{
         final_to = "DRY_END",
         fail_to = "FINE_TUNE_GRIPPER"
     },
-    {"DRY_END", JumpState}
-    {"CHECK_FOR_WP", JumpState}
-    {"CHECK_FOR_NO_WP", JumpState}
-    {"PUT_FAILED", JumpState}
-    {"PUT_SUCCESSFUL", JumpState}
-    {"PICK_FAILED", JumpState}
+    {"DRY_END", JumpState},
+    {"CHECK_FOR_WP", JumpState},
+    {"CHECK_FOR_NO_WP", JumpState},
+    {"PUT_FAILED", JumpState},
+    {"PUT_SUCCESSFUL", JumpState},
+    {"PICK_FAILED", JumpState},
     {"PICK_SUCCESSFUL", JumpState}
 }
 
@@ -507,12 +507,12 @@ fsm:add_transitions{
     }, {
         "DRY_END",
         "CHECK_FOR_WP",
-        cond = check_for_wp,
+        cond = "vars.check_workpiece",
         desc = "Check if there is a workpiece"
     }, {
         "DRY_END",
         "CHECK_FOR_NO_WP",
-        cond = check_for_no_wp,
+        cond = "not vars.check_workpiece",
         desc = "Check if there is no workpiece"
     }, {
         "CHECK_FOR_WP",

--- a/src/lua/skills/robotino/manipulate_wp.lua
+++ b/src/lua/skills/robotino/manipulate_wp.lua
@@ -407,7 +407,7 @@ function slide_put() return fsm.vars.target == "SLIDE" end
 
 fsm:define_states{
     export_to = _M,
-    closure = {MISSING_MAX = MISSING_MAX},
+    closure = {MISSING_MAX = MISSING_MAX, MAX_TRIES = MAX_TRIES},
     {"INIT", JumpState},
     {"START_TRACKING", JumpState},
     {"FIND_LASER_LINE", JumpState},
@@ -711,7 +711,7 @@ function START_TRACKING:init()
 end
 
 function START_TRACKING:exit()
-    if fsm.vars.nr_tries > MAX_TRIES then 
+    if fsm.vars.nr_tries > MAX_TRIES then
         fsm.vars.error = "too many retries"
     else
         fsm.vars.error = "OT interface closed"

--- a/src/lua/skills/robotino/pick_or_put_vs.lua
+++ b/src/lua/skills/robotino/pick_or_put_vs.lua
@@ -167,6 +167,13 @@ fsm:define_states{
         "MOVE_GRIPPER_UP",
         SkillJumpState,
         skills = {{gripper_commands}},
+        final_to = "MOVE_GRIPPER_BACK",
+        fail_to = "FAILED"
+    },
+    {
+        "MOVE_GRIPPER_BACK",
+        SkillJumpState,
+        skills = {{gripper_commands}},
         final_to = "DRIVE_BACK",
         fail_to = "FAILED"
     },
@@ -375,11 +382,14 @@ function MOVE_GRIPPER_UP:init()
     self.args["gripper_commands"].command = "MOVEABS"
 end
 
+function MOVE_GRIPPER_BACK:init()
+    self.args["gripper_commands"].x = 0.0
+    self.args["gripper_commands"].y = y_max / 2
+    self.args["gripper_commands"].z = arduino:z_position()
+    self.args["gripper_commands"].command = "MOVEABS"
+end
+
 function DRIVE_BACK:init()
-    if fsm.vars.target == "WORKPIECE" then
-        local calib_x_msg = arduino.CalibrateXMessage:new()
-        arduino:msgq_enqueue_copy(calib_x_msg)
-    end
     self.args["motor_move"].x = drive_back_x
 end
 

--- a/src/lua/skills/robotino/pick_or_put_vs.lua
+++ b/src/lua/skills/robotino/pick_or_put_vs.lua
@@ -389,8 +389,6 @@ function MOVE_GRIPPER_BACK:init()
     self.args["gripper_commands"].command = "MOVEABS"
 end
 
-function DRIVE_BACK:init()
-    self.args["motor_move"].x = drive_back_x
-end
+function DRIVE_BACK:init() self.args["motor_move"].x = drive_back_x end
 
 function CLOSE_DEFAULT:init() self.args["gripper_commands"].command = "CLOSE" end


### PR DESCRIPTION
This PR introduces a new variable to manipulate_wp, dry_end, which does a workpiece check after grasping to remove the need for a manipulate with dry_run afterwards. This saves a lot of time.

This is the first PR in a chain of 3 incoming PRs.