### PR TITLE
arduino usb reset message

### DIFF
--- a/src/lua/skills/robotino/gripper_commands.lua
+++ b/src/lua/skills/robotino/gripper_commands.lua
@@ -29,7 +29,7 @@ depends_interfaces = {
 }
 
 documentation = [==[
-    @param command    can be : ( OPEN | CLOSE | STOP | MOVEABS | MOVEREL | CALIBRATE )
+    @param command    can be : ( OPEN | CLOSE | STOP | MOVEABS | MOVEREL | CALIBRATE | RESETUSB )
     @param x   x position for gripper move
     @param y   y position for gripper move
     @param z   z position for gripper move
@@ -44,7 +44,9 @@ skillenv.skill_module(_M)
 
 function input_ok()
     if fsm.vars.command == "OPEN" or fsm.vars.command == "STOP" or
-        fsm.vars.command == "CLOSE" then return true end
+        fsm.vars.command == "CLOSE" or fsm.vars.command == "RESETUSB" then
+        return true
+    end
     if fsm.vars.command == "MOVEABS" or fsm.vars.command == "MOVEREL" then
         if not fsm.vars.x or not fsm.vars.y or not fsm.vars.z then
             print("Missing coordinates " .. fsm.vars.x .. " " .. fsm.vars.y ..
@@ -139,6 +141,9 @@ function COMMAND:init()
     elseif self.fsm.vars.command == "STOP" then
         theStopMessage = arduino.StopMessage:new()
         arduino:msgq_enqueue(theStopMessage)
+    elseif self.fsm.vars.command == "RESETUSB" then
+        theResetMessage = arduino.ResetUSBMessage:new()
+        arduino:msgq_enqueue(theResetMessage)
 
     elseif self.fsm.vars.command == "MOVEABS" then
 

--- a/src/plugins/arduino/com_thread.cpp
+++ b/src/plugins/arduino/com_thread.cpp
@@ -29,6 +29,8 @@
 
 #include <interfaces/ArduinoInterface.h>
 
+#include <stdlib.h>
+
 using namespace fawkes;
 
 /** @class ArduinoComThread "com_thread.h"
@@ -562,6 +564,8 @@ ArduinoComThread::bb_interface_message_received(Interface *interface, Message *m
 		goal_gripper_pose[Z] = gripper_pose_[Z];
 		append_message_to_queue(CMD_STOP);
 		status = true;
+	} else if (message->is_of_type<ArduinoInterface::ResetUSBMessage>()) {
+		system("usb_modeswitch -R -v 2341 -p 0243");
 	}
 
 	wakeup();

--- a/src/plugins/arduino/interfaces/ArduinoInterface.xml
+++ b/src/plugins/arduino/interfaces/ArduinoInterface.xml
@@ -77,4 +77,7 @@
   <message name="StatusUpdate">
     <comment>Request a status of the arduino</comment>
   </message>
+  <message name="ResetUSB">
+    <comment>Reset the usb device if arduino does not respond</comment>
+  </message>
 </interface>


### PR DESCRIPTION
This is a dirty little hack to reset the USB device of the arduino on command, which hopefully helps with our issues of the arduino not responding at all.

For it to work appropriately, a udev rule like this is needed to allow USB access at user level (already added to our ansible):
```
SUBSYSTEM=="usb", ATTR{idVendor}=="2341", ATTR{idProduct}=="0243", MODE="0666", GROUP="plugdev"
```