### PR TITLE
rcll-central: disallow unnecessary payments

### DIFF
--- a/src/clips-specs/rcll-central/exploration.clp
+++ b/src/clips-specs/rcll-central/exploration.clp
@@ -38,7 +38,7 @@
 	(wm-fact (key refbox version-info config args? name field_height) (value ?field-height))
 	(wm-fact (key refbox version-info config args? name field_width) (value ?field-width))
 	(wm-fact (key refbox version-info config args? name field_mirrored) (value ?mirrored))
-	(test (or (eq ?team-color CYAN) (eq ?team-clor MAGENTA)))
+	(test (or (eq ?team-color CYAN) (eq ?team-color MAGENTA)))
 	=>
 	(bind ?x_min 0)
 	(if (eq ?mirrored TRUE) then


### PR DESCRIPTION
Only creates pay-for-ring goals for machines with at least one ring with cost > 0